### PR TITLE
bug: Fix Broken Knative Webhook

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	k8s.io/apimachinery v0.25.2
 	k8s.io/client-go v0.25.2
 	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed
-	knative.dev/pkg v0.0.0-20221011175852-714b7630a836
+	knative.dev/pkg v0.0.0-20221020140913-5dd89c68dbdb
 	sigs.k8s.io/controller-runtime v0.13.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -834,8 +834,8 @@ k8s.io/kube-openapi v0.0.0-20220803162953-67bda5d908f1 h1:MQ8BAZPZlWk3S9K4a9NCkI
 k8s.io/kube-openapi v0.0.0-20220803162953-67bda5d908f1/go.mod h1:C/N6wCaBHeBHkHUesQOQy2/MZqGgMAFPqGsGQLdbZBU=
 k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed h1:jAne/RjBTyawwAy0utX5eqigAwz/lQhTmy+Hr/Cpue4=
 k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
-knative.dev/pkg v0.0.0-20221011175852-714b7630a836 h1:0N7Zo/O+xeUUebJPm9keBaGclrUoEbljr3J1MsqtaIM=
-knative.dev/pkg v0.0.0-20221011175852-714b7630a836/go.mod h1:DMTRDJ5WRxf/DrlOPzohzfhSuJggscLZ8EavOq9O/x8=
+knative.dev/pkg v0.0.0-20221020140913-5dd89c68dbdb h1:c6fviQy6EjKjAADKy5QKDAp2kimeTI4QW/5v1t+Md10=
+knative.dev/pkg v0.0.0-20221020140913-5dd89c68dbdb/go.mod h1:DMTRDJ5WRxf/DrlOPzohzfhSuJggscLZ8EavOq9O/x8=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/pkg/operator/controller/singleton.go
+++ b/pkg/operator/controller/singleton.go
@@ -1,0 +1,89 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"context"
+	"time"
+
+	"go.uber.org/multierr"
+	"knative.dev/pkg/logging"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type Builder struct {
+	mgr           manager.Manager
+	name          string
+	leaderElected bool
+}
+
+func NewSingletonManagedBy(m manager.Manager) Builder {
+	return Builder{
+		mgr: m,
+	}
+}
+
+func (b Builder) Named(n string) Builder {
+	b.name = n
+	return b
+}
+
+func (b Builder) LeaderElected() Builder {
+	b.leaderElected = true
+	return b
+}
+
+func (b Builder) Complete(r reconcile.Reconciler) error {
+	return b.mgr.Add(newSingleton(r, b.name, b.leaderElected))
+}
+
+type Singleton struct {
+	reconcile.Reconciler
+
+	name          string
+	leaderElected bool
+}
+
+func newSingleton(r reconcile.Reconciler, name string, leaderElected bool) *Singleton {
+	return &Singleton{
+		Reconciler:    r,
+		name:          name,
+		leaderElected: leaderElected,
+	}
+}
+
+func (s *Singleton) Start(ctx context.Context) error {
+	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).Named(s.name))
+	logging.FromContext(ctx).Infof("Starting Controller")
+	defer logging.FromContext(ctx).Infof("Stopping Controller")
+	for {
+		res, errs := s.Reconcile(ctx, reconcile.Request{})
+		if errs != nil {
+			for _, err := range multierr.Errors(errs) {
+				logging.FromContext(ctx).Error(err)
+			}
+		}
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(res.RequeueAfter):
+		}
+	}
+}
+
+func (s *Singleton) NeedLeaderElection() bool {
+	return s.leaderElected
+}

--- a/pkg/webhooks/webhooks.go
+++ b/pkg/webhooks/webhooks.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"runtime/debug"
 
+	"github.com/samber/lo"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/configmap/informer"
@@ -27,6 +29,7 @@ import (
 	knativeinjection "knative.dev/pkg/injection"
 	"knative.dev/pkg/injection/sharedmain"
 	"knative.dev/pkg/logging"
+	"knative.dev/pkg/metrics"
 	"knative.dev/pkg/system"
 	"knative.dev/pkg/webhook"
 	"knative.dev/pkg/webhook/certificates"
@@ -65,6 +68,9 @@ func Initialize(injectCloudProvider func(cloudprovider.Context) cloudprovider.Cl
 	cmw := informer.NewInformedWatcher(clientSet, system.Namespace())
 	ctx := injection.LoggingContextOrDie(component, config, cmw)
 	ctx = knativeinjection.WithNamespaceScope(ctx, system.Namespace())
+
+	// TODO: Consider customizing these observability metrics later by creating an observability ConfigMap
+	ctx = metrics.WithConfig(ctx, lo.Must(metrics.NewObservabilityConfigFromConfigMap(&v1.ConfigMap{})))
 
 	ctx = webhook.WithOptions(ctx, webhook.Options{
 		Port:        opts.WebhookPort,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Fixes broken `webhooks` package by using the default knative config for observability

Webhooks were broken by [this change](https://github.com/knative/pkg/pull/2610) which uses default as `nil` instead of an empty ConfigMap. This causes the process to crash.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
