### PR TITLE
bug: Fix Broken Knative Webhook

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	k8s.io/apimachinery v0.25.2
 	k8s.io/client-go v0.25.2
 	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed
-	knative.dev/pkg v0.0.0-20221011175852-714b7630a836
+	knative.dev/pkg v0.0.0-20221020140913-5dd89c68dbdb
 	sigs.k8s.io/controller-runtime v0.13.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -834,8 +834,8 @@ k8s.io/kube-openapi v0.0.0-20220803162953-67bda5d908f1 h1:MQ8BAZPZlWk3S9K4a9NCkI
 k8s.io/kube-openapi v0.0.0-20220803162953-67bda5d908f1/go.mod h1:C/N6wCaBHeBHkHUesQOQy2/MZqGgMAFPqGsGQLdbZBU=
 k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed h1:jAne/RjBTyawwAy0utX5eqigAwz/lQhTmy+Hr/Cpue4=
 k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
-knative.dev/pkg v0.0.0-20221011175852-714b7630a836 h1:0N7Zo/O+xeUUebJPm9keBaGclrUoEbljr3J1MsqtaIM=
-knative.dev/pkg v0.0.0-20221011175852-714b7630a836/go.mod h1:DMTRDJ5WRxf/DrlOPzohzfhSuJggscLZ8EavOq9O/x8=
+knative.dev/pkg v0.0.0-20221020140913-5dd89c68dbdb h1:c6fviQy6EjKjAADKy5QKDAp2kimeTI4QW/5v1t+Md10=
+knative.dev/pkg v0.0.0-20221020140913-5dd89c68dbdb/go.mod h1:DMTRDJ5WRxf/DrlOPzohzfhSuJggscLZ8EavOq9O/x8=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/pkg/webhooks/webhooks.go
+++ b/pkg/webhooks/webhooks.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"runtime/debug"
 
+	"github.com/samber/lo"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
 	"knative.dev/pkg/configmap"
 	"knative.dev/pkg/configmap/informer"
@@ -27,6 +29,7 @@ import (
 	knativeinjection "knative.dev/pkg/injection"
 	"knative.dev/pkg/injection/sharedmain"
 	"knative.dev/pkg/logging"
+	"knative.dev/pkg/metrics"
 	"knative.dev/pkg/system"
 	"knative.dev/pkg/webhook"
 	"knative.dev/pkg/webhook/certificates"
@@ -65,6 +68,11 @@ func Initialize(injectCloudProvider func(cloudprovider.Context) cloudprovider.Cl
 	cmw := informer.NewInformedWatcher(clientSet, system.Namespace())
 	ctx := injection.LoggingContextOrDie(component, config, cmw)
 	ctx = knativeinjection.WithNamespaceScope(ctx, system.Namespace())
+
+	// TODO: Consider customizing these observability metrics later by creating an observability ConfigMap
+	// NOTE: This is here because Knative's defaulting mechanism for this was broken starting in
+	// https://github.com/knative/pkg/pull/2610. DO NOT REMOVE THIS LINE OR THE PROCESS WILL CRASH
+	ctx = metrics.WithConfig(ctx, lo.Must(metrics.NewObservabilityConfigFromConfigMap(&v1.ConfigMap{})))
 
 	ctx = webhook.WithOptions(ctx, webhook.Options{
 		Port:        opts.WebhookPort,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Fixes broken `webhooks` package by using the default knative config for observability

Webhooks were broken by [this change](https://github.com/knative/pkg/pull/2610) which uses default as `nil` instead of an empty ConfigMap. This causes the process to crash.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
