### PR TITLE
test: Introduce a more robust way to do settings store test injection

### DIFF
--- a/pkg/test/settings.go
+++ b/pkg/test/settings.go
@@ -23,10 +23,14 @@ import (
 	"github.com/aws/karpenter-core/pkg/apis/config/settings"
 )
 
-type SettingsStore struct{}
+// SettingsStore is a map from ContextKey to settings/config data
+type SettingsStore map[interface{}]interface{}
 
 func (ss SettingsStore) InjectSettings(ctx context.Context) context.Context {
-	return settings.ToContext(ctx, Settings())
+	for k, v := range ss {
+		ctx = context.WithValue(ctx, k, v)
+	}
+	return ctx
 }
 
 func Settings() settings.Settings {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Makes the `test.SettingsStore` a map of `map[ContextKey]SettingsData` so that testing can inject whatever settings should be injected into the provisioner


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
