### PR TITLE
fix: Inject settings after the batcher completes waiting

### DIFF
--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -212,7 +212,6 @@ func ExpectProvisionedNoBindingWithOffset(offset int, ctx context.Context, c cli
 	}
 
 	// TODO: Check the error on the provisioner reconcile
-	go provisioner.TriggerImmediate()
 	_, _ = provisioner.Reconcile(ctx, reconcile.Request{})
 
 	// Update objects after reconciling


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Fix the time when settings are injected so that we perform `settingsstore.InjectSettings()` after we get a call to trigger the batcher. This will evolves into an abstract `WaitUntil()` mechanism for the `singletonController` which will wait before each call to `Reconcile()`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
