### PR TITLE
fix: Move `MustParse` call out of options.New()

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -75,7 +75,7 @@ func NewOperator() (context.Context, *Operator) {
 	ctx = sharedmain.WithHADisabled(ctx) // Disable leader election for webhook
 
 	// Options
-	opts := options.New()
+	opts := options.New().MustParse()
 	ctx = injection.WithOptions(ctx, *opts)
 
 	// Webhook

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -88,8 +88,7 @@ func New() *Options {
 		newLimit := int64(float64(opts.MemoryLimit) * 0.9)
 		debug.SetMemoryLimit(newLimit)
 	}
-
-	return opts.MustParse()
+	return opts
 }
 
 // MustParse reads the user passed flags, environment variables, and default values.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Fixes a bug where `docgen` was no longer working because `MustParse()` was moved inside of `options.New()`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
