### PR TITLE
fix: Fix REST config injection

### DIFF
--- a/pkg/cloudprovider/types.go
+++ b/pkg/cloudprovider/types.go
@@ -20,6 +20,7 @@ import (
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -32,6 +33,7 @@ import (
 type Context struct {
 	context.Context
 
+	RESTConfig          *rest.Config
 	KubernetesInterface kubernetes.Interface
 	KubeClient          client.Client
 	EventRecorder       events.Recorder

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -23,6 +23,7 @@ import (
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
 	"k8s.io/client-go/util/flowcontrol"
 	"k8s.io/utils/clock"
@@ -55,6 +56,7 @@ const (
 type Operator struct {
 	manager.Manager
 
+	RESTConfig          *rest.Config
 	KubernetesInterface kubernetes.Interface
 	SettingsStore       settingsstore.Store
 	EventRecorder       events.Recorder
@@ -129,6 +131,7 @@ func NewOperator() (context.Context, *Operator) {
 
 	return ctx, &Operator{
 		Manager:             manager,
+		RESTConfig:          config,
 		KubernetesInterface: kubernetesInterface,
 		SettingsStore:       settingsStore,
 		EventRecorder:       events.NewRecorder(manager.GetEventRecorderFor(appName)),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- RESTConfig was not being properly injected into cloudprovider context to `getCABundle`

This was broken starting in #29 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
