### PR TITLE
chore: Remove AWS options from CLI args and Env Vars

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -96,13 +96,14 @@ func NewOperator() (context.Context, *Operator) {
 
 	// Settings
 	settingsStore := settingsstore.WatchSettingsOrDie(ctx, kubernetesInterface, configMapWatcher, apis.Settings.List()...)
-	ctx = settingsStore.InjectSettings(ctx)
 
 	// Logging
 	logger := NewLogger(ctx, component, config, configMapWatcher)
 	ctx = logging.WithLogger(ctx, logger)
 
+	// Inject settings after starting the ConfigMapWatcher
 	lo.Must0(configMapWatcher.Start(ctx.Done()))
+	ctx = settingsStore.InjectSettings(ctx)
 
 	// Manager
 	manager, err := controllerruntime.NewManager(config, controllerruntime.Options{


### PR DESCRIPTION
__BREAKING CHANGE: Integrating this new code in upstream `aws/karpenter` will break customers who were using these CLI args__

*Issue #, if available:*

*Description of changes:*

- Removes the AWS-specific options to prepare migrating the options into the ConfigMap

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
