### PR TITLE
chore: Automatically inject `reconcile_duration` and `reconcile_errors` into singleton controller

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	k8s.io/apimachinery v0.25.2
 	k8s.io/client-go v0.25.2
 	k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed
-	knative.dev/pkg v0.0.0-20221011175852-714b7630a836
+	knative.dev/pkg v0.0.0-20221031132215-6eb8f1845a9d
 	sigs.k8s.io/controller-runtime v0.13.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -857,6 +857,8 @@ k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed h1:jAne/RjBTyawwAy0utX5eqigAwz/l
 k8s.io/utils v0.0.0-20220728103510-ee6ede2d64ed/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
 knative.dev/pkg v0.0.0-20221011175852-714b7630a836 h1:0N7Zo/O+xeUUebJPm9keBaGclrUoEbljr3J1MsqtaIM=
 knative.dev/pkg v0.0.0-20221011175852-714b7630a836/go.mod h1:DMTRDJ5WRxf/DrlOPzohzfhSuJggscLZ8EavOq9O/x8=
+knative.dev/pkg v0.0.0-20221031132215-6eb8f1845a9d h1:BRSonjQw4u63gaWeoE5i2724FF3K7teFf8DcmwjGdAQ=
+knative.dev/pkg v0.0.0-20221031132215-6eb8f1845a9d/go.mod h1:j5kO7gKmWGj2DJpefCEiPbItToiYf+2bCtI+A6REkQo=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/pkg/controllers/metrics/state/controller.go
+++ b/pkg/controllers/metrics/state/controller.go
@@ -43,7 +43,7 @@ func NewController(cluster *state.Cluster) *Controller {
 
 func (c *Controller) Builder(_ context.Context, mgr manager.Manager) operatorcontroller.Builder {
 	return operatorcontroller.NewSingletonManagedBy(mgr).
-		Named("metric-scraper")
+		Named("metric_scraper")
 }
 
 func (c *Controller) LivenessProbe(_ *http.Request) error {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Automatically inject reconcile duration into singleton controller

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
