### PR TITLE
test: Inject discovery label into node labels

### DIFF
--- a/pkg/test/provisioner.go
+++ b/pkg/test/provisioner.go
@@ -73,7 +73,7 @@ func Provisioner(overrides ...ProvisionerOptions) *v1alpha5.Provisioner {
 			ProviderRef:            options.ProviderRef,
 			Taints:                 options.Taints,
 			StartupTaints:          options.StartupTaints,
-			Labels:                 options.Labels,
+			Labels:                 lo.Assign(options.Labels, map[string]string{DiscoveryLabel: "unspecified"}), // For node cleanup discovery
 			Limits:                 &v1alpha5.Limits{Resources: options.Limits},
 			TTLSecondsAfterEmpty:   options.TTLSecondsAfterEmpty,
 			TTLSecondsUntilExpired: options.TTLSecondsUntilExpired,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Injects the test discovery label into nodes created by the provisioner

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
