### PR TITLE
chore: Use v1 operating system strings

### DIFF
--- a/pkg/apis/provisioning/v1alpha5/labels.go
+++ b/pkg/apis/provisioning/v1alpha5/labels.go
@@ -26,7 +26,6 @@ var (
 	// Well known labels and resources
 	ArchitectureAmd64    = "amd64"
 	ArchitectureArm64    = "arm64"
-	OperatingSystemLinux = "linux"
 	CapacityTypeSpot     = "spot"
 	CapacityTypeOnDemand = "on-demand"
 

--- a/pkg/cloudprovider/fake/cloudprovider.go
+++ b/pkg/cloudprovider/fake/cloudprovider.go
@@ -110,7 +110,7 @@ func (c *CloudProvider) GetInstanceTypes(_ context.Context, provisioner *v1alpha
 		NewInstanceType(InstanceTypeOptions{
 			Name:             "arm-instance-type",
 			Architecture:     "arm64",
-			OperatingSystems: sets.NewString("ios", "linux", "windows", "darwin"),
+			OperatingSystems: sets.NewString("ios", string(v1.Linux), string(v1.Windows), "darwin"),
 			Resources: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU:    resource.MustParse("16"),
 				v1.ResourceMemory: resource.MustParse("128Gi"),

--- a/pkg/cloudprovider/fake/instancetype.go
+++ b/pkg/cloudprovider/fake/instancetype.go
@@ -78,7 +78,7 @@ func NewInstanceType(options InstanceTypeOptions) *InstanceType {
 		options.Architecture = "amd64"
 	}
 	if options.OperatingSystems.Len() == 0 {
-		options.OperatingSystems = utilsets.NewString("linux", "windows", "darwin")
+		options.OperatingSystems = utilsets.NewString(string(v1.Linux), string(v1.Windows), "darwin")
 	}
 
 	return &InstanceType{
@@ -100,7 +100,7 @@ func InstanceTypesAssorted() []cloudprovider.InstanceType {
 		for _, mem := range []int{1, 2, 4, 8, 16, 32, 64, 128} {
 			for _, zone := range []string{"test-zone-1", "test-zone-2", "test-zone-3"} {
 				for _, ct := range []string{v1alpha5.CapacityTypeSpot, v1alpha5.CapacityTypeOnDemand} {
-					for _, os := range []utilsets.String{utilsets.NewString("linux"), utilsets.NewString("windows")} {
+					for _, os := range []utilsets.String{utilsets.NewString(string(v1.Linux)), utilsets.NewString(string(v1.Windows))} {
 						for _, arch := range []string{v1alpha5.ArchitectureAmd64, v1alpha5.ArchitectureArm64} {
 							opts := InstanceTypeOptions{
 								Name:             fmt.Sprintf("%d-cpu-%d-mem-%s-%s-%s-%s", cpu, mem, arch, strings.Join(os.List(), ","), zone, ct),

--- a/pkg/controllers/provisioning/scheduling/instance_selection_test.go
+++ b/pkg/controllers/provisioning/scheduling/instance_selection_test.go
@@ -133,14 +133,14 @@ var _ = Describe("Instance Type Selection", func() {
 			{
 				Key:      v1.LabelOSStable,
 				Operator: v1.NodeSelectorOpIn,
-				Values:   []string{"windows"},
+				Values:   []string{string(v1.Windows)},
 			},
 		}
 		ExpectApplied(ctx, env.Client, provisioner)
 		pod := ExpectProvisioned(ctx, env.Client, recorder, controller, prov, test.UnschedulablePod())
 		node := ExpectScheduled(ctx, env.Client, pod[0])
 		Expect(nodePrice(node)).To(Equal(minPrice))
-		ExpectInstancesWithLabel(cloudProv.CreateCalls[0].InstanceTypeOptions, v1.LabelOSStable, "windows")
+		ExpectInstancesWithLabel(cloudProv.CreateCalls[0].InstanceTypeOptions, v1.LabelOSStable, string(v1.Windows))
 	})
 	It("should schedule on one of the cheapest instances (pod os = windows)", func() {
 		ExpectApplied(ctx, env.Client, provisioner)
@@ -148,25 +148,25 @@ var _ = Describe("Instance Type Selection", func() {
 			test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{{
 				Key:      v1.LabelOSStable,
 				Operator: v1.NodeSelectorOpIn,
-				Values:   []string{"windows"},
+				Values:   []string{string(v1.Windows)},
 			}}}))
 		node := ExpectScheduled(ctx, env.Client, pod[0])
 		Expect(nodePrice(node)).To(Equal(minPrice))
-		ExpectInstancesWithLabel(cloudProv.CreateCalls[0].InstanceTypeOptions, v1.LabelOSStable, "windows")
+		ExpectInstancesWithLabel(cloudProv.CreateCalls[0].InstanceTypeOptions, v1.LabelOSStable, string(v1.Windows))
 	})
 	It("should schedule on one of the cheapest instances (prov os = windows)", func() {
 		provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
 			{
 				Key:      v1.LabelOSStable,
 				Operator: v1.NodeSelectorOpIn,
-				Values:   []string{"windows"},
+				Values:   []string{string(v1.Windows)},
 			},
 		}
 		ExpectApplied(ctx, env.Client, provisioner)
 		pod := ExpectProvisioned(ctx, env.Client, recorder, controller, prov, test.UnschedulablePod())
 		node := ExpectScheduled(ctx, env.Client, pod[0])
 		Expect(nodePrice(node)).To(Equal(minPrice))
-		ExpectInstancesWithLabel(cloudProv.CreateCalls[0].InstanceTypeOptions, v1.LabelOSStable, "windows")
+		ExpectInstancesWithLabel(cloudProv.CreateCalls[0].InstanceTypeOptions, v1.LabelOSStable, string(v1.Windows))
 	})
 	It("should schedule on one of the cheapest instances (pod os = linux)", func() {
 		ExpectApplied(ctx, env.Client, provisioner)
@@ -174,11 +174,11 @@ var _ = Describe("Instance Type Selection", func() {
 			test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{{
 				Key:      v1.LabelOSStable,
 				Operator: v1.NodeSelectorOpIn,
-				Values:   []string{"linux"},
+				Values:   []string{string(v1.Linux)},
 			}}}))
 		node := ExpectScheduled(ctx, env.Client, pod[0])
 		Expect(nodePrice(node)).To(Equal(minPrice))
-		ExpectInstancesWithLabel(cloudProv.CreateCalls[0].InstanceTypeOptions, v1.LabelOSStable, "linux")
+		ExpectInstancesWithLabel(cloudProv.CreateCalls[0].InstanceTypeOptions, v1.LabelOSStable, string(v1.Linux))
 	})
 	It("should schedule on one of the cheapest instances (pod os = linux)", func() {
 		ExpectApplied(ctx, env.Client, provisioner)
@@ -186,11 +186,11 @@ var _ = Describe("Instance Type Selection", func() {
 			test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{{
 				Key:      v1.LabelOSStable,
 				Operator: v1.NodeSelectorOpIn,
-				Values:   []string{"linux"},
+				Values:   []string{string(v1.Linux)},
 			}}}))
 		node := ExpectScheduled(ctx, env.Client, pod[0])
 		Expect(nodePrice(node)).To(Equal(minPrice))
-		ExpectInstancesWithLabel(cloudProv.CreateCalls[0].InstanceTypeOptions, v1.LabelOSStable, "linux")
+		ExpectInstancesWithLabel(cloudProv.CreateCalls[0].InstanceTypeOptions, v1.LabelOSStable, string(v1.Linux))
 	})
 	It("should schedule on one of the cheapest instances (prov zone = test-zone-2)", func() {
 		provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
@@ -310,7 +310,7 @@ var _ = Describe("Instance Type Selection", func() {
 			{
 				Key:      v1.LabelOSStable,
 				Operator: v1.NodeSelectorOpIn,
-				Values:   []string{"windows"},
+				Values:   []string{string(v1.Windows)},
 			},
 			{
 				Key:      v1alpha5.LabelCapacityType,
@@ -328,7 +328,7 @@ var _ = Describe("Instance Type Selection", func() {
 		node := ExpectScheduled(ctx, env.Client, pod[0])
 		Expect(nodePrice(node)).To(Equal(minPrice))
 		ExpectInstancesWithOffering(cloudProv.CreateCalls[0].InstanceTypeOptions, v1alpha5.CapacityTypeOnDemand, "test-zone-1")
-		ExpectInstancesWithLabel(cloudProv.CreateCalls[0].InstanceTypeOptions, v1.LabelOSStable, "windows")
+		ExpectInstancesWithLabel(cloudProv.CreateCalls[0].InstanceTypeOptions, v1.LabelOSStable, string(v1.Windows))
 		ExpectInstancesWithLabel(cloudProv.CreateCalls[0].InstanceTypeOptions, v1.LabelArchStable, "arm64")
 	})
 	It("should schedule on one of the cheapest instances (prov = spot/test-zone-2, pod = amd64/linux)", func() {
@@ -341,7 +341,7 @@ var _ = Describe("Instance Type Selection", func() {
 			{
 				Key:      v1.LabelOSStable,
 				Operator: v1.NodeSelectorOpIn,
-				Values:   []string{"linux"},
+				Values:   []string{string(v1.Linux)},
 			},
 		}
 		ExpectApplied(ctx, env.Client, provisioner)
@@ -361,7 +361,7 @@ var _ = Describe("Instance Type Selection", func() {
 		node := ExpectScheduled(ctx, env.Client, pod[0])
 		Expect(nodePrice(node)).To(Equal(minPrice))
 		ExpectInstancesWithOffering(cloudProv.CreateCalls[0].InstanceTypeOptions, v1alpha5.CapacityTypeSpot, "test-zone-2")
-		ExpectInstancesWithLabel(cloudProv.CreateCalls[0].InstanceTypeOptions, v1.LabelOSStable, "linux")
+		ExpectInstancesWithLabel(cloudProv.CreateCalls[0].InstanceTypeOptions, v1.LabelOSStable, string(v1.Linux))
 		ExpectInstancesWithLabel(cloudProv.CreateCalls[0].InstanceTypeOptions, v1.LabelArchStable, "amd64")
 	})
 	It("should schedule on one of the cheapest instances (pod ct = spot/test-zone-2/amd64/linux)", func() {
@@ -376,7 +376,7 @@ var _ = Describe("Instance Type Selection", func() {
 				{
 					Key:      v1.LabelOSStable,
 					Operator: v1.NodeSelectorOpIn,
-					Values:   []string{"linux"},
+					Values:   []string{string(v1.Linux)},
 				},
 				{
 					Key:      v1alpha5.LabelCapacityType,
@@ -392,7 +392,7 @@ var _ = Describe("Instance Type Selection", func() {
 		node := ExpectScheduled(ctx, env.Client, pod[0])
 		Expect(nodePrice(node)).To(Equal(minPrice))
 		ExpectInstancesWithOffering(cloudProv.CreateCalls[0].InstanceTypeOptions, v1alpha5.CapacityTypeSpot, "test-zone-2")
-		ExpectInstancesWithLabel(cloudProv.CreateCalls[0].InstanceTypeOptions, v1.LabelOSStable, "linux")
+		ExpectInstancesWithLabel(cloudProv.CreateCalls[0].InstanceTypeOptions, v1.LabelOSStable, string(v1.Linux))
 		ExpectInstancesWithLabel(cloudProv.CreateCalls[0].InstanceTypeOptions, v1.LabelArchStable, "amd64")
 	})
 	It("should not schedule if no instance type matches selector (pod arch = arm)", func() {
@@ -529,7 +529,7 @@ var _ = Describe("Instance Type Selection", func() {
 			fake.NewInstanceType(fake.InstanceTypeOptions{
 				Name:             "test-instance1",
 				Architecture:     "amd64",
-				OperatingSystems: sets.NewString("linux"),
+				OperatingSystems: sets.NewString(string(v1.Linux)),
 				Resources: v1.ResourceList{
 					v1.ResourceCPU:    resource.MustParse("1"),
 					v1.ResourceMemory: resource.MustParse("1Gi"),
@@ -542,7 +542,7 @@ var _ = Describe("Instance Type Selection", func() {
 			fake.NewInstanceType(fake.InstanceTypeOptions{
 				Name:             "test-instance2",
 				Architecture:     "amd64",
-				OperatingSystems: sets.NewString("linux"),
+				OperatingSystems: sets.NewString(string(v1.Linux)),
 				Resources: v1.ResourceList{
 					v1.ResourceCPU:    resource.MustParse("1"),
 					v1.ResourceMemory: resource.MustParse("1Gi"),

--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -406,7 +406,7 @@ var _ = Describe("Custom Constraints", func() {
 				// Constrained by architecture
 				test.UnschedulablePod(test.PodOptions{NodeSelector: map[string]string{v1.LabelArchStable: "arm64"}}),
 				// Constrained by operatingSystem
-				test.UnschedulablePod(test.PodOptions{NodeSelector: map[string]string{v1.LabelOSStable: "linux"}}),
+				test.UnschedulablePod(test.PodOptions{NodeSelector: map[string]string{v1.LabelOSStable: string(v1.Linux)}}),
 				// Constrained by capacity type
 				test.UnschedulablePod(test.PodOptions{NodeSelector: map[string]string{v1alpha5.LabelCapacityType: "spot"}}),
 			}
@@ -2990,10 +2990,10 @@ var _ = Describe("Instance Type Compatibility", func() {
 		ExpectApplied(ctx, env.Client, provisioner)
 		for _, pod := range ExpectProvisioned(ctx, env.Client, recorder, controller, prov,
 			test.UnschedulablePod(test.PodOptions{
-				NodeSelector: map[string]string{v1.LabelOSStable: "linux"},
+				NodeSelector: map[string]string{v1.LabelOSStable: string(v1.Linux)},
 			}),
 			test.UnschedulablePod(test.PodOptions{
-				NodeSelector: map[string]string{v1.LabelOSStable: "windows"},
+				NodeSelector: map[string]string{v1.LabelOSStable: string(v1.Windows)},
 			})) {
 			node := ExpectScheduled(ctx, env.Client, pod)
 			nodeNames.Insert(node.Name)

--- a/pkg/controllers/provisioning/suite_test.go
+++ b/pkg/controllers/provisioning/suite_test.go
@@ -127,7 +127,7 @@ var _ = Describe("Provisioning", func() {
 			// Constrained by architecture
 			test.UnschedulablePod(test.PodOptions{NodeSelector: map[string]string{v1.LabelArchStable: "arm64"}}),
 			// Constrained by operatingSystem
-			test.UnschedulablePod(test.PodOptions{NodeSelector: map[string]string{v1.LabelOSStable: "linux"}}),
+			test.UnschedulablePod(test.PodOptions{NodeSelector: map[string]string{v1.LabelOSStable: string(v1.Linux)}}),
 		}
 		unschedulable := []*v1.Pod{
 			// Ignored, matches another provisioner


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Changes all instances of `"linux"` to `string(v1.Linux)` and instances of `"windows"` to `string(v1.Windows)`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
