### PR TITLE
fix: move emptiness tests to deprovisioning and deduplicate deletion logic

### DIFF
--- a/pkg/controllers/deprovisioning/controller.go
+++ b/pkg/controllers/deprovisioning/controller.go
@@ -221,7 +221,6 @@ func (c *Controller) validateCommand(ctx context.Context, cmd Command, d Deprovi
 		return false, nil
 	}
 	remainingDelay := d.TTL() - c.clock.Since(cmd.created)
-	logging.FromContext(ctx).Debugf("This is the remainingDelay, %s", remainingDelay)
 	// deprovisioningTTL is how long we wait before re-validating our lifecycle command
 	if remainingDelay > 0 {
 		select {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- removes duplicated deprovisioning logic used for emptiness. `node/emptiness.go` and `deprovisioning/controller.go` were both executing deletion logic. 
- moves respective tests over

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
