### PR TITLE
chore: Wait for ConfigMap creation for SettingStore watcher

### DIFF
--- a/pkg/apis/config/registration.go
+++ b/pkg/apis/config/registration.go
@@ -28,7 +28,6 @@ type Constructor interface{}
 type Registration struct {
 	ConfigMapName string
 	Constructor   interface{}
-	DefaultData   map[string]string
 }
 
 func (r Registration) Validate() error {
@@ -37,9 +36,6 @@ func (r Registration) Validate() error {
 	}
 	if err := configmap.ValidateConstructor(r.Constructor); err != nil {
 		return fmt.Errorf("constructor validation failed in SettingsStore registration, %w", err)
-	}
-	if r.DefaultData == nil {
-		return fmt.Errorf("default value cannot be empty in SettingsStore registration")
 	}
 	return nil
 }

--- a/pkg/apis/config/settings/settings.go
+++ b/pkg/apis/config/settings/settings.go
@@ -16,12 +16,10 @@ package settings
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
 	"github.com/go-playground/validator/v10"
-	"github.com/samber/lo"
 	"go.uber.org/multierr"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -35,7 +33,6 @@ var ContextKey = Registration
 var Registration = &config.Registration{
 	ConfigMapName: "karpenter-global-settings",
 	Constructor:   NewSettingsFromConfigMap,
-	DefaultData:   lo.Must(defaultSettings.Data()),
 }
 
 var defaultSettings = Settings{
@@ -64,15 +61,6 @@ func NewSettingsFromConfigMap(cm *v1.ConfigMap) (Settings, error) {
 		panic(fmt.Sprintf("validating settings, %v", err))
 	}
 	return s, nil
-}
-
-func (s Settings) Data() (map[string]string, error) {
-	d := map[string]string{}
-
-	if err := json.Unmarshal(lo.Must(json.Marshal(defaultSettings)), &d); err != nil {
-		return d, fmt.Errorf("unmarshalling json data, %w", err)
-	}
-	return d, nil
 }
 
 // Validate leverages struct tags with go-playground/validator so you can define a struct with custom

--- a/pkg/apis/config/settings/suite_test.go
+++ b/pkg/apis/config/settings/suite_test.go
@@ -21,7 +21,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 	. "knative.dev/pkg/logging/testing"
 
@@ -75,17 +74,5 @@ var _ = Describe("Validation", func() {
 			},
 		}
 		_, _ = settings.NewSettingsFromConfigMap(cm)
-	})
-})
-
-var _ = Describe("Unmarshalling", func() {
-	It("should succeed to unmarshal default data", func() {
-		data := lo.Assign(settings.Registration.DefaultData)
-		cm := &v1.ConfigMap{
-			Data: data,
-		}
-		s, _ := settings.NewSettingsFromConfigMap(cm)
-		Expect(s.BatchMaxDuration.Duration).To(Equal(time.Second * 10))
-		Expect(s.BatchIdleDuration.Duration).To(Equal(time.Second))
 	})
 })

--- a/pkg/controllers/deprovisioning/suite_test.go
+++ b/pkg/controllers/deprovisioning/suite_test.go
@@ -1422,7 +1422,7 @@ var _ = Describe("Consolidation TTL", func() {
 		}()
 
 		// wait for the controller to block on the validation timeout
-		Eventually(fakeClock.HasWaiters).Should(BeTrue())
+		Eventually(fakeClock.HasWaiters, time.Second*5).Should(BeTrue())
 		// controller should be blocking during the timeout
 		Expect(finished.Load()).To(BeFalse())
 		// and the node should not be deleted yet
@@ -1475,7 +1475,7 @@ var _ = Describe("Consolidation TTL", func() {
 		}()
 
 		// wait for the controller to block on the validation timeout
-		Eventually(fakeClock.HasWaiters).Should(BeTrue())
+		Eventually(fakeClock.HasWaiters, time.Second*5).Should(BeTrue())
 		// controller should be blocking during the timeout
 		Expect(finished.Load()).To(BeFalse())
 		// and the node should not be deleted yet

--- a/pkg/operator/controller/suite_test.go
+++ b/pkg/operator/controller/suite_test.go
@@ -55,7 +55,14 @@ func TestAPIs(t *testing.T) {
 var _ = BeforeSuite(func() {
 	env = test.NewEnvironment(scheme.Scheme)
 	cmw = informer.NewInformedWatcher(env.KubernetesInterface, system.Namespace())
-	ss = settingsstore.WatchSettingsOrDie(ctx, env.KubernetesInterface, cmw, settings.Registration)
+	defaultConfigMap = &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "karpenter-global-settings",
+			Namespace: system.Namespace(),
+		},
+	}
+	ExpectApplied(ctx, env.Client, defaultConfigMap)
+	ss = settingsstore.NewWatcherOrDie(ctx, env.KubernetesInterface, cmw, settings.Registration)
 	Expect(cmw.Start(env.Done))
 })
 

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -94,12 +94,12 @@ func NewOperator() (context.Context, *Operator) {
 	kubernetesInterface := kubernetes.NewForConfigOrDie(config)
 	configMapWatcher := informer.NewInformedWatcher(kubernetesInterface, system.Namespace())
 
-	// Settings
-	settingsStore := settingsstore.WatchSettingsOrDie(ctx, kubernetesInterface, configMapWatcher, apis.Settings.List()...)
-
 	// Logging
 	logger := NewLogger(ctx, component, config, configMapWatcher)
 	ctx = logging.WithLogger(ctx, logger)
+
+	// Create the settingsStore for settings injection
+	settingsStore := settingsstore.NewWatcherOrDie(ctx, kubernetesInterface, configMapWatcher, apis.Settings.List()...)
 
 	// Inject settings after starting the ConfigMapWatcher
 	lo.Must0(configMapWatcher.Start(ctx.Done()))

--- a/pkg/operator/settingsstore/fake/settings.go
+++ b/pkg/operator/settingsstore/fake/settings.go
@@ -29,7 +29,6 @@ import (
 var SettingsRegistration = &config.Registration{
 	ConfigMapName: "karpenter-global-settings",
 	Constructor:   NewFakeSettingsFromConfigMap,
-	DefaultData:   lo.Must(defaultSettings.Data()),
 }
 
 var defaultSettings = Settings{

--- a/pkg/operator/settingsstore/suite_test.go
+++ b/pkg/operator/settingsstore/suite_test.go
@@ -46,13 +46,20 @@ var defaultConfigMap *v1.ConfigMap
 func TestAPIs(t *testing.T) {
 	ctx = TestContextWithLogger(t)
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Controller")
+	RunSpecs(t, "SettingsStore")
 }
 
 var _ = BeforeSuite(func() {
 	env = test.NewEnvironment(scheme.Scheme)
 	cmw = informer.NewInformedWatcher(env.KubernetesInterface, system.Namespace())
-	ss = settingsstore.WatchSettingsOrDie(ctx, env.KubernetesInterface, cmw, settings.Registration, fake.SettingsRegistration)
+	defaultConfigMap = &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "karpenter-global-settings",
+			Namespace: system.Namespace(),
+		},
+	}
+	ExpectApplied(ctx, env.Client, defaultConfigMap)
+	ss = settingsstore.NewWatcherOrDie(ctx, env.KubernetesInterface, cmw, settings.Registration, fake.SettingsRegistration)
 	Expect(cmw.Start(env.Done)).To(Succeed())
 })
 
@@ -74,88 +81,63 @@ var _ = AfterEach(func() {
 	ExpectDeleted(ctx, env.Client, defaultConfigMap.DeepCopy())
 })
 
-var _ = Describe("Operator Settings", func() {
-	It("should have default values", func() {
-		Eventually(func(g Gomega) {
-			testCtx := ss.InjectSettings(ctx)
-			s := settings.FromContext(testCtx)
-			g.Expect(s.BatchIdleDuration.Duration).To(Equal(1 * time.Second))
-			g.Expect(s.BatchMaxDuration.Duration).To(Equal(10 * time.Second))
-		}).Should(Succeed())
-	})
-	It("should update if values are changed", func() {
-		Eventually(func(g Gomega) {
-			testCtx := ss.InjectSettings(ctx)
-			s := settings.FromContext(testCtx)
-			g.Expect(s.BatchIdleDuration.Duration).To(Equal(1 * time.Second))
-			g.Expect(s.BatchMaxDuration.Duration).To(Equal(10 * time.Second))
+var _ = Describe("SettingsStore", func() {
+	Context("Operator Settings", func() {
+		It("should have default values", func() {
+			Eventually(func(g Gomega) {
+				testCtx := ss.InjectSettings(ctx)
+				s := settings.FromContext(testCtx)
+				g.Expect(s.BatchIdleDuration.Duration).To(Equal(1 * time.Second))
+				g.Expect(s.BatchMaxDuration.Duration).To(Equal(10 * time.Second))
+			}).Should(Succeed())
 		})
-		cm := defaultConfigMap.DeepCopy()
-		cm.Data = map[string]string{
-			"batchIdleDuration": "2s",
-			"batchMaxDuration":  "15s",
-		}
-		ExpectApplied(ctx, env.Client, cm)
+		It("should update if values are changed", func() {
+			Eventually(func(g Gomega) {
+				testCtx := ss.InjectSettings(ctx)
+				s := settings.FromContext(testCtx)
+				g.Expect(s.BatchIdleDuration.Duration).To(Equal(1 * time.Second))
+				g.Expect(s.BatchMaxDuration.Duration).To(Equal(10 * time.Second))
+			})
+			cm := defaultConfigMap.DeepCopy()
+			cm.Data = map[string]string{
+				"batchIdleDuration": "2s",
+				"batchMaxDuration":  "15s",
+			}
+			ExpectApplied(ctx, env.Client, cm)
 
-		Eventually(func(g Gomega) {
-			testCtx := ss.InjectSettings(ctx)
-			s := settings.FromContext(testCtx)
-			g.Expect(s.BatchIdleDuration.Duration).To(Equal(2 * time.Second))
-			g.Expect(s.BatchMaxDuration.Duration).To(Equal(15 * time.Second))
-		}).Should(Succeed())
+			Eventually(func(g Gomega) {
+				testCtx := ss.InjectSettings(ctx)
+				s := settings.FromContext(testCtx)
+				g.Expect(s.BatchIdleDuration.Duration).To(Equal(2 * time.Second))
+				g.Expect(s.BatchMaxDuration.Duration).To(Equal(15 * time.Second))
+			}).Should(Succeed())
+		})
 	})
-})
+	Context("Multiple Settings", func() {
+		It("should get operator settings and features from same configMap", func() {
+			Eventually(func(g Gomega) {
+				testCtx := ss.InjectSettings(ctx)
+				s := fake.SettingsFromContext(testCtx)
+				g.Expect(s.TestArg).To(Equal("default"))
+			}).Should(Succeed())
+		})
+		It("should get operator settings and features from same configMap", func() {
+			cm := defaultConfigMap.DeepCopy()
+			cm.Data = map[string]string{
+				"batchIdleDuration": "2s",
+				"batchMaxDuration":  "15s",
+				"testArg":           "my-value",
+			}
+			ExpectApplied(ctx, env.Client, cm)
 
-var _ = Describe("Multiple Settings", func() {
-	It("should get operator settings and features from same configMap", func() {
-		Eventually(func(g Gomega) {
-			testCtx := ss.InjectSettings(ctx)
-			s := fake.SettingsFromContext(testCtx)
-			g.Expect(s.TestArg).To(Equal("default"))
-		}).Should(Succeed())
-	})
-	It("should get operator settings and features from same configMap", func() {
-		cm := defaultConfigMap.DeepCopy()
-		cm.Data = map[string]string{
-			"batchIdleDuration": "2s",
-			"batchMaxDuration":  "15s",
-			"testArg":           "my-value",
-		}
-		ExpectApplied(ctx, env.Client, cm)
-
-		Eventually(func(g Gomega) {
-			testCtx := ss.InjectSettings(ctx)
-			s := settings.FromContext(testCtx)
-			fs := fake.SettingsFromContext(testCtx)
-			g.Expect(s.BatchIdleDuration.Duration).To(Equal(2 * time.Second))
-			g.Expect(s.BatchMaxDuration.Duration).To(Equal(15 * time.Second))
-			g.Expect(fs.TestArg).To(Equal("my-value"))
-		}).Should(Succeed())
-	})
-})
-
-var _ = Describe("ConfigMap Doesn't Exist on Startup", func() {
-	It("should default if the configMap doesn't exist on startup", func() {
-		Eventually(func(g Gomega) {
-			testCtx := ss.InjectSettings(ctx)
-			s := settings.FromContext(testCtx)
-			g.Expect(s.BatchIdleDuration.Duration).To(Equal(1 * time.Second))
-			g.Expect(s.BatchMaxDuration.Duration).To(Equal(10 * time.Second))
-		}).Should(Succeed())
-	})
-	It("should start watching settings when ConfigMap is added", func() {
-		cm := defaultConfigMap.DeepCopy()
-		cm.Data = map[string]string{
-			"batchIdleDuration": "2s",
-			"batchMaxDuration":  "15s",
-		}
-		ExpectApplied(ctx, env.Client, cm)
-
-		Eventually(func(g Gomega) {
-			testCtx := ss.InjectSettings(ctx)
-			s := settings.FromContext(testCtx)
-			g.Expect(s.BatchIdleDuration.Duration).To(Equal(2 * time.Second))
-			g.Expect(s.BatchMaxDuration.Duration).To(Equal(15 * time.Second))
-		}).Should(Succeed())
+			Eventually(func(g Gomega) {
+				testCtx := ss.InjectSettings(ctx)
+				s := settings.FromContext(testCtx)
+				fs := fake.SettingsFromContext(testCtx)
+				g.Expect(s.BatchIdleDuration.Duration).To(Equal(2 * time.Second))
+				g.Expect(s.BatchMaxDuration.Duration).To(Equal(15 * time.Second))
+				g.Expect(fs.TestArg).To(Equal("my-value"))
+			}).Should(Succeed())
+		})
 	})
 })

--- a/pkg/test/settings.go
+++ b/pkg/test/settings.go
@@ -21,7 +21,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/aws/karpenter-core/pkg/apis/config/settings"
+	"github.com/aws/karpenter-core/pkg/operator/settingsstore"
 )
+
+var _ settingsstore.Store = SettingsStore{}
 
 // SettingsStore is a map from ContextKey to settings/config data
 type SettingsStore map[interface{}]interface{}


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

SettingsStore configMaps should be required. This PR ensures there is no default settings that are set by the ConfigMapInformer but instead we wait for the creation of all configMaps before we continue to watching the configMaps.

**How was this change tested?**

- Manual deployment of new version to EKS cluster

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
