### PR TITLE
min capacity draft

### DIFF
--- a/pkg/apis/provisioning/v1alpha5/provisioner.go
+++ b/pkg/apis/provisioning/v1alpha5/provisioner.go
@@ -81,6 +81,8 @@ type ProvisionerSpec struct {
 	// +kubebuilder:validation:Maximum:=100
 	// +optional
 	Weight *int32 `json:"weight,omitempty"`
+	// MinCpu defines how many cpus should at least be provisioned
+	MinCpu *int32 `json:"minCpu,omitempty"`
 	// Consolidation are the consolidation parameters
 	// +optional
 	Consolidation *Consolidation `json:"consolidation,omitempty"`


### PR DESCRIPTION
feat:            allow setting minimum capacity per provisioner
fix:             https://github.com/aws/karpenter/issues/2050

**Description**
rough draft of how I think having a min capacity could work

... alternatively this could be done via "min nodes" setting and then computing that times the highest (or average) cpu of the matching instance types, but means more indirection

**How was this change tested?**
not

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
