### PR TITLE
feature: add inflight checks to detect some configuration issues

### DIFF
--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -24,6 +24,7 @@ import (
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
 	"github.com/aws/karpenter-core/pkg/controllers/counter"
 	"github.com/aws/karpenter-core/pkg/controllers/deprovisioning"
+	"github.com/aws/karpenter-core/pkg/controllers/inflightchecks"
 	metricspod "github.com/aws/karpenter-core/pkg/controllers/metrics/pod"
 	metricsprovisioner "github.com/aws/karpenter-core/pkg/controllers/metrics/provisioner"
 	metricsstate "github.com/aws/karpenter-core/pkg/controllers/metrics/state"
@@ -66,5 +67,6 @@ func NewControllers(
 		metricsprovisioner.NewController(kubeClient),
 		counter.NewController(kubeClient, cluster),
 		deprovisioning.NewController(clock, kubeClient, provisioner, cloudProvider, eventRecorder, cluster),
+		inflightchecks.NewController(clock, kubeClient, eventRecorder, cloudProvider, cluster),
 	}
 }

--- a/pkg/controllers/deprovisioning/pdblimits.go
+++ b/pkg/controllers/deprovisioning/pdblimits.go
@@ -54,17 +54,17 @@ func NewPDBLimits(ctx context.Context, kubeClient client.Client) (*PDBLimits, er
 
 // CanEvictPods returns true if every pod in the list is evictable. They may not all be evictable simultaneously, but
 // for every PDB that controls the pods at least one pod can be evicted.
-func (s *PDBLimits) CanEvictPods(pods []*v1.Pod) bool {
+func (s *PDBLimits) CanEvictPods(pods []*v1.Pod) (client.ObjectKey, bool) {
 	for _, pod := range pods {
 		for _, pdb := range s.pdbs {
 			if pdb.selector.Matches(labels.Set(pod.Labels)) {
 				if pdb.disruptionsAllowed == 0 {
-					return false
+					return pdb.name, false
 				}
 			}
 		}
 	}
-	return true
+	return client.ObjectKey{}, true
 }
 
 type pdbItem struct {

--- a/pkg/controllers/inflightchecks/controller.go
+++ b/pkg/controllers/inflightchecks/controller.go
@@ -1,0 +1,137 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inflightchecks
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/patrickmn/go-cache"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/clock"
+	"knative.dev/pkg/logging"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/aws/karpenter-core/pkg/apis/provisioning/v1alpha5"
+	"github.com/aws/karpenter-core/pkg/cloudprovider"
+	"github.com/aws/karpenter-core/pkg/controllers/deprovisioning"
+	"github.com/aws/karpenter-core/pkg/controllers/state"
+	"github.com/aws/karpenter-core/pkg/events"
+	operatorcontroller "github.com/aws/karpenter-core/pkg/operator/controller"
+	"github.com/aws/karpenter-core/pkg/operator/injection"
+)
+
+const controllerName = "inflightchecks"
+
+type Controller struct {
+	clock       clock.Clock
+	kubeClient  client.Client
+	checks      []Check
+	recorder    events.Recorder
+	lastScanned *cache.Cache
+}
+type Check interface {
+	// Check performs the inflight check, this should return a list of slice discovered, or an empty
+	// slice if no issues were found
+	Check(ctx context.Context, node *v1.Node, provisioner *v1alpha5.Provisioner, pdbs *deprovisioning.PDBLimits) ([]Issue, error)
+}
+
+type Issue struct {
+	node    *v1.Node
+	message string
+}
+
+// scanPeriod is how often we inspect and report issues that are found.
+const scanPeriod = 10 * time.Minute
+
+func NewController(clk clock.Clock, kubeclient client.Client, recorder events.Recorder, provider cloudprovider.CloudProvider, cluster *state.Cluster) *Controller {
+	return &Controller{
+		clock:       clk,
+		kubeClient:  kubeclient,
+		recorder:    recorder,
+		lastScanned: cache.New(scanPeriod, 1*time.Minute),
+		checks: []Check{
+			NewFailedInit(clk, provider),
+			NewTermination(kubeclient),
+			NewNodeShape(provider),
+		}}
+}
+
+func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
+	log := logging.FromContext(ctx).Named(controllerName).With("node", req.Name)
+	namespacedName := req.NamespacedName.String()
+	if lastTime, ok := c.lastScanned.Get(namespacedName); ok {
+		if lastTime, ok := lastTime.(time.Time); ok {
+			remaining := scanPeriod - c.clock.Since(lastTime)
+			return reconcile.Result{RequeueAfter: remaining}, nil
+		}
+		// the above should always succeed
+		return reconcile.Result{RequeueAfter: scanPeriod}, nil
+	}
+	c.lastScanned.SetDefault(namespacedName, c.clock.Now())
+
+	ctx = logging.WithLogger(ctx, log)
+	ctx = injection.WithControllerName(ctx, controllerName)
+
+	node := &v1.Node{}
+	if err := c.kubeClient.Get(ctx, req.NamespacedName, node); err != nil {
+		return reconcile.Result{}, client.IgnoreNotFound(err)
+	}
+
+	provisioner := &v1alpha5.Provisioner{}
+	if err := c.kubeClient.Get(ctx, types.NamespacedName{Name: node.Labels[v1alpha5.ProvisionerNameLabelKey]}, provisioner); err != nil {
+		// provisioner is missing, node should be removed soon
+		return reconcile.Result{}, client.IgnoreNotFound(err)
+	}
+
+	pdbs, err := deprovisioning.NewPDBLimits(ctx, c.kubeClient)
+	if err != nil {
+		return reconcile.Result{}, err
+	}
+	uniqueIssues := map[string]Issue{}
+	for _, check := range c.checks {
+		issues, err := check.Check(ctx, node, provisioner, pdbs)
+		if err != nil {
+			log.Errorf("checking node %s with %T, %s", node.Name, check, err)
+		}
+		for _, i := range issues {
+			uniqueIssues[i.node.Name+i.message] = i
+		}
+	}
+
+	for _, iss := range uniqueIssues {
+		log.Infof("Inflight check failed for node %s, %s", iss.node.Name, iss.message)
+		c.recorder.Publish(events.NodeInflightCheck(iss.node, iss.message))
+	}
+	return reconcile.Result{RequeueAfter: scanPeriod}, nil
+}
+
+func (c *Controller) Builder(ctx context.Context, m manager.Manager) operatorcontroller.Builder {
+	return controllerruntime.
+		NewControllerManagedBy(m).
+		Named(controllerName).
+		For(&v1.Node{}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: 10})
+}
+
+func (c *Controller) LivenessProbe(req *http.Request) error {
+	return nil
+}

--- a/pkg/controllers/inflightchecks/failedinit.go
+++ b/pkg/controllers/inflightchecks/failedinit.go
@@ -1,0 +1,100 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inflightchecks
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/samber/lo"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/utils/clock"
+
+	"github.com/aws/karpenter-core/pkg/apis/provisioning/v1alpha5"
+	"github.com/aws/karpenter-core/pkg/cloudprovider"
+	"github.com/aws/karpenter-core/pkg/controllers/deprovisioning"
+	"github.com/aws/karpenter-core/pkg/controllers/node"
+)
+
+// initFailureTime is the time after which we start reporting a node as having failed to initialize. This is set
+// so that we should have few if any false positives.
+const initFailureTime = 1 * time.Hour
+
+// FailedInit detects nodes that fail to initialize within an hour and reports the reason for the initialization
+// failure
+type FailedInit struct {
+	clock    clock.Clock
+	provider cloudprovider.CloudProvider
+}
+
+func NewFailedInit(clk clock.Clock, provider cloudprovider.CloudProvider) Check {
+	return &FailedInit{clock: clk, provider: provider}
+}
+
+func (f FailedInit) Check(ctx context.Context, n *v1.Node, provisioner *v1alpha5.Provisioner, pdbs *deprovisioning.PDBLimits) ([]Issue, error) {
+	// ignore nodes that are deleting
+	if !n.DeletionTimestamp.IsZero() {
+		return nil, nil
+	}
+
+	nodeAge := f.clock.Since(n.CreationTimestamp.Time)
+	// n is already initialized or not old enough
+	if n.Labels[v1alpha5.LabelNodeInitialized] == "true" || nodeAge < initFailureTime {
+		return nil, nil
+	}
+
+	instanceTypes, err := f.provider.GetInstanceTypes(ctx, provisioner)
+	if err != nil {
+		return nil, err
+	}
+
+	instanceType, ok := lo.Find(instanceTypes, func(it cloudprovider.InstanceType) bool { return it.Name() == n.Labels[v1.LabelInstanceType] })
+	if !ok {
+		return []Issue{{
+			node:    n,
+			message: fmt.Sprintf("Instance Type %q not found", n.Labels[v1.LabelInstanceType]),
+		}}, nil
+	}
+
+	// detect startup taints which should be removed
+	var result []Issue
+	if taint, ok := node.IsStartupTaintRemoved(n, provisioner); !ok {
+		result = append(result, Issue{
+			node:    n,
+			message: fmt.Sprintf("Startup taint %q is still on the node", formatTaint(taint)),
+		})
+	}
+
+	// and extended resources which never registered
+	if resource, ok := node.IsExtendedResourceRegistered(n, instanceType); !ok {
+		result = append(result, Issue{
+			node:    n,
+			message: fmt.Sprintf("Expected resource %q didn't register on the node", resource),
+		})
+	}
+
+	return result, nil
+}
+
+func formatTaint(taint *v1.Taint) string {
+	if taint == nil {
+		return "<nil>"
+	}
+	if taint.Value == "" {
+		return fmt.Sprintf("%s:%s", taint.Key, taint.Effect)
+	}
+	return fmt.Sprintf("%s=%s:%s", taint.Key, taint.Value, taint.Effect)
+}

--- a/pkg/controllers/inflightchecks/nodeshape.go
+++ b/pkg/controllers/inflightchecks/nodeshape.go
@@ -1,0 +1,84 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inflightchecks
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/samber/lo"
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/aws/karpenter-core/pkg/apis/provisioning/v1alpha5"
+	"github.com/aws/karpenter-core/pkg/cloudprovider"
+	"github.com/aws/karpenter-core/pkg/controllers/deprovisioning"
+)
+
+// NodeShape detects nodes that have launched with 10% or less of any resource than was expected.
+type NodeShape struct {
+	provider cloudprovider.CloudProvider
+}
+
+func NewNodeShape(provider cloudprovider.CloudProvider) Check {
+	return &NodeShape{
+		provider: provider,
+	}
+}
+
+func (n *NodeShape) Check(ctx context.Context, node *v1.Node, provisioner *v1alpha5.Provisioner, pdbs *deprovisioning.PDBLimits) ([]Issue, error) {
+	// ignore nodes that are deleting
+	if !node.DeletionTimestamp.IsZero() {
+		return nil, nil
+	}
+	// and nodes that haven't initialized yet
+	if node.Labels[v1alpha5.LabelNodeInitialized] != "true" {
+		return nil, nil
+	}
+
+	instanceTypes, err := n.provider.GetInstanceTypes(ctx, provisioner)
+	if err != nil {
+		return nil, err
+	}
+
+	instanceType, ok := lo.Find(instanceTypes, func(it cloudprovider.InstanceType) bool { return it.Name() == node.Labels[v1.LabelInstanceType] })
+	if !ok {
+		return []Issue{{
+			node:    node,
+			message: fmt.Sprintf("Instance Type %q not found", node.Labels[v1.LabelInstanceType]),
+		}}, nil
+	}
+	var issues []Issue
+	for resourceName, expectedQuantity := range instanceType.Resources() {
+		nodeQuantity, ok := node.Status.Capacity[resourceName]
+		if !ok && !expectedQuantity.IsZero() {
+			issues = append(issues, Issue{
+				node:    node,
+				message: fmt.Sprintf("Expected resource %s not found", resourceName),
+			})
+			continue
+		}
+
+		pct := nodeQuantity.AsApproximateFloat64() / expectedQuantity.AsApproximateFloat64()
+		if pct < 0.90 {
+			issues = append(issues, Issue{
+				node: node,
+				message: fmt.Sprintf("Expected %s of resource %s, but found %s (%0.1f%% of expected)", expectedQuantity.String(),
+					resourceName, nodeQuantity.String(), pct*100),
+			})
+		}
+
+	}
+	return issues, nil
+}

--- a/pkg/controllers/inflightchecks/suite_test.go
+++ b/pkg/controllers/inflightchecks/suite_test.go
@@ -1,0 +1,193 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inflightchecks_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	clock "k8s.io/utils/clock/testing"
+	. "knative.dev/pkg/logging/testing"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/aws/karpenter-core/pkg/apis"
+	"github.com/aws/karpenter-core/pkg/apis/config/settings"
+	"github.com/aws/karpenter-core/pkg/apis/provisioning/v1alpha5"
+	"github.com/aws/karpenter-core/pkg/cloudprovider/fake"
+	"github.com/aws/karpenter-core/pkg/controllers/inflightchecks"
+	"github.com/aws/karpenter-core/pkg/events"
+	"github.com/aws/karpenter-core/pkg/operator/scheme"
+	"github.com/aws/karpenter-core/pkg/test"
+	. "github.com/aws/karpenter-core/pkg/test/expectations"
+)
+
+var ctx context.Context
+var controller *inflightchecks.Controller
+var env *test.Environment
+var fakeClock *clock.FakeClock
+var cp *fake.CloudProvider
+var recorder *test.EventRecorder
+
+func TestAPIs(t *testing.T) {
+	ctx = TestContextWithLogger(t)
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Node")
+}
+
+var _ = BeforeSuite(func() {
+	fakeClock = clock.NewFakeClock(time.Now())
+	env = test.NewEnvironment(scheme.Scheme, apis.CRDs...)
+	ctx = settings.ToContext(ctx, test.Settings())
+	cp = &fake.CloudProvider{}
+	recorder = test.NewEventRecorder()
+	controller = inflightchecks.NewController(fakeClock, env.Client, recorder, cp, nil)
+})
+
+var _ = AfterSuite(func() {
+	Expect(env.Stop()).To(Succeed(), "Failed to stop environment")
+})
+
+var _ = Describe("Controller", func() {
+	var provisioner *v1alpha5.Provisioner
+	BeforeEach(func() {
+		provisioner = &v1alpha5.Provisioner{
+			ObjectMeta: metav1.ObjectMeta{Name: test.RandomName()},
+			Spec:       v1alpha5.ProvisionerSpec{},
+		}
+		recorder.Reset()
+	})
+
+	AfterEach(func() {
+		fakeClock.SetTime(time.Now())
+		ExpectCleanedUp(ctx, env.Client)
+	})
+
+	Context("Initialization Failure", func() {
+		It("should detect issues with nodes that never have an extended resource registered", func() {
+			n := test.Node(test.NodeOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
+						v1.LabelInstanceType:             "gpu-vendor-instance-type",
+					},
+				},
+			})
+			n.Status.Capacity = v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("1"),
+				v1.ResourceMemory: resource.MustParse("1Gi"),
+				v1.ResourcePods:   resource.MustParse("10"),
+			}
+			ExpectApplied(ctx, env.Client, provisioner, n)
+			fakeClock.Step(2 * time.Hour)
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(n))
+			ExpectDetectedEvent("Expected resource \"fake.com/vendor-a\" didn't register on the node")
+		})
+		It("should detect issues with nodes that have a startup taint which isn't removed", func() {
+			startupTaint := v1.Taint{
+				Key:    "my.startup.taint",
+				Effect: v1.TaintEffectNoSchedule,
+			}
+			provisioner.Spec.StartupTaints = append(provisioner.Spec.StartupTaints, startupTaint)
+			n := test.Node(test.NodeOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
+						v1.LabelInstanceType:             "default-instance-type",
+					},
+				},
+			})
+			n.Spec.Taints = append(n.Spec.Taints, startupTaint)
+			n.Status.Capacity = v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("1"),
+				v1.ResourceMemory: resource.MustParse("1Gi"),
+				v1.ResourcePods:   resource.MustParse("10"),
+			}
+			ExpectApplied(ctx, env.Client, provisioner, n)
+			fakeClock.Step(2 * time.Hour)
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(n))
+			ExpectDetectedEvent("Startup taint \"my.startup.taint:NoSchedule\" is still on the node")
+		})
+	})
+
+	Context("Termination failure", func() {
+		It("should detect issues with a node that is stuck deleting due to a PDB", func() {
+			n := test.Node(test.NodeOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
+						v1.LabelInstanceType:             "default-instance-type",
+					},
+				},
+			})
+			podsLabels := map[string]string{"myapp": "deleteme"}
+			pdb := test.PodDisruptionBudget(test.PDBOptions{
+				Labels:         podsLabels,
+				MaxUnavailable: &intstr.IntOrString{IntVal: 0, Type: intstr.Int},
+			})
+			n.Status.Capacity = v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("1"),
+				v1.ResourceMemory: resource.MustParse("1Gi"),
+				v1.ResourcePods:   resource.MustParse("10"),
+			}
+			n.Finalizers = []string{"prevent.deletion/now"}
+			p := test.Pod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: podsLabels}})
+			ExpectApplied(ctx, env.Client, provisioner, n, p, pdb)
+			ExpectManualBinding(ctx, env.Client, p, n)
+			_ = env.Client.Delete(ctx, n)
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(n))
+			ExpectDetectedEvent(fmt.Sprintf("Can't drain node, PDB %s/%s is blocking evictions", pdb.Namespace, pdb.Name))
+		})
+	})
+
+	Context("Node Shape", func() {
+		It("should detect issues that launch with much fewer resources than expected", func() {
+			n := test.Node(test.NodeOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
+						v1.LabelInstanceType:             "arm-instance-type",
+						v1alpha5.LabelNodeInitialized:    "true",
+					},
+				},
+			})
+			n.Status.Capacity = v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("16"),
+				v1.ResourceMemory: resource.MustParse("64Gi"),
+				v1.ResourcePods:   resource.MustParse("10"),
+			}
+			ExpectApplied(ctx, env.Client, provisioner, n)
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(n))
+			ExpectDetectedEvent("Expected 128Gi of resource memory, but found 64Gi (50.0% of expected)")
+		})
+	})
+})
+
+func ExpectDetectedEvent(msg string) {
+	foundEvent := false
+	recorder.ForEachEvent(func(evt events.Event) {
+		if evt.Message == msg {
+			foundEvent = true
+		}
+	})
+	ExpectWithOffset(1, foundEvent).To(BeTrue(), fmt.Sprintf("didn't find %q event", msg))
+}

--- a/pkg/controllers/inflightchecks/termination.go
+++ b/pkg/controllers/inflightchecks/termination.go
@@ -1,0 +1,66 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package inflightchecks
+
+import (
+	"context"
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/aws/karpenter-core/pkg/apis/provisioning/v1alpha5"
+	"github.com/aws/karpenter-core/pkg/controllers/deprovisioning"
+	nodeutils "github.com/aws/karpenter-core/pkg/utils/node"
+)
+
+// Termination detects nodes that are stuck terminating and reports why.
+type Termination struct {
+	kubeClient client.Client
+}
+
+func NewTermination(kubeClient client.Client) Check {
+	return &Termination{
+		kubeClient: kubeClient,
+	}
+}
+
+func (t *Termination) Check(ctx context.Context, node *v1.Node, provisioner *v1alpha5.Provisioner, pdbs *deprovisioning.PDBLimits) ([]Issue, error) {
+	// we are only looking at nodes that are hung deleting
+	if node.DeletionTimestamp.IsZero() {
+		return nil, nil
+	}
+
+	pods, err := nodeutils.GetNodePods(ctx, t.kubeClient, node)
+	if err != nil {
+		return nil, err
+	}
+	var issues []Issue
+	if pdb, ok := pdbs.CanEvictPods(pods); !ok {
+		issues = append(issues, Issue{
+			node:    node,
+			message: fmt.Sprintf("Can't drain node, PDB %s is blocking evictions", pdb),
+		})
+	}
+
+	if reason, ok := deprovisioning.PodsPreventEviction(pods); ok {
+		issues = append(issues, Issue{
+			node:    node,
+			message: fmt.Sprintf("Can't drain node, %s", reason),
+		})
+	}
+
+	return issues, nil
+}

--- a/pkg/events/events.go
+++ b/pkg/events/events.go
@@ -64,3 +64,13 @@ func NodeFailedToDrain(node *v1.Node, err error) Event {
 		DedupeValues:   []string{node.Name},
 	}
 }
+
+func NodeInflightCheck(node *v1.Node, message string) Event {
+	return Event{
+		InvolvedObject: node,
+		Type:           v1.EventTypeWarning,
+		Reason:         "FailedInflightCheck",
+		Message:        message,
+		DedupeValues:   []string{node.Name, message},
+	}
+}


### PR DESCRIPTION
Report as events and logs the reasons why a node is stuck terminating or  failing to initialize.

Fixes  https://github.com/aws/karpenter/issues/2829

**Description**

**How was this change tested?**
Unit testing & deployed.

Sample log:
```
karpenter-74bdb86d9c-kc77c controller 2022-11-10T15:56:42.861Z	INFO	controller.inflightchecks	Inflight check failed for node ip-192-168-85-164.us-west-2.compute.internal, Can't drain node, pod default/my-shell is not owned	{"commit": "f691533-dirty", "node": "ip-192-168-85-164.us-west-2.compute.internal"}
```
Sample event:

```
51s         Warning   FailedInflightCheck             node/ip-192-168-85-164.us-west-2.compute.internal    Can't drain node, pod default/my-shell is not owned
```


There is some duplication here as we also report failures to evict. I haven't come to an opinion on if that's ok.  I'm leaning towards it's better to have the duplication as this is rate limited to once per 10 minutes per node and also logs at the info level in addition to creating the event. 

```
  Warning  FailedInflightCheck  2m34s (x2 over 12m)  karpenter  Can't drain node, pod default/my-shell is not owned
  Warning  FailedDraining       32s (x7 over 12m)    karpenter  Failed to drain node, pod default/my-shell does not have any owner references
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
