### PR TITLE
Feat: add an option to disable provisioner

### DIFF
--- a/pkg/apis/provisioning/v1alpha5/provisioner.go
+++ b/pkg/apis/provisioning/v1alpha5/provisioner.go
@@ -84,6 +84,8 @@ type ProvisionerSpec struct {
 	// Consolidation are the consolidation parameters
 	// +optional
 	Consolidation *Consolidation `json:"consolidation,omitempty"`
+	// Disable the provisioner: no new nodes will be added
+	Disabled *bool `json:"disabled,omitempty"`
 }
 
 type Consolidation struct {

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -252,7 +252,7 @@ func (p *Provisioner) NewScheduler(ctx context.Context, pods []*v1.Pod, stateNod
 
 	for i := range provisionerList.Items {
 		provisioner := &provisionerList.Items[i]
-		if *provisioner.Spec.Disabled {
+		if provisioner.Spec.Disabled != nil && *provisioner.Spec.Disabled {
 			continue
 		}
 		if !provisioner.DeletionTimestamp.IsZero() {

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -252,6 +252,9 @@ func (p *Provisioner) NewScheduler(ctx context.Context, pods []*v1.Pod, stateNod
 
 	for i := range provisionerList.Items {
 		provisioner := &provisionerList.Items[i]
+		if *provisioner.Spec.Disabled {
+			continue
+		}
 		if !provisioner.DeletionTimestamp.IsZero() {
 			continue
 		}

--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -50,7 +50,7 @@ func NewScheduler(ctx context.Context, kubeClient client.Client, nodeTemplates [
 	toleratePreferNoSchedule := false
 	for _, prov := range provisioners {
 		for _, taint := range prov.Spec.Taints {
-			if !*prov.Spec.Disabled && taint.Effect == v1.TaintEffectPreferNoSchedule {
+			if (prov.Spec.Disabled == nil || !*prov.Spec.Disabled) && taint.Effect == v1.TaintEffectPreferNoSchedule {
 				toleratePreferNoSchedule = true
 			}
 		}

--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -50,7 +50,7 @@ func NewScheduler(ctx context.Context, kubeClient client.Client, nodeTemplates [
 	toleratePreferNoSchedule := false
 	for _, prov := range provisioners {
 		for _, taint := range prov.Spec.Taints {
-			if taint.Effect == v1.TaintEffectPreferNoSchedule {
+			if !*prov.Spec.Disabled && taint.Effect == v1.TaintEffectPreferNoSchedule {
 				toleratePreferNoSchedule = true
 			}
 		}

--- a/pkg/controllers/provisioning/suite_test.go
+++ b/pkg/controllers/provisioning/suite_test.go
@@ -227,6 +227,19 @@ var _ = Describe("Provisioning", func() {
 			Expect(n.Name).ToNot(Equal(node.Name))
 		})
 	})
+	FIt("should not provision from disabled provisioner", func() {
+		x := test.Provisioner()
+		y := true
+		x.Spec.Disabled = &y
+		ExpectApplied(ctx, env.Client, x)
+		pods := ExpectProvisioned(ctx, env.Client, recorder, controller, prov, test.UnschedulablePod())
+		nodes := &v1.NodeList{}
+		Expect(env.Client.List(ctx, nodes)).To(Succeed())
+		Expect(len(nodes.Items)).To(Equal(0))
+		for _, pod := range pods {
+			ExpectNotScheduled(ctx, env.Client, pod)
+		}
+	})
 	Context("Resource Limits", func() {
 		It("should not schedule when limits are exceeded", func() {
 			ExpectApplied(ctx, env.Client, test.Provisioner(test.ProvisionerOptions{


### PR DESCRIPTION
**Description**
Fix https://github.com/aws/karpenter/issues/2491
To stop provisioner from provision more nodes when things going wrong, like there are pending pods.

**How was this change tested?**
Not tested yet. The test currently failed. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
