### PR TITLE
feat: Allow to reference a local yaml settings file

### DIFF
--- a/pkg/apis/config/registration.go
+++ b/pkg/apis/config/registration.go
@@ -17,25 +17,22 @@ package config
 import (
 	"fmt"
 
-	"knative.dev/pkg/configmap"
+	v1 "k8s.io/api/core/v1"
 )
-
-// Constructor should take the form func(*v1.ConfigMap) (T, error)
-type Constructor interface{}
 
 // Registration defines a ConfigMap registration to be watched by the settingsstore.Watcher
 // and to be injected into the Reconcile() contexts of controllers
 type Registration struct {
 	ConfigMapName string
-	Constructor   interface{}
+	Constructor   func(*v1.ConfigMap) (interface{}, error)
 }
 
 func (r Registration) Validate() error {
 	if r.ConfigMapName == "" {
-		return fmt.Errorf("configMap cannot be empty in SettingsStore registration")
+		return fmt.Errorf("configMapName cannot be empty in SettingsStore registration")
 	}
-	if err := configmap.ValidateConstructor(r.Constructor); err != nil {
-		return fmt.Errorf("constructor validation failed in SettingsStore registration, %w", err)
+	if r.Constructor == nil {
+		return fmt.Errorf("constructor cannot be nil")
 	}
 	return nil
 }

--- a/pkg/apis/config/settings/settings.go
+++ b/pkg/apis/config/settings/settings.go
@@ -41,12 +41,12 @@ var defaultSettings = Settings{
 }
 
 type Settings struct {
-	BatchMaxDuration  metav1.Duration `json:"batchMaxDuration"`
-	BatchIdleDuration metav1.Duration `json:"batchIdleDuration"`
+	BatchMaxDuration  metav1.Duration
+	BatchIdleDuration metav1.Duration
 }
 
 // NewSettingsFromConfigMap creates a Settings from the supplied ConfigMap
-func NewSettingsFromConfigMap(cm *v1.ConfigMap) (Settings, error) {
+func NewSettingsFromConfigMap(cm *v1.ConfigMap) (interface{}, error) {
 	s := defaultSettings
 
 	if err := configmap.Parse(cm.Data,

--- a/pkg/apis/config/settings/suite_test.go
+++ b/pkg/apis/config/settings/suite_test.go
@@ -21,6 +21,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 	. "knative.dev/pkg/logging/testing"
 
@@ -37,12 +38,12 @@ func TestSettings(t *testing.T) {
 	RunSpecs(t, "Settings")
 }
 
-var _ = Describe("Validation", func() {
+var _ = Describe("Settings", func() {
 	It("should succeed to set defaults", func() {
 		cm := &v1.ConfigMap{
 			Data: map[string]string{},
 		}
-		s, _ := settings.NewSettingsFromConfigMap(cm)
+		s := lo.Must(settings.NewSettingsFromConfigMap(cm)).(settings.Settings)
 		Expect(s.BatchMaxDuration.Duration).To(Equal(time.Second * 10))
 		Expect(s.BatchIdleDuration.Duration).To(Equal(time.Second))
 	})
@@ -53,7 +54,7 @@ var _ = Describe("Validation", func() {
 				"batchIdleDuration": "5s",
 			},
 		}
-		s, _ := settings.NewSettingsFromConfigMap(cm)
+		s := lo.Must(settings.NewSettingsFromConfigMap(cm)).(settings.Settings)
 		Expect(s.BatchMaxDuration.Duration).To(Equal(time.Second * 30))
 		Expect(s.BatchIdleDuration.Duration).To(Equal(time.Second * 5))
 	})

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -99,7 +99,12 @@ func NewOperator() (context.Context, *Operator) {
 	ctx = logging.WithLogger(ctx, logger)
 
 	// Create the settingsStore for settings injection
-	settingsStore := settingsstore.NewWatcherOrDie(ctx, kubernetesInterface, configMapWatcher, apis.Settings.List()...)
+	var settingsStore settingsstore.Store
+	if opts.SettingsFile != "" {
+		settingsStore = settingsstore.NewLocalStoreOrDie(ctx, apis.Settings.List()...)
+	} else {
+		settingsStore = settingsstore.NewWatcherOrDie(ctx, kubernetesInterface, configMapWatcher, apis.Settings.List()...)
+	}
 
 	// Inject settings after starting the ConfigMapWatcher
 	lo.Must0(configMapWatcher.Start(ctx.Done()))

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -44,6 +44,7 @@ type Options struct {
 	EnableProfiling      bool
 	EnableLeaderElection bool
 	MemoryLimit          int64
+	SettingsFile         string
 }
 
 // New creates an Options struct and registers CLI flags and environment variables to fill-in the Options struct fields
@@ -63,6 +64,7 @@ func New() *Options {
 	f.BoolVar(&opts.EnableProfiling, "enable-profiling", env.WithDefaultBool("ENABLE_PROFILING", false), "Enable the profiling on the metric endpoint")
 	f.BoolVar(&opts.EnableLeaderElection, "leader-elect", env.WithDefaultBool("LEADER_ELECT", true), "Start leader election client and gain leadership before executing the main loop. Enable this when running replicated components for high availability.")
 	f.Int64Var(&opts.MemoryLimit, "memory-limit", env.WithDefaultInt64("MEMORY_LIMIT", -1), "Memory limit on the container running the controller. The GC soft memory limit is set to 90% of this value.")
+	f.StringVar(&opts.SettingsFile, "settings-file", env.WithDefaultString("SETTINGS_FILE", ""), "The filepath to a local settings file. If set, settings will come from this style instead of a ConfigMap")
 
 	if opts.MemoryLimit > 0 {
 		newLimit := int64(float64(opts.MemoryLimit) * 0.9)

--- a/pkg/operator/settingsstore/fake/settings.go
+++ b/pkg/operator/settingsstore/fake/settings.go
@@ -16,10 +16,8 @@ package fake
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
-	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/configmap"
 
@@ -39,16 +37,7 @@ type Settings struct {
 	TestArg string `json:"testArg"`
 }
 
-func (s Settings) Data() (map[string]string, error) {
-	d := map[string]string{}
-
-	if err := json.Unmarshal(lo.Must(json.Marshal(defaultSettings)), &d); err != nil {
-		return d, err
-	}
-	return d, nil
-}
-
-func NewFakeSettingsFromConfigMap(cm *v1.ConfigMap) (Settings, error) {
+func NewFakeSettingsFromConfigMap(cm *v1.ConfigMap) (interface{}, error) {
 	s := defaultSettings
 
 	if err := configmap.Parse(cm.Data,

--- a/pkg/operator/settingsstore/testdata/testsettings.yaml
+++ b/pkg/operator/settingsstore/testdata/testsettings.yaml
@@ -1,0 +1,2 @@
+batchMaxDuration: 15s
+batchIdleDuration: 2s


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

Allow a reference to a local settings file for Karpenter global settings with `--settings-file`. Settings file should be a yaml file formatted like

```yaml
batchMaxDuration: 10s
batchIdleDuration: 1s
aws:
  clusterName: karpenter-cluster
  clusterEndpoint: https://....gr7.us-west-2.eks.amazonaws.com
  defaultInstanceProfile: KarpenterNodeInstanceProfile-karpenter-cluster
```

**How was this change tested?**

`make run`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
