### PR TITLE
fix: Wait on `.status.Capacity` and `.status.Allocatable` in Initialization

### DIFF
--- a/pkg/controllers/deprovisioning/suite_test.go
+++ b/pkg/controllers/deprovisioning/suite_test.go
@@ -572,7 +572,8 @@ var _ = Describe("Replace Nodes", func() {
 					v1alpha5.LabelCapacityType:       mostExpensiveOffering.CapacityType,
 					v1.LabelTopologyZone:             mostExpensiveOffering.Zone,
 				}},
-			Allocatable: map[v1.ResourceName]resource.Quantity{v1.ResourceCPU: resource.MustParse("32")}})
+			Allocatable: map[v1.ResourceName]resource.Quantity{v1.ResourceCPU: resource.MustParse("32")},
+		})
 
 		ExpectApplied(ctx, env.Client, rs, pod, node, prov)
 		ExpectMakeNodesReady(ctx, env.Client, node)
@@ -643,7 +644,8 @@ var _ = Describe("Replace Nodes", func() {
 			Allocatable: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU:  resource.MustParse("32"),
 				v1.ResourcePods: resource.MustParse("100"),
-			}})
+			},
+		})
 
 		ExpectApplied(ctx, env.Client, rs, pods[0], pods[1], pods[2], node1, prov, pdb)
 		ExpectApplied(ctx, env.Client, node1)
@@ -704,7 +706,8 @@ var _ = Describe("Replace Nodes", func() {
 			Allocatable: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU:  resource.MustParse("32"),
 				v1.ResourcePods: resource.MustParse("100"),
-			}})
+			},
+		})
 
 		annotatedNode := test.Node(test.NodeOptions{
 			ObjectMeta: metav1.ObjectMeta{
@@ -720,7 +723,8 @@ var _ = Describe("Replace Nodes", func() {
 			Allocatable: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU:  resource.MustParse("32"),
 				v1.ResourcePods: resource.MustParse("100"),
-			}})
+			},
+		})
 
 		ExpectApplied(ctx, env.Client, rs, pods[0], pods[1], pods[2], prov)
 		ExpectApplied(ctx, env.Client, regularNode, annotatedNode)

--- a/pkg/controllers/node/initialization.go
+++ b/pkg/controllers/node/initialization.go
@@ -101,15 +101,13 @@ func isExtendedResourceRegistered(node *v1.Node, instanceType cloudprovider.Inst
 		return true
 	}
 	for resourceName, quantity := range instanceType.Resources() {
-		// kubelet will zero out both the capacity and allocatable for an extended resource on startup, so if our
-		// annotation says the resource should be there, but it's zero'd in both then the device plugin hasn't
-		// registered it yet
 		if quantity.IsZero() {
 			continue
 		}
-		if resources.IsZero(node.Status.Capacity[resourceName]) {
-			return false
-		}
+		// kubelet will zero out both the capacity and allocatable for an extended resource on startup, so if our
+		// annotation says the resource should be there, but it's zero'd in both then the device plugin hasn't
+		// registered it yet.
+		// We wait on allocatable since this is the value that is used in scheduling
 		if resources.IsZero(node.Status.Allocatable[resourceName]) {
 			return false
 		}

--- a/pkg/controllers/node/initialization.go
+++ b/pkg/controllers/node/initialization.go
@@ -104,9 +104,13 @@ func isExtendedResourceRegistered(node *v1.Node, instanceType cloudprovider.Inst
 		// kubelet will zero out both the capacity and allocatable for an extended resource on startup, so if our
 		// annotation says the resource should be there, but it's zero'd in both then the device plugin hasn't
 		// registered it yet
-		if resources.IsZero(node.Status.Capacity[resourceName]) &&
-			resources.IsZero(node.Status.Allocatable[resourceName]) &&
-			!quantity.IsZero() {
+		if quantity.IsZero() {
+			continue
+		}
+		if resources.IsZero(node.Status.Capacity[resourceName]) {
+			return false
+		}
+		if resources.IsZero(node.Status.Allocatable[resourceName]) {
 			return false
 		}
 	}

--- a/pkg/controllers/node/suite_test.go
+++ b/pkg/controllers/node/suite_test.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	clock "k8s.io/utils/clock/testing"
 	"knative.dev/pkg/ptr"
@@ -82,70 +83,186 @@ var _ = Describe("Controller", func() {
 
 	Context("Initialization", func() {
 		It("should initialize the node when ready", func() {
-
-		})
-		It("should not initialize the node when not ready", func() {
-
-		})
-		It("should initialize the node when extended resources are registered", func() {
-
-		})
-		It("should not initialize the node when extended resource isn't registered", func() {
-
-		})
-		It("should initialize the node when startup taints are removed", func() {
-
-		})
-		It("should not initialize the node when startup taints aren't removed", func() {
-
-		})
-	})
-	Context("Expiration", func() {
-		It("should ignore nodes without TTLSecondsUntilExpired", func() {
-			n := test.Node(test.NodeOptions{
+			node := test.Node(test.NodeOptions{
 				ObjectMeta: metav1.ObjectMeta{
-					Finalizers: []string{v1alpha5.TerminationFinalizer},
 					Labels: map[string]string{
 						v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
 					},
 				},
+				ReadyStatus: v1.ConditionTrue,
 			})
-			ExpectApplied(ctx, env.Client, provisioner, n)
-			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(n))
+			ExpectApplied(ctx, env.Client, provisioner, node)
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(node))
 
-			n = ExpectNodeExists(ctx, env.Client, n.Name)
-			Expect(n.DeletionTimestamp.IsZero()).To(BeTrue())
+			node = ExpectNodeExists(ctx, env.Client, node.Name)
+			Expect(node.Labels).To(HaveKey(v1alpha5.LabelNodeInitialized))
 		})
-		It("should ignore nodes without a provisioner", func() {
-			n := test.Node(test.NodeOptions{ObjectMeta: metav1.ObjectMeta{Finalizers: []string{v1alpha5.TerminationFinalizer}}})
-			ExpectApplied(ctx, env.Client, provisioner, n)
-			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(n))
-
-			n = ExpectNodeExists(ctx, env.Client, n.Name)
-			Expect(n.DeletionTimestamp.IsZero()).To(BeTrue())
-		})
-		It("should delete nodes after expiry", func() {
-			provisioner.Spec.TTLSecondsUntilExpired = ptr.Int64(30)
-			n := test.Node(test.NodeOptions{ObjectMeta: metav1.ObjectMeta{
-				Finalizers: []string{v1alpha5.TerminationFinalizer},
-				Labels: map[string]string{
-					v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
+		It("should not initialize the node when not ready", func() {
+			node := test.Node(test.NodeOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
+					},
 				},
-			}})
-			ExpectApplied(ctx, env.Client, provisioner, n)
-			fakeClock.SetTime(time.Now())
+				ReadyStatus: v1.ConditionFalse,
+			})
+			ExpectApplied(ctx, env.Client, provisioner, node)
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(node))
 
-			// Should still exist
-			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(n))
-			n = ExpectNodeExists(ctx, env.Client, n.Name)
-			Expect(n.DeletionTimestamp.IsZero()).To(BeTrue())
+			node = ExpectNodeExists(ctx, env.Client, node.Name)
+			Expect(node.Labels).ToNot(HaveKey(v1alpha5.LabelNodeInitialized))
+		})
+		It("should initialize the node when extended resources are registered", func() {
+			node := test.Node(test.NodeOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
+						v1.LabelInstanceTypeStable:       "gpu-vendor-instance-type",
+					},
+				},
+				ReadyStatus: v1.ConditionTrue,
+				Allocatable: v1.ResourceList{
+					v1.ResourceCPU:          resource.MustParse("4"),
+					v1.ResourceMemory:       resource.MustParse("4Gi"),
+					v1.ResourcePods:         resource.MustParse("5"),
+					fake.ResourceGPUVendorA: resource.MustParse("2"),
+				},
+				Capacity: v1.ResourceList{
+					v1.ResourceCPU:          resource.MustParse("4"),
+					v1.ResourceMemory:       resource.MustParse("4Gi"),
+					v1.ResourcePods:         resource.MustParse("5"),
+					fake.ResourceGPUVendorA: resource.MustParse("2"),
+				},
+			})
+			ExpectApplied(ctx, env.Client, provisioner, node)
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(node))
 
-			// Simulate time passing
-			fakeClock.Step(time.Duration(*provisioner.Spec.TTLSecondsUntilExpired) * time.Second)
+			node = ExpectNodeExists(ctx, env.Client, node.Name)
+			Expect(node.Labels).To(HaveKey(v1alpha5.LabelNodeInitialized))
+		})
+		It("should not initialize the node when extended resource isn't registered", func() {
+			node := test.Node(test.NodeOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
+						v1.LabelInstanceTypeStable:       "gpu-vendor-instance-type",
+					},
+				},
+				ReadyStatus: v1.ConditionTrue,
+				Allocatable: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("4"),
+					v1.ResourceMemory: resource.MustParse("4Gi"),
+					v1.ResourcePods:   resource.MustParse("5"),
+				},
+				Capacity: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("4"),
+					v1.ResourceMemory: resource.MustParse("4Gi"),
+					v1.ResourcePods:   resource.MustParse("5"),
+				},
+			})
+			ExpectApplied(ctx, env.Client, provisioner, node)
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(node))
 
-			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(n))
-			n = ExpectNodeExists(ctx, env.Client, n.Name)
-			Expect(n.DeletionTimestamp.IsZero()).To(BeFalse())
+			node = ExpectNodeExists(ctx, env.Client, node.Name)
+			Expect(node.Labels).ToNot(HaveKey(v1alpha5.LabelNodeInitialized))
+		})
+		It("should not initialize the node when capacity is filled but allocatable isn't set", func() {
+			node := test.Node(test.NodeOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
+						v1.LabelInstanceTypeStable:       "gpu-vendor-instance-type",
+					},
+				},
+				ReadyStatus: v1.ConditionTrue,
+				Allocatable: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("4"),
+					v1.ResourceMemory: resource.MustParse("4Gi"),
+					v1.ResourcePods:   resource.MustParse("5"),
+				},
+				Capacity: v1.ResourceList{
+					v1.ResourceCPU:          resource.MustParse("4"),
+					v1.ResourceMemory:       resource.MustParse("4Gi"),
+					v1.ResourcePods:         resource.MustParse("5"),
+					fake.ResourceGPUVendorA: resource.MustParse("2"),
+				},
+			})
+			ExpectApplied(ctx, env.Client, provisioner, node)
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(node))
+
+			node = ExpectNodeExists(ctx, env.Client, node.Name)
+			Expect(node.Labels).ToNot(HaveKey(v1alpha5.LabelNodeInitialized))
+		})
+		It("should initialize the node when startup taints are removed", func() {
+			provisioner.Spec.StartupTaints = []v1.Taint{
+				{
+					Key:    "example.com/startup-taint1",
+					Value:  "true",
+					Effect: v1.TaintEffectNoExecute,
+				},
+				{
+					Key:    "example.com/startup-taint1",
+					Value:  "true",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+				{
+					Key:    "example.com/startup-taint2",
+					Value:  "true",
+					Effect: v1.TaintEffectNoExecute,
+				},
+			}
+			node := test.Node(test.NodeOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
+					},
+				},
+				ReadyStatus: v1.ConditionTrue,
+			})
+			ExpectApplied(ctx, env.Client, provisioner, node)
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(node))
+
+			node = ExpectNodeExists(ctx, env.Client, node.Name)
+			Expect(node.Labels).To(HaveKey(v1alpha5.LabelNodeInitialized))
+		})
+		It("should not initialize the node when startup taints aren't removed", func() {
+			provisioner.Spec.StartupTaints = []v1.Taint{
+				{
+					Key:    "example.com/startup-taint1",
+					Value:  "true",
+					Effect: v1.TaintEffectNoExecute,
+				},
+				{
+					Key:    "example.com/startup-taint1",
+					Value:  "true",
+					Effect: v1.TaintEffectNoSchedule,
+				},
+				{
+					Key:    "example.com/startup-taint2",
+					Value:  "true",
+					Effect: v1.TaintEffectNoExecute,
+				},
+			}
+			node := test.Node(test.NodeOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
+					},
+				},
+				Taints: []v1.Taint{
+					{
+						Key:    "example.com/startup-taint1",
+						Value:  "true",
+						Effect: v1.TaintEffectNoExecute,
+					},
+				},
+				ReadyStatus: v1.ConditionTrue,
+			})
+			ExpectApplied(ctx, env.Client, provisioner, node)
+			ExpectReconcileSucceeded(ctx, controller, client.ObjectKeyFromObject(node))
+
+			node = ExpectNodeExists(ctx, env.Client, node.Name)
+			Expect(node.Labels).ToNot(HaveKey(v1alpha5.LabelNodeInitialized))
 		})
 	})
 	Context("Emptiness", func() {

--- a/pkg/controllers/state/suite_test.go
+++ b/pkg/controllers/state/suite_test.go
@@ -760,7 +760,7 @@ func ExpectNodeResourceRequest(node *v1.Node, resourceName v1.ResourceName, amou
 
 		nodeRequest := requested[resourceName]
 		expected := resource.MustParse(amount)
-		Expect(nodeRequest.AsApproximateFloat64()).To(BeNumerically("~", expected.AsApproximateFloat64(), 0.001))
+		ExpectWithOffset(1, nodeRequest.AsApproximateFloat64()).To(BeNumerically("~", expected.AsApproximateFloat64(), 0.001))
 		return false
 	})
 }

--- a/pkg/test/nodes.go
+++ b/pkg/test/nodes.go
@@ -31,6 +31,7 @@ type NodeOptions struct {
 	ProviderID    string
 	Taints        []v1.Taint
 	Allocatable   v1.ResourceList
+	Capacity      v1.ResourceList
 }
 
 func Node(overrides ...NodeOptions) *v1.Node {
@@ -43,6 +44,9 @@ func Node(overrides ...NodeOptions) *v1.Node {
 	if options.ReadyStatus == "" {
 		options.ReadyStatus = v1.ConditionTrue
 	}
+	if options.Capacity == nil {
+		options.Capacity = options.Allocatable
+	}
 
 	return &v1.Node{
 		ObjectMeta: ObjectMeta(options.ObjectMeta),
@@ -53,7 +57,7 @@ func Node(overrides ...NodeOptions) *v1.Node {
 		},
 		Status: v1.NodeStatus{
 			Allocatable: options.Allocatable,
-			Capacity:    options.Allocatable,
+			Capacity:    options.Capacity,
 			Conditions:  []v1.NodeCondition{{Type: v1.NodeReady, Status: options.ReadyStatus, Reason: options.ReadyReason}},
 		},
 	}


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

Uses `.status.allocatable` and `.status.capacity` values immediately when they are set vs. waiting for node initialization

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
