### PR TITLE
BREAKING CHANGE: Evict pods with no ownerRefs by default

### DIFF
--- a/pkg/controllers/deprovisioning/consolidation.go
+++ b/pkg/controllers/deprovisioning/consolidation.go
@@ -265,10 +265,6 @@ func podsPreventEviction(node CandidateNode) bool {
 		if pod.HasDoNotEvict(p) {
 			return true
 		}
-
-		if pod.IsNotOwned(p) {
-			return true
-		}
 	}
 	return false
 }

--- a/pkg/controllers/deprovisioning/suite_test.go
+++ b/pkg/controllers/deprovisioning/suite_test.go
@@ -1255,7 +1255,7 @@ var _ = Describe("Delete Node", func() {
 		// but we expect to delete the node with more pods (node1) as the pod on node2 has a do-not-evict annotation
 		ExpectNotFound(ctx, env.Client, node1)
 	})
-	It("can delete nodes, doesn't evict standalone pods", func() {
+	It("can delete nodes, evicts pods without an ownerRef", func() {
 		// create our RS so we can link a pod to it
 		rs := test.ReplicaSet()
 		ExpectApplied(ctx, env.Client, rs)
@@ -1327,9 +1327,9 @@ var _ = Describe("Delete Node", func() {
 
 		// we don't need a new node
 		Expect(cloudProvider.CreateCalls).To(HaveLen(0))
-		// but we expect to delete the node with more pods (node1) as the pod on node2 doesn't have a controller to
-		// recreate it
-		ExpectNotFound(ctx, env.Client, node1)
+		// but we expect to delete the node with the fewest pods (node 2) even though the pod has no ownerRefs
+		// and will not be recreated
+		ExpectNotFound(ctx, env.Client, node2)
 	})
 })
 

--- a/pkg/utils/pod/scheduling.go
+++ b/pkg/utils/pod/scheduling.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/aws/karpenter-core/pkg/apis/provisioning/v1alpha5"
+	"github.com/aws/karpenter-core/pkg/scheduling"
 )
 
 func IsProvisionable(pod *v1.Pod) bool {
@@ -67,10 +68,6 @@ func IsOwnedByNode(pod *v1.Pod) bool {
 	})
 }
 
-func IsNotOwned(pod *v1.Pod) bool {
-	return len(pod.ObjectMeta.OwnerReferences) == 0
-}
-
 func IsOwnedBy(pod *v1.Pod, gvks []schema.GroupVersionKind) bool {
 	for _, ignoredOwner := range gvks {
 		for _, owner := range pod.ObjectMeta.OwnerReferences {
@@ -87,6 +84,11 @@ func HasDoNotEvict(pod *v1.Pod) bool {
 		return false
 	}
 	return pod.Annotations[v1alpha5.DoNotEvictPodAnnotationKey] == "true"
+}
+
+// HasUnschedulableToleration returns true if the pod tolerates node.kubernetes.io/unschedulable taint
+func ToleratesUnschedulableTaint(pod *v1.Pod) bool {
+	return (scheduling.Taints{{Key: v1.TaintNodeUnschedulable, Effect: v1.TaintEffectNoSchedule}}).Tolerates(pod) == nil
 }
 
 // HasRequiredPodAntiAffinity returns true if a non-empty PodAntiAffinity/RequiredDuringSchedulingIgnoredDuringExecution


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->
[#1532](https://github.com/aws/karpenter/issues/2391), [#2391](https://github.com/aws/karpenter/issues/1532)

**Description**
This reverts a change made in a [previous PR](https://github.com/aws/karpenter/pull/2092) to prevent a node from being terminated if a pod without an ownerRef is encountered ("naked" pod).  Per Kubernetes documentation, the use of naked pods should be avoided if possible and Karpenter should reinforce that recommendation.  There should be no assumption of reliability or stability when naked pods are used given an involuntary node interruption can cause the pod to go away and not be recreated.  Karpenter users should be aware of how naked pods are being used in their clusters and define how evictions should be handled on each pod.  Users can prevent naked pods from being voluntarily disrupted by applying the "karpenter.sh/do-not-evict: false" annotation to the pod in question.

**How was this change tested?**
Automated tests and manual validation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
