### PR TITLE
chore: simplified deprovisioning interface

### DIFF
--- a/pkg/controllers/deprovisioning/controller.go
+++ b/pkg/controllers/deprovisioning/controller.go
@@ -147,6 +147,7 @@ func (c *Controller) ProcessCluster(ctx context.Context) (Result, error) {
 		if err != nil {
 			return ResultFailed, fmt.Errorf("deprovisioning nodes, %w", err)
 		}
+
 		switch result {
 		case ResultFailed:
 			return result, err

--- a/pkg/controllers/deprovisioning/helpers.go
+++ b/pkg/controllers/deprovisioning/helpers.go
@@ -149,10 +149,11 @@ func disruptionCost(ctx context.Context, pods []*v1.Pod) float64 {
 	return cost
 }
 
+type CandidateFilter func(context.Context, *state.Node, *v1alpha5.Provisioner, []*v1.Pod) bool
+
 // candidateNodes returns nodes that appear to be currently deprovisionable based off of their provisioner
 // nolint:gocyclo
-func candidateNodes(ctx context.Context, cluster *state.Cluster, kubeClient client.Client, clk clock.Clock, cloudProvider cloudprovider.CloudProvider,
-	shouldDeprovision func(context.Context, *state.Node, *v1alpha5.Provisioner, []*v1.Pod) bool) ([]CandidateNode, error) {
+func candidateNodes(ctx context.Context, cluster *state.Cluster, kubeClient client.Client, clk clock.Clock, cloudProvider cloudprovider.CloudProvider, shouldDeprovision CandidateFilter) ([]CandidateNode, error) {
 	provisioners, instanceTypesByProvisioner, err := buildProvisionerMap(ctx, kubeClient, cloudProvider)
 	if err != nil {
 		return nil, err

--- a/pkg/controllers/deprovisioning/helpers.go
+++ b/pkg/controllers/deprovisioning/helpers.go
@@ -32,6 +32,7 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/utils/clock"
 	"knative.dev/pkg/logging"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -145,6 +146,128 @@ func disruptionCost(ctx context.Context, pods []*v1.Pod) float64 {
 		cost += GetPodEvictionCost(ctx, p)
 	}
 	return cost
+}
+
+// candidateNodes returns nodes that appear to be currently deprovisionable based off of their provisioner
+// nolint:gocyclo
+func candidateNodes(ctx context.Context, d deprovisioner, cloudProvider cloudprovider.CloudProvider,
+	shouldDeprovision func(context.Context, *state.Node, *v1alpha5.Provisioner, []*v1.Pod) bool) ([]CandidateNode, error) {
+	provisioners, instanceTypesByProvisioner, err := buildProvisionerMap(ctx, d.kubeClient, cloudProvider)
+	if err != nil {
+		return nil, err
+	}
+
+	var nodes []CandidateNode
+	d.cluster.ForEachNode(func(n *state.Node) bool {
+		var provisioner *v1alpha5.Provisioner
+		var instanceTypeMap map[string]cloudprovider.InstanceType
+		if provName, ok := n.Node.Labels[v1alpha5.ProvisionerNameLabelKey]; ok {
+			provisioner = provisioners[provName]
+			instanceTypeMap = instanceTypesByProvisioner[provName]
+		}
+		// skip any nodes that are already marked for deletion and being handled
+		if n.MarkedForDeletion {
+			return true
+		}
+		// skip any nodes where we can't determine the provisioner
+		if provisioner == nil || instanceTypeMap == nil {
+			return true
+		}
+
+		instanceType := instanceTypeMap[n.Node.Labels[v1.LabelInstanceTypeStable]]
+		// skip any nodes that we can't determine the instance of
+		if instanceType == nil {
+			return true
+		}
+
+		// skip any nodes that we can't determine the capacity type or the topology zone for
+		ct, ok := n.Node.Labels[v1alpha5.LabelCapacityType]
+		if !ok {
+			return true
+		}
+		az, ok := n.Node.Labels[v1.LabelTopologyZone]
+		if !ok {
+			return true
+		}
+
+		// Skip nodes that aren't initialized
+		if n.Node.Labels[v1alpha5.LabelNodeInitialized] != "true" {
+			return true
+		}
+
+		// Skip the node if it is nominated by a recent provisioning pass to be the target of a pending pod.
+		if d.cluster.IsNodeNominated(n.Node.Name) {
+			return true
+		}
+
+		pods, err := nodeutils.GetNodePods(ctx, d.kubeClient, n.Node)
+		if err != nil {
+			logging.FromContext(ctx).Errorf("Determining node pods, %s", err)
+			return true
+		}
+
+		if !shouldDeprovision(ctx, n, provisioner, pods) {
+			return true
+		}
+
+		cn := CandidateNode{
+			Node:           n.Node,
+			instanceType:   instanceType,
+			capacityType:   ct,
+			zone:           az,
+			provisioner:    provisioner,
+			pods:           pods,
+			disruptionCost: disruptionCost(ctx, pods),
+		}
+		// lifetimeRemaining is the fraction of node lifetime remaining in the range [0.0, 1.0].  If the TTLSecondsUntilExpired
+		// is non-zero, we use it to scale down the disruption costs of nodes that are going to expire.  Just after creation, the
+		// disruption cost is highest and it approaches zero as the node ages towards its expiration time.
+		lifetimeRemaining := calculateLifetimeRemaining(cn, d.clock)
+		cn.disruptionCost *= lifetimeRemaining
+
+		nodes = append(nodes, cn)
+		return true
+	})
+
+	return nodes, nil
+}
+
+// buildProvisionerMap builds a provName -> provisioner map and a provName -> instanceName -> instance type map
+func buildProvisionerMap(ctx context.Context, kubeClient client.Client, cloudProvider cloudprovider.CloudProvider) (map[string]*v1alpha5.Provisioner, map[string]map[string]cloudprovider.InstanceType, error) {
+	provisioners := map[string]*v1alpha5.Provisioner{}
+	var provList v1alpha5.ProvisionerList
+	if err := kubeClient.List(ctx, &provList); err != nil {
+		return nil, nil, fmt.Errorf("listing provisioners, %w", err)
+	}
+	instanceTypesByProvisioner := map[string]map[string]cloudprovider.InstanceType{}
+	for i := range provList.Items {
+		p := &provList.Items[i]
+		provisioners[p.Name] = p
+
+		provInstanceTypes, err := cloudProvider.GetInstanceTypes(ctx, p)
+		if err != nil {
+			return nil, nil, fmt.Errorf("listing instance types for %s, %w", p.Name, err)
+		}
+		instanceTypesByProvisioner[p.Name] = map[string]cloudprovider.InstanceType{}
+		for _, it := range provInstanceTypes {
+			instanceTypesByProvisioner[p.Name][it.Name()] = it
+		}
+	}
+	return provisioners, instanceTypesByProvisioner, nil
+}
+
+// calculateLifetimeRemaining calculates the fraction of node lifetime remaining in the range [0.0, 1.0].  If the TTLSecondsUntilExpired
+// is non-zero, we use it to scale down the disruption costs of nodes that are going to expire.  Just after creation, the
+// disruption cost is highest and it approaches zero as the node ages towards its expiration time.
+func calculateLifetimeRemaining(node CandidateNode, clock clock.Clock) float64 {
+	remaining := 1.0
+	if node.provisioner.Spec.TTLSecondsUntilExpired != nil {
+		ageInSeconds := clock.Since(node.CreationTimestamp.Time).Seconds()
+		totalLifetimeSeconds := float64(*node.provisioner.Spec.TTLSecondsUntilExpired)
+		lifetimeRemainingSeconds := totalLifetimeSeconds - ageInSeconds
+		remaining = clamp(0.0, lifetimeRemainingSeconds/totalLifetimeSeconds, 1.0)
+	}
+	return remaining
 }
 
 // worstLaunchPrice gets the worst-case launch price from the offerings that are offered

--- a/pkg/controllers/deprovisioning/types.go
+++ b/pkg/controllers/deprovisioning/types.go
@@ -21,6 +21,8 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/utils/clock"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aws/karpenter-core/pkg/apis/provisioning/v1alpha5"
 
@@ -52,6 +54,11 @@ func (r Result) String() string {
 	default:
 		return fmt.Sprintf("Unknown (%d)", r)
 	}
+}
+type deprovisioner struct {
+	kubeClient    client.Client
+	cluster       *state.Cluster
+	clock         clock.Clock
 }
 
 type Deprovisioner interface {


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
This simplifies the deprovisioning interface by pulling out out some of the consolidation specific details from the interface.
This also fixes a bug introduced where the Consolidation TTL wasn't considered for empty nodes, resulting in cases where empty nodes would get more aggressively terminated. 

**How was this change tested?**
- `make presubmit`
- `make e2etests`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
