### PR TITLE
chore: remove duplicate err log in deprovisioning reconciler

### DIFF
--- a/pkg/controllers/deprovisioning/controller.go
+++ b/pkg/controllers/deprovisioning/controller.go
@@ -101,7 +101,6 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	result, err := c.ProcessCluster(ctx)
 	switch result {
 	case ResultFailed:
-		logging.FromContext(ctx).Errorf("processing cluster, %w", err)
 		return reconcile.Result{}, fmt.Errorf("processing cluster, %w", err)
 	case ResultRetry:
 		return reconcile.Result{Requeue: true}, nil


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
 - Removes duplicate log in deprovisioning reconciler (also not formatted properly)

```
2022-11-18T08:41:47.704Z 2022-11-18T08:41:47.701145575Z stdout F         2022-11-18T08:41:10.226Z       ERROR   controller.deprovisioning       processing cluster, %!w(*fmt.wrapError=&{determining candidate nodes, listing instance types for browplaid-2-qbupxthidb, getting providerRef, AWSNodeTemplate.karpenter.k8s.aws "stingerwool-1-gxudy64fsb" not found 0xc0010edfc0})     {"commit": "f290d37"}
2022-11-18T08:41:47.704Z 2022-11-18T08:41:47.701147825Z stdout F         2022-11-18T08:41:10.226Z       ERROR   controller.deprovisioning       processing cluster, determining candidate nodes, listing instance types for browplaid-2-qbupxthidb, getting providerRef, AWSNodeTemplate.karpenter.k8s.aws "stingerwool-1-gxudy64fsb" not found {"commit": "f290d37"}
```

**How was this change tested?**


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
