### PR TITLE
fix: track pending pods when consolidating

### DIFF
--- a/pkg/controllers/deprovisioning/controller.go
+++ b/pkg/controllers/deprovisioning/controller.go
@@ -190,7 +190,7 @@ func (c *Controller) executeDeprovisioning(ctx context.Context, d Deprovisioner,
 
 func (c *Controller) executeCommand(ctx context.Context, command Command, d Deprovisioner) (Result, error) {
 	deprovisioningActionsPerformedCounter.With(prometheus.Labels{"action": fmt.Sprintf("%s/%s", d, command.action)}).Add(1)
-	logging.FromContext(ctx).Infof("deprovisioning via %s/%s", d, command.action)
+	logging.FromContext(ctx).Infof("deprovisioning via %s %s", d, command)
 
 	if command.action == actionReplace {
 		if err := c.launchReplacementNodes(ctx, command); err != nil {

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -148,7 +148,7 @@ func (p *Provisioner) Reconcile(ctx context.Context, _ reconcile.Request) (recon
 	})
 
 	// Get pods, exit if nothing to do
-	pendingPods, err := p.getPendingPods(ctx)
+	pendingPods, err := p.GetPendingPods(ctx)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
@@ -212,7 +212,7 @@ func (p *Provisioner) LaunchNodes(ctx context.Context, opts LaunchOptions, nodes
 	return nodeNames, nil
 }
 
-func (p *Provisioner) getPendingPods(ctx context.Context) ([]*v1.Pod, error) {
+func (p *Provisioner) GetPendingPods(ctx context.Context) ([]*v1.Pod, error) {
 	var podList v1.PodList
 	if err := p.kubeClient.List(ctx, &podList, client.MatchingFields{"spec.nodeName": ""}); err != nil {
 		return nil, fmt.Errorf("listing pods, %w", err)


### PR DESCRIPTION

Fixes # <!-- issue number -->

**Description**

Consolidation used to be primarily triggered when there were no pending pods. Since this is no longer the case, we need to treat all pending pods as part of the consolidation solution to avoid prematurely consolidating.

**How was this change tested?**

Unit testing & deployed to EKS.
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
