### PR TITLE
fix: Fix go generate to generate deepcopy

### DIFF
--- a/pkg/apis/apis.go
+++ b/pkg/apis/apis.go
@@ -44,7 +44,7 @@ var (
 	Settings = sets.New(settings.Registration)
 )
 
-//go:generate controller-gen crd paths="./..." output:crd:artifacts:config=crds
+//go:generate controller-gen crd object:headerFile="../../hack/boilerplate.go.txt" paths="./..." output:crd:artifacts:config=crds
 var (
 	//go:embed crds/karpenter.sh_provisioners.yaml
 	ProvisionerCRD []byte


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

- Fixes `go generate` so that it generates the `zz_generated_deepcopy.go` file

**How was this change tested?**

`go generate ./...`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
