### PR TITLE
chore: Convert `InstanceType` interface to struct 

### DIFF
--- a/pkg/cloudprovider/fake/cloudprovider.go
+++ b/pkg/cloudprovider/fake/cloudprovider.go
@@ -36,7 +36,7 @@ import (
 var _ cloudprovider.CloudProvider = (*CloudProvider)(nil)
 
 type CloudProvider struct {
-	InstanceTypes []cloudprovider.InstanceType
+	InstanceTypes []*cloudprovider.InstanceType
 
 	// CreateCalls contains the arguments for every create call that was made since it was cleared
 	mu                 sync.Mutex
@@ -93,11 +93,11 @@ func (c *CloudProvider) Create(ctx context.Context, nodeRequest *cloudprovider.N
 	return n, nil
 }
 
-func (c *CloudProvider) GetInstanceTypes(_ context.Context, provisioner *v1alpha5.Provisioner) ([]cloudprovider.InstanceType, error) {
+func (c *CloudProvider) GetInstanceTypes(_ context.Context, provisioner *v1alpha5.Provisioner) ([]*cloudprovider.InstanceType, error) {
 	if c.InstanceTypes != nil {
 		return c.InstanceTypes, nil
 	}
-	return []cloudprovider.InstanceType{
+	return []*cloudprovider.InstanceType{
 		NewInstanceType(InstanceTypeOptions{
 			Name: "default-instance-type",
 		}),

--- a/pkg/cloudprovider/fake/cloudprovider.go
+++ b/pkg/cloudprovider/fake/cloudprovider.go
@@ -71,7 +71,7 @@ func (c *CloudProvider) Create(ctx context.Context, nodeRequest *cloudprovider.N
 		}
 	}
 	// Find Offering
-	for _, o := range cloudprovider.AvailableOfferings(instanceType) {
+	for _, o := range instanceType.Offerings.Available() {
 		if nodeRequest.Template.Requirements.Compatible(scheduling.NewRequirements(
 			scheduling.NewRequirement(v1.LabelTopologyZone, v1.NodeSelectorOpIn, o.Zone),
 			scheduling.NewRequirement(v1alpha5.LabelCapacityType, v1.NodeSelectorOpIn, o.CapacityType),

--- a/pkg/cloudprovider/fake/cloudprovider.go
+++ b/pkg/cloudprovider/fake/cloudprovider.go
@@ -45,7 +45,6 @@ type CloudProvider struct {
 }
 
 var _ cloudprovider.CloudProvider = (*CloudProvider)(nil)
-var _ cloudprovider.InstanceType = (*InstanceType)(nil)
 
 func NewCloudProvider() *CloudProvider {
 	return &CloudProvider{
@@ -66,7 +65,7 @@ func (c *CloudProvider) Create(ctx context.Context, nodeRequest *cloudprovider.N
 	instanceType := nodeRequest.InstanceTypeOptions[0]
 	// Labels
 	labels := map[string]string{}
-	for key, requirement := range instanceType.Requirements() {
+	for key, requirement := range instanceType.Requirements {
 		if requirement.Len() == 1 {
 			labels[key] = requirement.Values()[0]
 		}

--- a/pkg/cloudprovider/fake/instancetype.go
+++ b/pkg/cloudprovider/fake/instancetype.go
@@ -46,15 +46,9 @@ func init() {
 	)
 }
 
-func NewInstanceType(options InstanceTypeOptions) *InstanceType {
+func NewInstanceType(options InstanceTypeOptions) cloudprovider.InstanceType {
 	if options.Resources == nil {
 		options.Resources = map[v1.ResourceName]resource.Quantity{}
-	}
-	if options.Overhead == nil {
-		options.Overhead = v1.ResourceList{
-			v1.ResourceCPU:    resource.MustParse("100m"),
-			v1.ResourceMemory: resource.MustParse("10Mi"),
-		}
 	}
 	if r := options.Resources[v1.ResourceCPU]; r.IsZero() {
 		options.Resources[v1.ResourceCPU] = resource.MustParse("4")
@@ -80,17 +74,38 @@ func NewInstanceType(options InstanceTypeOptions) *InstanceType {
 	if options.OperatingSystems.Len() == 0 {
 		options.OperatingSystems = utilsets.NewString(string(v1.Linux), string(v1.Windows), "darwin")
 	}
-
-	return &InstanceType{
-		options: InstanceTypeOptions{
-			Name:             options.Name,
-			Offerings:        options.Offerings,
-			Architecture:     options.Architecture,
-			OperatingSystems: options.OperatingSystems,
-			Resources:        options.Resources,
-			Overhead:         options.Overhead,
+	i := cloudprovider.InstanceType{
+		Name:      options.Name,
+		Offerings: options.Offerings,
+		Capacity:  options.Resources,
+		Overhead: cloudprovider.InstanceTypeOverhead{
+			KubeReserved: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("100m"),
+				v1.ResourceMemory: resource.MustParse("10Mi"),
+			},
 		},
 	}
+
+	requirements := scheduling.NewRequirements(
+		scheduling.NewRequirement(v1.LabelInstanceTypeStable, v1.NodeSelectorOpIn, options.Name),
+		scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, options.Architecture),
+		scheduling.NewRequirement(v1.LabelOSStable, v1.NodeSelectorOpIn, options.OperatingSystems.List()...),
+		scheduling.NewRequirement(v1.LabelTopologyZone, v1.NodeSelectorOpIn, lo.Map(cloudprovider.AvailableOfferings(i), func(o cloudprovider.Offering, _ int) string { return o.Zone })...),
+		scheduling.NewRequirement(v1alpha5.LabelCapacityType, v1.NodeSelectorOpIn, lo.Map(cloudprovider.AvailableOfferings(i), func(o cloudprovider.Offering, _ int) string { return o.CapacityType })...),
+		scheduling.NewRequirement(LabelInstanceSize, v1.NodeSelectorOpDoesNotExist),
+		scheduling.NewRequirement(ExoticInstanceLabelKey, v1.NodeSelectorOpDoesNotExist),
+		scheduling.NewRequirement(IntegerInstanceLabelKey, v1.NodeSelectorOpIn, fmt.Sprint(options.Resources.Cpu().Value())),
+	)
+	if options.Resources.Cpu().Cmp(resource.MustParse("4")) > 0 &&
+		options.Resources.Memory().Cmp(resource.MustParse("8Gi")) > 0 {
+		requirements.Get(LabelInstanceSize).Insert("large")
+		requirements.Get(ExoticInstanceLabelKey).Insert("optional")
+	} else {
+		requirements.Get(LabelInstanceSize).Insert("small")
+	}
+	i.Requirements = requirements
+
+	return i
 }
 
 // InstanceTypesAssorted create many unique instance types with varying CPU/memory/architecture/OS/zone/capacity type.
@@ -156,16 +171,7 @@ type InstanceTypeOptions struct {
 	Offerings        []cloudprovider.Offering
 	Architecture     string
 	OperatingSystems utilsets.String
-	Overhead         v1.ResourceList
 	Resources        v1.ResourceList
-}
-
-type InstanceType struct {
-	options InstanceTypeOptions
-}
-
-func (i *InstanceType) Name() string {
-	return i.options.Name
 }
 
 func priceFromResources(resources v1.ResourceList) float64 {
@@ -181,37 +187,4 @@ func priceFromResources(resources v1.ResourceList) float64 {
 		}
 	}
 	return price
-}
-
-func (i *InstanceType) Resources() v1.ResourceList {
-	return i.options.Resources
-}
-
-func (i *InstanceType) Offerings() []cloudprovider.Offering {
-	return i.options.Offerings
-}
-
-func (i *InstanceType) Overhead() v1.ResourceList {
-	return i.options.Overhead
-}
-
-func (i *InstanceType) Requirements() scheduling.Requirements {
-	requirements := scheduling.NewRequirements(
-		scheduling.NewRequirement(v1.LabelInstanceTypeStable, v1.NodeSelectorOpIn, i.options.Name),
-		scheduling.NewRequirement(v1.LabelArchStable, v1.NodeSelectorOpIn, i.options.Architecture),
-		scheduling.NewRequirement(v1.LabelOSStable, v1.NodeSelectorOpIn, i.options.OperatingSystems.List()...),
-		scheduling.NewRequirement(v1.LabelTopologyZone, v1.NodeSelectorOpIn, lo.Map(cloudprovider.AvailableOfferings(i), func(o cloudprovider.Offering, _ int) string { return o.Zone })...),
-		scheduling.NewRequirement(v1alpha5.LabelCapacityType, v1.NodeSelectorOpIn, lo.Map(cloudprovider.AvailableOfferings(i), func(o cloudprovider.Offering, _ int) string { return o.CapacityType })...),
-		scheduling.NewRequirement(LabelInstanceSize, v1.NodeSelectorOpDoesNotExist),
-		scheduling.NewRequirement(ExoticInstanceLabelKey, v1.NodeSelectorOpDoesNotExist),
-		scheduling.NewRequirement(IntegerInstanceLabelKey, v1.NodeSelectorOpIn, fmt.Sprint(i.options.Resources.Cpu().Value())),
-	)
-	if i.options.Resources.Cpu().Cmp(resource.MustParse("4")) > 0 &&
-		i.options.Resources.Memory().Cmp(resource.MustParse("8Gi")) > 0 {
-		requirements.Get(LabelInstanceSize).Insert("large")
-		requirements.Get(ExoticInstanceLabelKey).Insert("optional")
-	} else {
-		requirements.Get(LabelInstanceSize).Insert("small")
-	}
-	return requirements
 }

--- a/pkg/cloudprovider/fake/instancetype.go
+++ b/pkg/cloudprovider/fake/instancetype.go
@@ -46,7 +46,7 @@ func init() {
 	)
 }
 
-func NewInstanceType(options InstanceTypeOptions) cloudprovider.InstanceType {
+func NewInstanceType(options InstanceTypeOptions) *cloudprovider.InstanceType {
 	if options.Resources == nil {
 		options.Resources = map[v1.ResourceName]resource.Quantity{}
 	}
@@ -74,11 +74,11 @@ func NewInstanceType(options InstanceTypeOptions) cloudprovider.InstanceType {
 	if options.OperatingSystems.Len() == 0 {
 		options.OperatingSystems = utilsets.NewString(string(v1.Linux), string(v1.Windows), "darwin")
 	}
-	i := cloudprovider.InstanceType{
+	i := &cloudprovider.InstanceType{
 		Name:      options.Name,
 		Offerings: options.Offerings,
 		Capacity:  options.Resources,
-		Overhead: cloudprovider.InstanceTypeOverhead{
+		Overhead: &cloudprovider.InstanceTypeOverhead{
 			KubeReserved: v1.ResourceList{
 				v1.ResourceCPU:    resource.MustParse("100m"),
 				v1.ResourceMemory: resource.MustParse("10Mi"),
@@ -109,8 +109,8 @@ func NewInstanceType(options InstanceTypeOptions) cloudprovider.InstanceType {
 }
 
 // InstanceTypesAssorted create many unique instance types with varying CPU/memory/architecture/OS/zone/capacity type.
-func InstanceTypesAssorted() []cloudprovider.InstanceType {
-	var instanceTypes []cloudprovider.InstanceType
+func InstanceTypesAssorted() []*cloudprovider.InstanceType {
+	var instanceTypes []*cloudprovider.InstanceType
 	for _, cpu := range []int{1, 2, 4, 8, 16, 32, 64} {
 		for _, mem := range []int{1, 2, 4, 8, 16, 32, 64, 128} {
 			for _, zone := range []string{"test-zone-1", "test-zone-2", "test-zone-3"} {
@@ -151,8 +151,8 @@ func InstanceTypesAssorted() []cloudprovider.InstanceType {
 //
 //	2vcpu, 4Gi mem, 20 pods
 //	3vcpu, 6Gi mem, 30 pods
-func InstanceTypes(total int) []cloudprovider.InstanceType {
-	instanceTypes := []cloudprovider.InstanceType{}
+func InstanceTypes(total int) []*cloudprovider.InstanceType {
+	instanceTypes := []*cloudprovider.InstanceType{}
 	for i := 0; i < total; i++ {
 		instanceTypes = append(instanceTypes, NewInstanceType(InstanceTypeOptions{
 			Name: fmt.Sprintf("fake-it-%d", i),

--- a/pkg/cloudprovider/metrics/cloudprovider.go
+++ b/pkg/cloudprovider/metrics/cloudprovider.go
@@ -77,7 +77,7 @@ func (d *decorator) Delete(ctx context.Context, node *v1.Node) error {
 	return d.CloudProvider.Delete(ctx, node)
 }
 
-func (d *decorator) GetInstanceTypes(ctx context.Context, provisioner *v1alpha5.Provisioner) ([]cloudprovider.InstanceType, error) {
+func (d *decorator) GetInstanceTypes(ctx context.Context, provisioner *v1alpha5.Provisioner) ([]*cloudprovider.InstanceType, error) {
 	defer metrics.Measure(methodDurationHistogramVec.WithLabelValues(injection.GetControllerName(ctx), "GetInstanceTypes", d.Name()))()
 	return d.CloudProvider.GetInstanceTypes(ctx, provisioner)
 }

--- a/pkg/cloudprovider/types.go
+++ b/pkg/cloudprovider/types.go
@@ -56,14 +56,14 @@ type CloudProvider interface {
 	// Availability of types or zone may vary by provisioner or over time.  Regardless of
 	// availability, the GetInstanceTypes method should always return all instance types,
 	// even those with no offerings available.
-	GetInstanceTypes(context.Context, *v1alpha5.Provisioner) ([]InstanceType, error)
+	GetInstanceTypes(context.Context, *v1alpha5.Provisioner) ([]*InstanceType, error)
 	// Name returns the CloudProvider implementation name.
 	Name() string
 }
 
 type NodeRequest struct {
 	Template            *scheduling.NodeTemplate
-	InstanceTypeOptions []InstanceType
+	InstanceTypeOptions []*InstanceType
 }
 
 // InstanceType describes the properties of a potential node (either concrete attributes of an instance of this type
@@ -80,7 +80,7 @@ type InstanceType struct {
 	Capacity v1.ResourceList
 	// Overhead is the amount of resource overhead expected to be used by kubelet and any other system daemons outside
 	// of Kubernetes.
-	Overhead InstanceTypeOverhead
+	Overhead *InstanceTypeOverhead
 }
 
 type InstanceTypeOverhead struct {
@@ -105,7 +105,7 @@ type Offering struct {
 
 // AvailableOfferings filters the offerings on the passed instance type
 // and returns the offerings marked as available
-func AvailableOfferings(it InstanceType) []Offering {
+func AvailableOfferings(it *InstanceType) []Offering {
 	return lo.Filter(it.Offerings, func(o Offering, _ int) bool {
 		return o.Available
 	})
@@ -113,7 +113,7 @@ func AvailableOfferings(it InstanceType) []Offering {
 
 // GetOffering gets the offering from passed instance type that matches the
 // passed zone and capacity type
-func GetOffering(it InstanceType, ct, zone string) (Offering, bool) {
+func GetOffering(it *InstanceType, ct, zone string) (Offering, bool) {
 	return lo.Find(it.Offerings, func(of Offering) bool {
 		return of.CapacityType == ct && of.Zone == zone
 	})

--- a/pkg/controllers/deprovisioning/consolidation.go
+++ b/pkg/controllers/deprovisioning/consolidation.go
@@ -237,7 +237,7 @@ func (c *consolidation) computeConsolidation(ctx context.Context, nodes ...Candi
 func getNodePrices(nodes []CandidateNode) (float64, error) {
 	var price float64
 	for _, n := range nodes {
-		offering, ok := cloudprovider.GetOffering(n.instanceType, n.capacityType, n.zone)
+		offering, ok := n.instanceType.Offerings.Get(n.capacityType, n.zone)
 		if !ok {
 			return 0.0, fmt.Errorf("unable to determine offering for %s/%s/%s", n.instanceType.Name, n.capacityType, n.zone)
 		}

--- a/pkg/controllers/deprovisioning/consolidation.go
+++ b/pkg/controllers/deprovisioning/consolidation.go
@@ -239,7 +239,7 @@ func getNodePrices(nodes []CandidateNode) (float64, error) {
 	for _, n := range nodes {
 		offering, ok := cloudprovider.GetOffering(n.instanceType, n.capacityType, n.zone)
 		if !ok {
-			return 0.0, fmt.Errorf("unable to determine offering for %s/%s/%s", n.instanceType.Name(), n.capacityType, n.zone)
+			return 0.0, fmt.Errorf("unable to determine offering for %s/%s/%s", n.instanceType.Name, n.capacityType, n.zone)
 		}
 		price += offering.Price
 	}

--- a/pkg/controllers/deprovisioning/controller.go
+++ b/pkg/controllers/deprovisioning/controller.go
@@ -126,7 +126,7 @@ func (c *Controller) Reconcile(ctx context.Context, r reconcile.Request) (reconc
 // making that determination
 type CandidateNode struct {
 	*v1.Node
-	instanceType   cloudprovider.InstanceType
+	instanceType   *cloudprovider.InstanceType
 	capacityType   string
 	zone           string
 	provisioner    *v1alpha5.Provisioner

--- a/pkg/controllers/deprovisioning/helpers.go
+++ b/pkg/controllers/deprovisioning/helpers.go
@@ -148,7 +148,7 @@ func GetPodEvictionCost(ctx context.Context, p *v1.Pod) float64 {
 func filterByPrice(options []*cloudprovider.InstanceType, reqs scheduling.Requirements, price float64) []*cloudprovider.InstanceType {
 	var result []*cloudprovider.InstanceType
 	for _, it := range options {
-		launchPrice := worstLaunchPrice(cloudprovider.AvailableOfferings(it), reqs)
+		launchPrice := worstLaunchPrice(it.Offerings.Available(), reqs)
 		if launchPrice < price {
 			result = append(result, it)
 		}

--- a/pkg/controllers/deprovisioning/helpers.go
+++ b/pkg/controllers/deprovisioning/helpers.go
@@ -116,8 +116,8 @@ func simulateScheduling(ctx context.Context, kubeClient client.Client, cluster *
 
 // instanceTypesAreSubset returns true if the lhs slice of instance types are a subset of the rhs.
 func instanceTypesAreSubset(lhs []cloudprovider.InstanceType, rhs []cloudprovider.InstanceType) bool {
-	rhsNames := sets.NewString(lo.Map(rhs, func(t cloudprovider.InstanceType, i int) string { return t.Name() })...)
-	lhsNames := sets.NewString(lo.Map(lhs, func(t cloudprovider.InstanceType, i int) string { return t.Name() })...)
+	rhsNames := sets.NewString(lo.Map(rhs, func(t cloudprovider.InstanceType, i int) string { return t.Name })...)
+	lhsNames := sets.NewString(lo.Map(lhs, func(t cloudprovider.InstanceType, i int) string { return t.Name })...)
 	return len(rhsNames.Intersection(lhsNames)) == len(lhsNames)
 }
 
@@ -191,9 +191,9 @@ func candidateNodes(ctx context.Context, cluster *state.Cluster, kubeClient clie
 			return true
 		}
 
-		instanceType := instanceTypeMap[n.Node.Labels[v1.LabelInstanceTypeStable]]
+		instanceType, ok := instanceTypeMap[n.Node.Labels[v1.LabelInstanceTypeStable]]
 		// skip any nodes that we can't determine the instance of
-		if instanceType == nil {
+		if !ok {
 			return true
 		}
 
@@ -267,7 +267,7 @@ func buildProvisionerMap(ctx context.Context, kubeClient client.Client, cloudPro
 		}
 		instanceTypesByProvisioner[p.Name] = map[string]cloudprovider.InstanceType{}
 		for _, it := range provInstanceTypes {
-			instanceTypesByProvisioner[p.Name][it.Name()] = it
+			instanceTypesByProvisioner[p.Name][it.Name] = it
 		}
 	}
 	return provisioners, instanceTypesByProvisioner, nil

--- a/pkg/controllers/deprovisioning/multinodeconsolidation.go
+++ b/pkg/controllers/deprovisioning/multinodeconsolidation.go
@@ -136,7 +136,7 @@ func (m *MultiNodeConsolidation) firstNNodeConsolidationOption(ctx context.Conte
 // This code sees that t3a.small is the cheapest type in both lists and filters it and anything more expensive out
 // leaving the valid consolidation:
 // nodes=[t3a.2xlarge, t3a.2xlarge, t3a.small] -> 1 of t3a.nano
-func filterOutSameType(newNode *scheduling.Node, consolidate []CandidateNode) []cloudprovider.InstanceType {
+func filterOutSameType(newNode *scheduling.Node, consolidate []CandidateNode) []*cloudprovider.InstanceType {
 	existingInstanceTypes := sets.NewString()
 	nodePricesByInstanceType := map[string]float64{}
 

--- a/pkg/controllers/deprovisioning/multinodeconsolidation.go
+++ b/pkg/controllers/deprovisioning/multinodeconsolidation.go
@@ -142,17 +142,17 @@ func filterOutSameType(newNode *scheduling.Node, consolidate []CandidateNode) []
 
 	// get the price of the cheapest node that we currently are considering deleting indexed by instance type
 	for _, n := range consolidate {
-		existingInstanceTypes.Insert(n.instanceType.Name())
+		existingInstanceTypes.Insert(n.instanceType.Name)
 		of, ok := cloudprovider.GetOffering(n.instanceType, n.capacityType, n.zone)
 		if !ok {
 			continue
 		}
-		existingPrice, ok := nodePricesByInstanceType[n.instanceType.Name()]
+		existingPrice, ok := nodePricesByInstanceType[n.instanceType.Name]
 		if !ok {
 			existingPrice = math.MaxFloat64
 		}
 		if of.Price < existingPrice {
-			nodePricesByInstanceType[n.instanceType.Name()] = of.Price
+			nodePricesByInstanceType[n.instanceType.Name] = of.Price
 		}
 	}
 
@@ -161,9 +161,9 @@ func filterOutSameType(newNode *scheduling.Node, consolidate []CandidateNode) []
 		// we are considering replacing multiple nodes with a single node of one of the same types, so the replacement
 		// node must be cheaper than the price of the existing node, or we should just keep that one and do a
 		// deletion only to reduce cluster disruption (fewer pods will re-schedule).
-		if existingInstanceTypes.Has(it.Name()) {
-			if nodePricesByInstanceType[it.Name()] < maxPrice {
-				maxPrice = nodePricesByInstanceType[it.Name()]
+		if existingInstanceTypes.Has(it.Name) {
+			if nodePricesByInstanceType[it.Name] < maxPrice {
+				maxPrice = nodePricesByInstanceType[it.Name]
 			}
 		}
 	}

--- a/pkg/controllers/deprovisioning/multinodeconsolidation.go
+++ b/pkg/controllers/deprovisioning/multinodeconsolidation.go
@@ -143,7 +143,7 @@ func filterOutSameType(newNode *scheduling.Node, consolidate []CandidateNode) []
 	// get the price of the cheapest node that we currently are considering deleting indexed by instance type
 	for _, n := range consolidate {
 		existingInstanceTypes.Insert(n.instanceType.Name)
-		of, ok := cloudprovider.GetOffering(n.instanceType, n.capacityType, n.zone)
+		of, ok := n.instanceType.Offerings.Get(n.capacityType, n.zone)
 		if !ok {
 			continue
 		}

--- a/pkg/controllers/deprovisioning/singlenodeconsolidation.go
+++ b/pkg/controllers/deprovisioning/singlenodeconsolidation.go
@@ -131,7 +131,7 @@ func (c *SingleNodeConsolidation) computeConsolidation(ctx context.Context, node
 
 	// get the current node price based on the offering
 	// fallback if we can't find the specific zonal pricing data
-	offering, ok := cloudprovider.GetOffering(node.instanceType, node.capacityType, node.zone)
+	offering, ok := node.instanceType.Offerings.Get(node.capacityType, node.zone)
 	if !ok {
 		return Command{}, fmt.Errorf("getting offering price from candidate node, %w", err)
 	}

--- a/pkg/controllers/deprovisioning/suite_test.go
+++ b/pkg/controllers/deprovisioning/suite_test.go
@@ -60,10 +60,10 @@ var cloudProvider *fake.CloudProvider
 var recorder *test.EventRecorder
 var nodeStateController *state.NodeController
 var fakeClock *clock.FakeClock
-var onDemandInstances []cloudprovider.InstanceType
-var mostExpensiveInstance cloudprovider.InstanceType
+var onDemandInstances []*cloudprovider.InstanceType
+var mostExpensiveInstance *cloudprovider.InstanceType
 var mostExpensiveOffering cloudprovider.Offering
-var leastExpensiveInstance cloudprovider.InstanceType
+var leastExpensiveInstance *cloudprovider.InstanceType
 var leastExpensiveOffering cloudprovider.Offering
 
 func TestAPIs(t *testing.T) {
@@ -103,7 +103,7 @@ var _ = BeforeEach(func() {
 	cloudProvider.CreateCalls = nil
 	cloudProvider.InstanceTypes = fake.InstanceTypesAssorted()
 	cloudProvider.AllowedCreateCalls = math.MaxInt
-	onDemandInstances = lo.Filter(cloudProvider.InstanceTypes, func(i cloudprovider.InstanceType, _ int) bool {
+	onDemandInstances = lo.Filter(cloudProvider.InstanceTypes, func(i *cloudprovider.InstanceType, _ int) bool {
 		for _, o := range cloudprovider.AvailableOfferings(i) {
 			if o.CapacityType == v1alpha5.CapacityTypeOnDemand {
 				return true
@@ -323,7 +323,7 @@ var _ = Describe("Expiration", func() {
 			},
 			Resources: map[v1.ResourceName]resource.Quantity{v1.ResourceCPU: resource.MustParse("3")},
 		})
-		cloudProvider.InstanceTypes = []cloudprovider.InstanceType{
+		cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{
 			currentInstance,
 			replacementInstance,
 		}
@@ -414,7 +414,7 @@ var _ = Describe("Expiration", func() {
 			},
 			Resources: map[v1.ResourceName]resource.Quantity{v1.ResourceCPU: resource.MustParse("3")},
 		})
-		cloudProvider.InstanceTypes = []cloudprovider.InstanceType{
+		cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{
 			currentInstance,
 			replacementInstance,
 		}
@@ -784,7 +784,7 @@ var _ = Describe("Replace Nodes", func() {
 				},
 			},
 		})
-		cloudProvider.InstanceTypes = []cloudprovider.InstanceType{
+		cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{
 			currentInstance,
 			replacementInstance,
 		}
@@ -879,7 +879,7 @@ var _ = Describe("Replace Nodes", func() {
 			},
 		})
 
-		cloudProvider.InstanceTypes = []cloudprovider.InstanceType{
+		cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{
 			currentInstance,
 			replacementInstance,
 		}
@@ -2411,7 +2411,7 @@ var _ = Describe("Multi-Node Consolidation", func() {
 	})
 })
 
-func leastExpensiveInstanceWithZone(zone string) cloudprovider.InstanceType {
+func leastExpensiveInstanceWithZone(zone string) *cloudprovider.InstanceType {
 	for _, elem := range onDemandInstances {
 		if hasZone(elem.Offerings, zone) {
 			return elem
@@ -2420,7 +2420,7 @@ func leastExpensiveInstanceWithZone(zone string) cloudprovider.InstanceType {
 	return onDemandInstances[len(onDemandInstances)-1]
 }
 
-func mostExpensiveInstanceWithZone(zone string) cloudprovider.InstanceType {
+func mostExpensiveInstanceWithZone(zone string) *cloudprovider.InstanceType {
 	for i := len(onDemandInstances) - 1; i >= 0; i-- {
 		elem := onDemandInstances[i]
 		if hasZone(elem.Offerings, zone) {

--- a/pkg/controllers/deprovisioning/suite_test.go
+++ b/pkg/controllers/deprovisioning/suite_test.go
@@ -113,12 +113,12 @@ var _ = BeforeEach(func() {
 	})
 	// Sort the instances by pricing from low to high
 	sort.Slice(onDemandInstances, func(i, j int) bool {
-		return cheapestOffering(onDemandInstances[i].Offerings()).Price < cheapestOffering(onDemandInstances[j].Offerings()).Price
+		return cheapestOffering(onDemandInstances[i].Offerings).Price < cheapestOffering(onDemandInstances[j].Offerings).Price
 	})
 	leastExpensiveInstance = onDemandInstances[0]
-	leastExpensiveOffering = leastExpensiveInstance.Offerings()[0]
+	leastExpensiveOffering = leastExpensiveInstance.Offerings[0]
 	mostExpensiveInstance = onDemandInstances[len(onDemandInstances)-1]
-	mostExpensiveOffering = mostExpensiveInstance.Offerings()[0]
+	mostExpensiveOffering = mostExpensiveInstance.Offerings[0]
 
 	recorder.Reset()
 	fakeClock.SetTime(time.Now())
@@ -145,7 +145,7 @@ var _ = Describe("Expiration", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: prov.Name,
-					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name(),
+					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name,
 					v1alpha5.LabelCapacityType:       mostExpensiveOffering.CapacityType,
 					v1.LabelTopologyZone:             mostExpensiveOffering.Zone,
 				}},
@@ -176,7 +176,7 @@ var _ = Describe("Expiration", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: prov.Name,
-					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name(),
+					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name,
 					v1alpha5.LabelCapacityType:       mostExpensiveOffering.CapacityType,
 					v1.LabelTopologyZone:             mostExpensiveOffering.Zone,
 				}},
@@ -209,7 +209,7 @@ var _ = Describe("Expiration", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: expireProv.Name,
-					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name(),
+					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name,
 					v1alpha5.LabelCapacityType:       mostExpensiveOffering.CapacityType,
 					v1.LabelTopologyZone:             mostExpensiveOffering.Zone,
 				}},
@@ -222,7 +222,7 @@ var _ = Describe("Expiration", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: prov.Name,
-					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name(),
+					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name,
 					v1alpha5.LabelCapacityType:       mostExpensiveOffering.CapacityType,
 					v1.LabelTopologyZone:             mostExpensiveOffering.Zone,
 				}},
@@ -274,7 +274,7 @@ var _ = Describe("Expiration", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: prov.Name,
-					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name(),
+					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name,
 					v1alpha5.LabelCapacityType:       mostExpensiveOffering.CapacityType,
 					v1.LabelTopologyZone:             mostExpensiveOffering.Zone,
 				}},
@@ -362,9 +362,9 @@ var _ = Describe("Expiration", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: prov.Name,
-					v1.LabelInstanceTypeStable:       currentInstance.Name(),
-					v1alpha5.LabelCapacityType:       currentInstance.Offerings()[0].CapacityType,
-					v1.LabelTopologyZone:             currentInstance.Offerings()[0].Zone,
+					v1.LabelInstanceTypeStable:       currentInstance.Name,
+					v1alpha5.LabelCapacityType:       currentInstance.Offerings[0].CapacityType,
+					v1.LabelTopologyZone:             currentInstance.Offerings[0].Zone,
 				}},
 			Allocatable: map[v1.ResourceName]resource.Quantity{v1.ResourceCPU: resource.MustParse("7")},
 		})
@@ -452,9 +452,9 @@ var _ = Describe("Expiration", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: prov.Name,
-					v1.LabelInstanceTypeStable:       currentInstance.Name(),
-					v1alpha5.LabelCapacityType:       currentInstance.Offerings()[0].CapacityType,
-					v1.LabelTopologyZone:             currentInstance.Offerings()[0].Zone,
+					v1.LabelInstanceTypeStable:       currentInstance.Name,
+					v1alpha5.LabelCapacityType:       currentInstance.Offerings[0].CapacityType,
+					v1.LabelTopologyZone:             currentInstance.Offerings[0].Zone,
 				}},
 			Allocatable: map[v1.ResourceName]resource.Quantity{v1.ResourceCPU: resource.MustParse("8")},
 		})
@@ -568,7 +568,7 @@ var _ = Describe("Replace Nodes", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: prov.Name,
-					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name(),
+					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name,
 					v1alpha5.LabelCapacityType:       mostExpensiveOffering.CapacityType,
 					v1.LabelTopologyZone:             mostExpensiveOffering.Zone,
 				}},
@@ -637,7 +637,7 @@ var _ = Describe("Replace Nodes", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: prov.Name,
-					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name(),
+					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name,
 					v1alpha5.LabelCapacityType:       mostExpensiveOffering.CapacityType,
 					v1.LabelTopologyZone:             mostExpensiveOffering.Zone,
 				}},
@@ -699,7 +699,7 @@ var _ = Describe("Replace Nodes", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: prov.Name,
-					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name(),
+					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name,
 					v1alpha5.LabelCapacityType:       mostExpensiveOffering.CapacityType,
 					v1.LabelTopologyZone:             mostExpensiveOffering.Zone,
 				}},
@@ -716,7 +716,7 @@ var _ = Describe("Replace Nodes", func() {
 				},
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: prov.Name,
-					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name(),
+					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name,
 					v1alpha5.LabelCapacityType:       mostExpensiveOffering.CapacityType,
 					v1.LabelTopologyZone:             mostExpensiveOffering.Zone,
 				}},
@@ -817,9 +817,9 @@ var _ = Describe("Replace Nodes", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: prov.Name,
-					v1.LabelInstanceTypeStable:       currentInstance.Name(),
-					v1alpha5.LabelCapacityType:       currentInstance.Offerings()[0].CapacityType,
-					v1.LabelTopologyZone:             currentInstance.Offerings()[0].Zone,
+					v1.LabelInstanceTypeStable:       currentInstance.Name,
+					v1alpha5.LabelCapacityType:       currentInstance.Offerings[0].CapacityType,
+					v1.LabelTopologyZone:             currentInstance.Offerings[0].Zone,
 				}},
 			Allocatable: map[v1.ResourceName]resource.Quantity{v1.ResourceCPU: resource.MustParse("32")}})
 
@@ -920,9 +920,9 @@ var _ = Describe("Replace Nodes", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: prov.Name,
-					v1.LabelInstanceTypeStable:       currentInstance.Name(),
-					v1alpha5.LabelCapacityType:       currentInstance.Offerings()[0].CapacityType,
-					v1.LabelTopologyZone:             currentInstance.Offerings()[0].Zone,
+					v1.LabelInstanceTypeStable:       currentInstance.Name,
+					v1alpha5.LabelCapacityType:       currentInstance.Offerings[0].CapacityType,
+					v1.LabelTopologyZone:             currentInstance.Offerings[0].Zone,
 				}},
 			Allocatable: map[v1.ResourceName]resource.Quantity{v1.ResourceCPU: resource.MustParse("32")}})
 
@@ -970,7 +970,7 @@ var _ = Describe("Replace Nodes", func() {
 				Finalizers: []string{"unit-test.com/block-deletion"},
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: prov.Name,
-					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name(),
+					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name,
 					v1alpha5.LabelCapacityType:       mostExpensiveOffering.CapacityType,
 					v1.LabelTopologyZone:             mostExpensiveOffering.Zone,
 				}},
@@ -1046,7 +1046,7 @@ var _ = Describe("Delete Node", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: prov.Name,
-					v1.LabelInstanceTypeStable:       leastExpensiveInstance.Name(),
+					v1.LabelInstanceTypeStable:       leastExpensiveInstance.Name,
 					v1alpha5.LabelCapacityType:       leastExpensiveOffering.CapacityType,
 					v1.LabelTopologyZone:             leastExpensiveOffering.Zone,
 				}},
@@ -1059,7 +1059,7 @@ var _ = Describe("Delete Node", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: prov.Name,
-					v1.LabelInstanceTypeStable:       leastExpensiveInstance.Name(),
+					v1.LabelInstanceTypeStable:       leastExpensiveInstance.Name,
 					v1alpha5.LabelCapacityType:       leastExpensiveOffering.CapacityType,
 					v1.LabelTopologyZone:             leastExpensiveOffering.Zone,
 				}},
@@ -1137,7 +1137,7 @@ var _ = Describe("Delete Node", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: prov.Name,
-					v1.LabelInstanceTypeStable:       leastExpensiveInstance.Name(),
+					v1.LabelInstanceTypeStable:       leastExpensiveInstance.Name,
 					v1alpha5.LabelCapacityType:       leastExpensiveOffering.CapacityType,
 					v1.LabelTopologyZone:             leastExpensiveOffering.Zone,
 				}},
@@ -1150,7 +1150,7 @@ var _ = Describe("Delete Node", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: prov.Name,
-					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name(),
+					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name,
 					v1alpha5.LabelCapacityType:       mostExpensiveOffering.CapacityType,
 					v1.LabelTopologyZone:             mostExpensiveOffering.Zone,
 				}},
@@ -1215,7 +1215,7 @@ var _ = Describe("Delete Node", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: prov.Name,
-					v1.LabelInstanceTypeStable:       leastExpensiveInstance.Name(),
+					v1.LabelInstanceTypeStable:       leastExpensiveInstance.Name,
 					v1alpha5.LabelCapacityType:       leastExpensiveOffering.CapacityType,
 					v1.LabelTopologyZone:             leastExpensiveOffering.Zone,
 				}},
@@ -1228,7 +1228,7 @@ var _ = Describe("Delete Node", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: prov.Name,
-					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name(),
+					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name,
 					v1alpha5.LabelCapacityType:       mostExpensiveOffering.CapacityType,
 					v1.LabelTopologyZone:             mostExpensiveOffering.Zone,
 				}},
@@ -1290,7 +1290,7 @@ var _ = Describe("Delete Node", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: prov.Name,
-					v1.LabelInstanceTypeStable:       leastExpensiveInstance.Name(),
+					v1.LabelInstanceTypeStable:       leastExpensiveInstance.Name,
 					v1alpha5.LabelCapacityType:       leastExpensiveOffering.CapacityType,
 					v1.LabelTopologyZone:             leastExpensiveOffering.Zone,
 				}},
@@ -1303,7 +1303,7 @@ var _ = Describe("Delete Node", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: prov.Name,
-					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name(),
+					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name,
 					v1alpha5.LabelCapacityType:       mostExpensiveOffering.CapacityType,
 					v1.LabelTopologyZone:             mostExpensiveOffering.Zone,
 				}},
@@ -1370,7 +1370,7 @@ var _ = Describe("Node Lifetime Consideration", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: prov.Name,
-					v1.LabelInstanceTypeStable:       leastExpensiveInstance.Name(),
+					v1.LabelInstanceTypeStable:       leastExpensiveInstance.Name,
 					v1alpha5.LabelCapacityType:       leastExpensiveOffering.CapacityType,
 					v1.LabelTopologyZone:             leastExpensiveOffering.Zone,
 				}},
@@ -1383,7 +1383,7 @@ var _ = Describe("Node Lifetime Consideration", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: prov.Name,
-					v1.LabelInstanceTypeStable:       leastExpensiveInstance.Name(),
+					v1.LabelInstanceTypeStable:       leastExpensiveInstance.Name,
 					v1alpha5.LabelCapacityType:       leastExpensiveOffering.CapacityType,
 					v1.LabelTopologyZone:             leastExpensiveOffering.Zone,
 				}},
@@ -1466,8 +1466,8 @@ var _ = Describe("Topology Consideration", func() {
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: prov.Name,
 					v1.LabelTopologyZone:             "test-zone-1",
-					v1.LabelInstanceTypeStable:       testZone1Instance.Name(),
-					v1alpha5.LabelCapacityType:       testZone1Instance.Offerings()[0].CapacityType,
+					v1.LabelInstanceTypeStable:       testZone1Instance.Name,
+					v1alpha5.LabelCapacityType:       testZone1Instance.Offerings[0].CapacityType,
 				}},
 			Allocatable: map[v1.ResourceName]resource.Quantity{v1.ResourceCPU: resource.MustParse("1")}})
 
@@ -1476,8 +1476,8 @@ var _ = Describe("Topology Consideration", func() {
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: prov.Name,
 					v1.LabelTopologyZone:             "test-zone-2",
-					v1.LabelInstanceTypeStable:       testZone2Instance.Name(),
-					v1alpha5.LabelCapacityType:       testZone2Instance.Offerings()[0].CapacityType,
+					v1.LabelInstanceTypeStable:       testZone2Instance.Name,
+					v1alpha5.LabelCapacityType:       testZone2Instance.Offerings[0].CapacityType,
 				}},
 			Allocatable: map[v1.ResourceName]resource.Quantity{v1.ResourceCPU: resource.MustParse("1")}})
 
@@ -1486,8 +1486,8 @@ var _ = Describe("Topology Consideration", func() {
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: prov.Name,
 					v1.LabelTopologyZone:             "test-zone-3",
-					v1.LabelInstanceTypeStable:       testZone3Instance.Name(),
-					v1alpha5.LabelCapacityType:       testZone1Instance.Offerings()[0].CapacityType,
+					v1.LabelInstanceTypeStable:       testZone3Instance.Name,
+					v1alpha5.LabelCapacityType:       testZone1Instance.Offerings[0].CapacityType,
 				}},
 			Allocatable: map[v1.ResourceName]resource.Quantity{v1.ResourceCPU: resource.MustParse("1")}})
 
@@ -1571,8 +1571,8 @@ var _ = Describe("Topology Consideration", func() {
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: prov.Name,
 					v1.LabelTopologyZone:             "test-zone-1",
-					v1.LabelInstanceTypeStable:       testZone1Instance.Name(),
-					v1alpha5.LabelCapacityType:       testZone1Instance.Offerings()[0].CapacityType,
+					v1.LabelInstanceTypeStable:       testZone1Instance.Name,
+					v1alpha5.LabelCapacityType:       testZone1Instance.Offerings[0].CapacityType,
 				}},
 			Allocatable: map[v1.ResourceName]resource.Quantity{v1.ResourceCPU: resource.MustParse("1")}})
 
@@ -1581,8 +1581,8 @@ var _ = Describe("Topology Consideration", func() {
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: prov.Name,
 					v1.LabelTopologyZone:             "test-zone-2",
-					v1.LabelInstanceTypeStable:       testZone2Instance.Name(),
-					v1alpha5.LabelCapacityType:       testZone2Instance.Offerings()[0].CapacityType,
+					v1.LabelInstanceTypeStable:       testZone2Instance.Name,
+					v1alpha5.LabelCapacityType:       testZone2Instance.Offerings[0].CapacityType,
 				}},
 			Allocatable: map[v1.ResourceName]resource.Quantity{v1.ResourceCPU: resource.MustParse("1")}})
 
@@ -1591,8 +1591,8 @@ var _ = Describe("Topology Consideration", func() {
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: prov.Name,
 					v1.LabelTopologyZone:             "test-zone-3",
-					v1.LabelInstanceTypeStable:       testZone3Instance.Name(),
-					v1alpha5.LabelCapacityType:       testZone3Instance.Offerings()[0].CapacityType,
+					v1.LabelInstanceTypeStable:       testZone3Instance.Name,
+					v1alpha5.LabelCapacityType:       testZone3Instance.Offerings[0].CapacityType,
 				}},
 			Allocatable: map[v1.ResourceName]resource.Quantity{v1.ResourceCPU: resource.MustParse("1")}})
 
@@ -1635,7 +1635,7 @@ var _ = Describe("Empty Nodes", func() {
 					v1alpha5.ProvisionerNameLabelKey: prov.Name,
 					v1alpha5.LabelCapacityType:       mostExpensiveOffering.CapacityType,
 					v1.LabelTopologyZone:             mostExpensiveOffering.Zone,
-					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name(),
+					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name,
 					v1alpha5.LabelNodeInitialized:    "true",
 				},
 			},
@@ -1665,7 +1665,7 @@ var _ = Describe("Empty Nodes", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: prov.Name,
-					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name(),
+					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name,
 					v1alpha5.LabelCapacityType:       mostExpensiveOffering.CapacityType,
 					v1.LabelTopologyZone:             mostExpensiveOffering.Zone,
 				}},
@@ -1677,7 +1677,7 @@ var _ = Describe("Empty Nodes", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: prov.Name,
-					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name(),
+					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name,
 					v1alpha5.LabelCapacityType:       mostExpensiveOffering.CapacityType,
 					v1.LabelTopologyZone:             mostExpensiveOffering.Zone,
 				}},
@@ -1710,7 +1710,7 @@ var _ = Describe("Empty Nodes", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: prov.Name,
-					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name(),
+					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name,
 					v1alpha5.LabelCapacityType:       mostExpensiveOffering.CapacityType,
 					v1.LabelTopologyZone:             mostExpensiveOffering.Zone,
 				},
@@ -1743,7 +1743,7 @@ var _ = Describe("Empty Nodes", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: prov.Name,
-					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name(),
+					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name,
 					v1alpha5.LabelCapacityType:       mostExpensiveOffering.CapacityType,
 					v1.LabelTopologyZone:             mostExpensiveOffering.Zone,
 				}},
@@ -1799,7 +1799,7 @@ var _ = Describe("consolidation TTL", func() {
 					v1alpha5.ProvisionerNameLabelKey: prov.Name,
 					v1alpha5.LabelCapacityType:       mostExpensiveOffering.CapacityType,
 					v1.LabelTopologyZone:             mostExpensiveOffering.Zone,
-					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name(),
+					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name,
 					v1alpha5.LabelNodeInitialized:    "true",
 				},
 			},
@@ -1869,7 +1869,7 @@ var _ = Describe("consolidation TTL", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: prov.Name,
-					v1.LabelInstanceTypeStable:       leastExpensiveInstance.Name(),
+					v1.LabelInstanceTypeStable:       leastExpensiveInstance.Name,
 					v1alpha5.LabelCapacityType:       leastExpensiveOffering.CapacityType,
 					v1.LabelTopologyZone:             leastExpensiveOffering.Zone,
 				}},
@@ -1882,7 +1882,7 @@ var _ = Describe("consolidation TTL", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: prov.Name,
-					v1.LabelInstanceTypeStable:       leastExpensiveInstance.Name(),
+					v1.LabelInstanceTypeStable:       leastExpensiveInstance.Name,
 					v1alpha5.LabelCapacityType:       leastExpensiveOffering.CapacityType,
 					v1.LabelTopologyZone:             leastExpensiveOffering.Zone,
 				}},
@@ -1943,7 +1943,7 @@ var _ = Describe("consolidation TTL", func() {
 					v1alpha5.ProvisionerNameLabelKey: prov.Name,
 					v1alpha5.LabelCapacityType:       mostExpensiveOffering.CapacityType,
 					v1.LabelTopologyZone:             mostExpensiveOffering.Zone,
-					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name(),
+					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name,
 					v1alpha5.LabelNodeInitialized:    "true",
 				},
 			},
@@ -2022,7 +2022,7 @@ var _ = Describe("Parallelization", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: prov.Name,
-					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name(),
+					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name,
 					v1alpha5.LabelCapacityType:       mostExpensiveOffering.CapacityType,
 					v1.LabelTopologyZone:             mostExpensiveOffering.Zone,
 				},
@@ -2177,7 +2177,7 @@ var _ = Describe("Multi-Node Consolidation", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: prov.Name,
-					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name(),
+					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name,
 					v1alpha5.LabelCapacityType:       mostExpensiveOffering.CapacityType,
 					v1.LabelTopologyZone:             mostExpensiveOffering.Zone,
 				}},
@@ -2190,7 +2190,7 @@ var _ = Describe("Multi-Node Consolidation", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: prov.Name,
-					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name(),
+					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name,
 					v1alpha5.LabelCapacityType:       mostExpensiveOffering.CapacityType,
 					v1.LabelTopologyZone:             mostExpensiveOffering.Zone,
 				}},
@@ -2203,7 +2203,7 @@ var _ = Describe("Multi-Node Consolidation", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: prov.Name,
-					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name(),
+					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name,
 					v1alpha5.LabelCapacityType:       mostExpensiveOffering.CapacityType,
 					v1.LabelTopologyZone:             mostExpensiveOffering.Zone,
 				}},
@@ -2266,7 +2266,7 @@ var _ = Describe("Multi-Node Consolidation", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: prov.Name,
-					v1.LabelInstanceTypeStable:       leastExpensiveInstance.Name(),
+					v1.LabelInstanceTypeStable:       leastExpensiveInstance.Name,
 					v1alpha5.LabelCapacityType:       leastExpensiveOffering.CapacityType,
 					v1.LabelTopologyZone:             leastExpensiveOffering.Zone,
 				}},
@@ -2279,7 +2279,7 @@ var _ = Describe("Multi-Node Consolidation", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: prov.Name,
-					v1.LabelInstanceTypeStable:       leastExpensiveInstance.Name(),
+					v1.LabelInstanceTypeStable:       leastExpensiveInstance.Name,
 					v1alpha5.LabelCapacityType:       leastExpensiveOffering.CapacityType,
 					v1.LabelTopologyZone:             leastExpensiveOffering.Zone,
 				}},
@@ -2345,7 +2345,7 @@ var _ = Describe("Multi-Node Consolidation", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: prov.Name,
-					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name(),
+					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name,
 					v1alpha5.LabelCapacityType:       mostExpensiveOffering.CapacityType,
 					v1.LabelTopologyZone:             mostExpensiveOffering.Zone,
 				}},
@@ -2358,7 +2358,7 @@ var _ = Describe("Multi-Node Consolidation", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: prov.Name,
-					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name(),
+					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name,
 					v1alpha5.LabelCapacityType:       mostExpensiveOffering.CapacityType,
 					v1.LabelTopologyZone:             mostExpensiveOffering.Zone,
 				}},
@@ -2413,7 +2413,7 @@ var _ = Describe("Multi-Node Consolidation", func() {
 
 func leastExpensiveInstanceWithZone(zone string) cloudprovider.InstanceType {
 	for _, elem := range onDemandInstances {
-		if hasZone(elem.Offerings(), zone) {
+		if hasZone(elem.Offerings, zone) {
 			return elem
 		}
 	}
@@ -2423,7 +2423,7 @@ func leastExpensiveInstanceWithZone(zone string) cloudprovider.InstanceType {
 func mostExpensiveInstanceWithZone(zone string) cloudprovider.InstanceType {
 	for i := len(onDemandInstances) - 1; i >= 0; i-- {
 		elem := onDemandInstances[i]
-		if hasZone(elem.Offerings(), zone) {
+		if hasZone(elem.Offerings, zone) {
 			return elem
 		}
 	}

--- a/pkg/controllers/deprovisioning/suite_test.go
+++ b/pkg/controllers/deprovisioning/suite_test.go
@@ -104,7 +104,7 @@ var _ = BeforeEach(func() {
 	cloudProvider.InstanceTypes = fake.InstanceTypesAssorted()
 	cloudProvider.AllowedCreateCalls = math.MaxInt
 	onDemandInstances = lo.Filter(cloudProvider.InstanceTypes, func(i *cloudprovider.InstanceType, _ int) bool {
-		for _, o := range cloudprovider.AvailableOfferings(i) {
+		for _, o := range i.Offerings.Available() {
 			if o.CapacityType == v1alpha5.CapacityTypeOnDemand {
 				return true
 			}

--- a/pkg/controllers/inflightchecks/failedinit.go
+++ b/pkg/controllers/inflightchecks/failedinit.go
@@ -61,7 +61,7 @@ func (f FailedInit) Check(ctx context.Context, n *v1.Node, provisioner *v1alpha5
 		return nil, err
 	}
 
-	instanceType, ok := lo.Find(instanceTypes, func(it cloudprovider.InstanceType) bool { return it.Name() == n.Labels[v1.LabelInstanceType] })
+	instanceType, ok := lo.Find(instanceTypes, func(it cloudprovider.InstanceType) bool { return it.Name == n.Labels[v1.LabelInstanceType] })
 	if !ok {
 		return []Issue{{
 			node:    n,

--- a/pkg/controllers/inflightchecks/failedinit.go
+++ b/pkg/controllers/inflightchecks/failedinit.go
@@ -61,7 +61,7 @@ func (f FailedInit) Check(ctx context.Context, n *v1.Node, provisioner *v1alpha5
 		return nil, err
 	}
 
-	instanceType, ok := lo.Find(instanceTypes, func(it cloudprovider.InstanceType) bool { return it.Name == n.Labels[v1.LabelInstanceType] })
+	instanceType, ok := lo.Find(instanceTypes, func(it *cloudprovider.InstanceType) bool { return it.Name == n.Labels[v1.LabelInstanceType] })
 	if !ok {
 		return []Issue{{
 			node:    n,

--- a/pkg/controllers/inflightchecks/nodeshape.go
+++ b/pkg/controllers/inflightchecks/nodeshape.go
@@ -52,7 +52,7 @@ func (n *NodeShape) Check(ctx context.Context, node *v1.Node, provisioner *v1alp
 		return nil, err
 	}
 
-	instanceType, ok := lo.Find(instanceTypes, func(it cloudprovider.InstanceType) bool { return it.Name == node.Labels[v1.LabelInstanceType] })
+	instanceType, ok := lo.Find(instanceTypes, func(it *cloudprovider.InstanceType) bool { return it.Name == node.Labels[v1.LabelInstanceType] })
 	if !ok {
 		return []Issue{{
 			node:    node,

--- a/pkg/controllers/inflightchecks/nodeshape.go
+++ b/pkg/controllers/inflightchecks/nodeshape.go
@@ -52,7 +52,7 @@ func (n *NodeShape) Check(ctx context.Context, node *v1.Node, provisioner *v1alp
 		return nil, err
 	}
 
-	instanceType, ok := lo.Find(instanceTypes, func(it cloudprovider.InstanceType) bool { return it.Name() == node.Labels[v1.LabelInstanceType] })
+	instanceType, ok := lo.Find(instanceTypes, func(it cloudprovider.InstanceType) bool { return it.Name == node.Labels[v1.LabelInstanceType] })
 	if !ok {
 		return []Issue{{
 			node:    node,
@@ -60,7 +60,7 @@ func (n *NodeShape) Check(ctx context.Context, node *v1.Node, provisioner *v1alp
 		}}, nil
 	}
 	var issues []Issue
-	for resourceName, expectedQuantity := range instanceType.Resources() {
+	for resourceName, expectedQuantity := range instanceType.Capacity {
 		nodeQuantity, ok := node.Status.Capacity[resourceName]
 		if !ok && !expectedQuantity.IsZero() {
 			issues = append(issues, Issue{

--- a/pkg/controllers/node/initialization.go
+++ b/pkg/controllers/node/initialization.go
@@ -56,14 +56,14 @@ func (r *Initialization) Reconcile(ctx context.Context, provisioner *v1alpha5.Pr
 	return reconcile.Result{}, nil
 }
 
-func (r *Initialization) getInstanceType(ctx context.Context, provisioner *v1alpha5.Provisioner, instanceTypeName string) (cloudprovider.InstanceType, error) {
+func (r *Initialization) getInstanceType(ctx context.Context, provisioner *v1alpha5.Provisioner, instanceTypeName string) (*cloudprovider.InstanceType, error) {
 	instanceTypes, err := r.cloudProvider.GetInstanceTypes(ctx, provisioner)
 	if err != nil {
-		return cloudprovider.InstanceType{}, err
+		return nil, err
 	}
 	// The instance type may not be found which can occur if the instance type label was removed/edited.  This shouldn't occur,
 	// but if it does we only lose the ability to check for extended resources.
-	return lo.FindOrElse(instanceTypes, cloudprovider.InstanceType{}, func(it cloudprovider.InstanceType) bool { return it.Name == instanceTypeName }), nil
+	return lo.FindOrElse(instanceTypes, nil, func(it *cloudprovider.InstanceType) bool { return it.Name == instanceTypeName }), nil
 }
 
 // isInitialized returns true if the node has:
@@ -71,7 +71,7 @@ func (r *Initialization) getInstanceType(ctx context.Context, provisioner *v1alp
 // b) all the startup taints have been removed from the node
 // c) all extended resources have been registered
 // This method handles both nil provisioners and nodes without extended resources gracefully.
-func (r *Initialization) isInitialized(n *v1.Node, provisioner *v1alpha5.Provisioner, instanceType cloudprovider.InstanceType) bool {
+func (r *Initialization) isInitialized(n *v1.Node, provisioner *v1alpha5.Provisioner, instanceType *cloudprovider.InstanceType) bool {
 	// fast checks first
 	if node.GetCondition(n, v1.NodeReady).Status != v1.ConditionTrue {
 		return false
@@ -104,7 +104,11 @@ func IsStartupTaintRemoved(node *v1.Node, provisioner *v1alpha5.Provisioner) (*v
 
 // IsExtendedResourceRegistered returns true if there are no extended resources on the node, or they have all been
 // registered by device plugins
-func IsExtendedResourceRegistered(node *v1.Node, instanceType cloudprovider.InstanceType) (v1.ResourceName, bool) {
+func IsExtendedResourceRegistered(node *v1.Node, instanceType *cloudprovider.InstanceType) (v1.ResourceName, bool) {
+	if instanceType == nil {
+		// no way to know, so assume they're registered
+		return "", true
+	}
 	for resourceName, quantity := range instanceType.Capacity {
 		if quantity.IsZero() {
 			continue

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -266,7 +266,7 @@ func (p *Provisioner) NewScheduler(ctx context.Context, pods []*v1.Pod, stateNod
 
 		// Construct Topology Domains
 		for _, instanceType := range instanceTypeOptions {
-			for key, requirement := range instanceType.Requirements() {
+			for key, requirement := range instanceType.Requirements {
 				domains[key] = domains[key].Union(sets.NewString(requirement.Values()...))
 			}
 		}

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -323,8 +323,8 @@ func (p *Provisioner) launch(ctx context.Context, opts LaunchOptions, node *sche
 
 	// Order instance types so that we get the cheapest instance types of the available offerings
 	sort.Slice(node.InstanceTypeOptions, func(i, j int) bool {
-		iOfferings := cloudprovider.AvailableOfferings(node.InstanceTypeOptions[i])
-		jOfferings := cloudprovider.AvailableOfferings(node.InstanceTypeOptions[j])
+		iOfferings := node.InstanceTypeOptions[i].Offerings.Available()
+		jOfferings := node.InstanceTypeOptions[j].Offerings.Available()
 		return cheapestOfferingPrice(iOfferings, node.Requirements) < cheapestOfferingPrice(jOfferings, node.Requirements)
 	})
 

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -239,7 +239,7 @@ func (p *Provisioner) NewScheduler(ctx context.Context, pods []*v1.Pod, stateNod
 	// Build node templates
 	var nodeTemplates []*scheduling.NodeTemplate
 	var provisionerList v1alpha5.ProvisionerList
-	instanceTypes := map[string][]cloudprovider.InstanceType{}
+	instanceTypes := map[string][]*cloudprovider.InstanceType{}
 	domains := map[string]sets.String{}
 	if err := p.kubeClient.List(ctx, &provisionerList); err != nil {
 		return nil, fmt.Errorf("listing provisioners, %w", err)

--- a/pkg/controllers/provisioning/scheduling/node.go
+++ b/pkg/controllers/provisioning/scheduling/node.go
@@ -131,7 +131,7 @@ func InstanceTypeList(instanceTypeOptions []cloudprovider.InstanceType) string {
 		} else if i > 0 {
 			fmt.Fprint(&itSb, ", ")
 		}
-		fmt.Fprint(&itSb, it.Name())
+		fmt.Fprint(&itSb, it.Name)
 	}
 	return itSb.String()
 }
@@ -143,11 +143,11 @@ func filterInstanceTypesByRequirements(instanceTypes []cloudprovider.InstanceTyp
 }
 
 func compatible(instanceType cloudprovider.InstanceType, requirements scheduling.Requirements) bool {
-	return instanceType.Requirements().Intersects(requirements) == nil
+	return instanceType.Requirements.Intersects(requirements) == nil
 }
 
 func fits(instanceType cloudprovider.InstanceType, requests v1.ResourceList) bool {
-	return resources.Fits(resources.Merge(requests, instanceType.Overhead()), instanceType.Resources())
+	return resources.Fits(resources.Merge(requests, instanceType.Overhead.SystemReserved, instanceType.Overhead.KubeReserved), instanceType.Capacity)
 }
 
 func hasOffering(instanceType cloudprovider.InstanceType, requirements scheduling.Requirements) bool {

--- a/pkg/controllers/provisioning/scheduling/node.go
+++ b/pkg/controllers/provisioning/scheduling/node.go
@@ -148,11 +148,11 @@ func compatible(instanceType *cloudprovider.InstanceType, requirements schedulin
 }
 
 func fits(instanceType *cloudprovider.InstanceType, requests v1.ResourceList) bool {
-	return resources.Fits(resources.Merge(requests, instanceType.Overhead.SystemReserved, instanceType.Overhead.KubeReserved), instanceType.Capacity)
+	return resources.Fits(resources.Merge(requests, instanceType.Overhead.Total()), instanceType.Capacity)
 }
 
 func hasOffering(instanceType *cloudprovider.InstanceType, requirements scheduling.Requirements) bool {
-	for _, offering := range cloudprovider.AvailableOfferings(instanceType) {
+	for _, offering := range instanceType.Offerings.Available() {
 		if (!requirements.Has(v1.LabelTopologyZone) || requirements.Get(v1.LabelTopologyZone).Has(offering.Zone)) &&
 			(!requirements.Has(v1alpha5.LabelCapacityType) || requirements.Get(v1alpha5.LabelCapacityType).Has(offering.CapacityType)) {
 			return true

--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -258,7 +258,7 @@ func subtractMax(remaining v1.ResourceList, instanceTypes []cloudprovider.Instan
 	}
 	var allInstanceResources []v1.ResourceList
 	for _, it := range instanceTypes {
-		allInstanceResources = append(allInstanceResources, it.Resources())
+		allInstanceResources = append(allInstanceResources, it.Capacity)
 	}
 	result := v1.ResourceList{}
 	itResources := resources.MaxResources(allInstanceResources...)
@@ -274,7 +274,7 @@ func subtractMax(remaining v1.ResourceList, instanceTypes []cloudprovider.Instan
 func filterByRemainingResources(instanceTypes []cloudprovider.InstanceType, remaining v1.ResourceList) []cloudprovider.InstanceType {
 	var filtered []cloudprovider.InstanceType
 	for _, it := range instanceTypes {
-		itResources := it.Resources()
+		itResources := it.Capacity
 		viableInstance := true
 		for resourceName, remainingQuantity := range remaining {
 			// if the instance capacity is greater than the remaining quantity for this resource

--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -3044,8 +3044,8 @@ var _ = Describe("Instance Type Compatibility", func() {
 		cloudProv.InstanceTypes = fake.InstanceTypes(5)
 		const fakeGPU1 = "karpenter.sh/super-great-gpu"
 		const fakeGPU2 = "karpenter.sh/even-better-gpu"
-		cloudProv.InstanceTypes[0].Resources()[fakeGPU1] = resource.MustParse("25")
-		cloudProv.InstanceTypes[1].Resources()[fakeGPU2] = resource.MustParse("25")
+		cloudProv.InstanceTypes[0].Capacity[fakeGPU1] = resource.MustParse("25")
+		cloudProv.InstanceTypes[1].Capacity[fakeGPU2] = resource.MustParse("25")
 
 		nodeNames := sets.NewString()
 		ExpectApplied(ctx, env.Client, provisioner)
@@ -3070,8 +3070,8 @@ var _ = Describe("Instance Type Compatibility", func() {
 		cloudProv.InstanceTypes = fake.InstanceTypes(5)
 		const fakeGPU1 = "karpenter.sh/super-great-gpu"
 		const fakeGPU2 = "karpenter.sh/even-better-gpu"
-		cloudProv.InstanceTypes[0].Resources()[fakeGPU1] = resource.MustParse("25")
-		cloudProv.InstanceTypes[1].Resources()[fakeGPU2] = resource.MustParse("25")
+		cloudProv.InstanceTypes[0].Capacity[fakeGPU1] = resource.MustParse("25")
+		cloudProv.InstanceTypes[1].Capacity[fakeGPU2] = resource.MustParse("25")
 
 		ExpectApplied(ctx, env.Client, provisioner)
 		pods := ExpectProvisioned(ctx, env.Client, recorder, controller, prov,
@@ -3103,11 +3103,11 @@ var _ = Describe("Instance Type Compatibility", func() {
 			pods := ExpectProvisioned(ctx, env.Client, recorder, controller, prov,
 				test.UnschedulablePod(test.PodOptions{NodeSelector: map[string]string{
 					fake.LabelInstanceSize:     "large",
-					v1.LabelInstanceTypeStable: cloudProv.InstanceTypes[0].Name(),
+					v1.LabelInstanceTypeStable: cloudProv.InstanceTypes[0].Name,
 				}}),
 				test.UnschedulablePod(test.PodOptions{NodeSelector: map[string]string{
 					fake.LabelInstanceSize:     "small",
-					v1.LabelInstanceTypeStable: cloudProv.InstanceTypes[4].Name(),
+					v1.LabelInstanceTypeStable: cloudProv.InstanceTypes[4].Name,
 				}}),
 			)
 			ExpectNotScheduled(ctx, env.Client, pods[0])
@@ -3124,7 +3124,7 @@ var _ = Describe("Instance Type Compatibility", func() {
 			)
 			node := ExpectScheduled(ctx, env.Client, pods[0])
 			Expect(node.Labels).To(HaveKey(fake.ExoticInstanceLabelKey))
-			Expect(node.Labels).To(HaveKeyWithValue(v1.LabelInstanceTypeStable, cloudProv.InstanceTypes[4].Name()))
+			Expect(node.Labels).To(HaveKeyWithValue(v1.LabelInstanceTypeStable, cloudProv.InstanceTypes[4].Name))
 		})
 		It("should schedule without optional labels if disallowed", func() {
 			cloudProv.InstanceTypes = fake.InstanceTypes(5)
@@ -3560,7 +3560,7 @@ var _ = Describe("Binpacking", func() {
 		// all three options should be passed to the cloud provider
 		possibleInstanceType := sets.NewString()
 		for _, it := range cloudProv.CreateCalls[0].InstanceTypeOptions {
-			possibleInstanceType.Insert(it.Name())
+			possibleInstanceType.Insert(it.Name)
 		}
 		Expect(possibleInstanceType).To(Equal(sets.NewString("small", "medium", "large")))
 	})

--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -3498,7 +3498,7 @@ var _ = Describe("Binpacking", func() {
 	It("should select for valid instance types, regardless of price", func() {
 		// capacity sizes and prices don't correlate here, regardless we should filter and see that all three instance types
 		// are valid before preferring the cheapest one 'large'
-		cloudProv.InstanceTypes = []cloudprovider.InstanceType{
+		cloudProv.InstanceTypes = []*cloudprovider.InstanceType{
 			fake.NewInstanceType(fake.InstanceTypeOptions{
 				Name: "medium",
 				Resources: v1.ResourceList{
@@ -4040,7 +4040,7 @@ var _ = Describe("In-Flight Nodes", func() {
 	})
 	// nolint:gosec
 	It("should pack in-flight nodes before launching new nodes", func() {
-		cloudProv.InstanceTypes = []cloudprovider.InstanceType{
+		cloudProv.InstanceTypes = []*cloudprovider.InstanceType{
 			fake.NewInstanceType(fake.InstanceTypeOptions{
 				Name: "medium",
 				Resources: v1.ResourceList{
@@ -4211,7 +4211,7 @@ var _ = Describe("No Pre-Binding", func() {
 var _ = Describe("Volume Limits", func() {
 	It("should launch multiple nodes if required due to volume limits", func() {
 		const csiProvider = "fake.csi.provider"
-		cloudProv.InstanceTypes = []cloudprovider.InstanceType{
+		cloudProv.InstanceTypes = []*cloudprovider.InstanceType{
 			fake.NewInstanceType(
 				fake.InstanceTypeOptions{
 					Name: "instance-type",
@@ -4274,7 +4274,7 @@ var _ = Describe("Volume Limits", func() {
 	})
 	It("should launch a single node if all pods use the same PVC", func() {
 		const csiProvider = "fake.csi.provider"
-		cloudProv.InstanceTypes = []cloudprovider.InstanceType{
+		cloudProv.InstanceTypes = []*cloudprovider.InstanceType{
 			fake.NewInstanceType(
 				fake.InstanceTypeOptions{
 					Name: "instance-type",
@@ -4340,7 +4340,7 @@ var _ = Describe("Volume Limits", func() {
 	})
 	It("should not fail for non-dynamic PVCs", func() {
 		const csiProvider = "fake.csi.provider"
-		cloudProv.InstanceTypes = []cloudprovider.InstanceType{
+		cloudProv.InstanceTypes = []*cloudprovider.InstanceType{
 			fake.NewInstanceType(
 				fake.InstanceTypeOptions{
 					Name: "instance-type",
@@ -4407,7 +4407,7 @@ var _ = Describe("Volume Limits", func() {
 		Expect(nodeList.Items).To(HaveLen(1))
 	})
 	It("should not fail for NFS volumes", func() {
-		cloudProv.InstanceTypes = []cloudprovider.InstanceType{
+		cloudProv.InstanceTypes = []*cloudprovider.InstanceType{
 			fake.NewInstanceType(
 				fake.InstanceTypeOptions{
 					Name: "instance-type",

--- a/pkg/controllers/provisioning/suite_test.go
+++ b/pkg/controllers/provisioning/suite_test.go
@@ -55,7 +55,7 @@ var prov *provisioning.Provisioner
 var controller *provisioning.Controller
 var env *test.Environment
 var recorder *test.EventRecorder
-var instanceTypeMap map[string]cloudprovider.InstanceType
+var instanceTypeMap map[string]*cloudprovider.InstanceType
 
 func TestAPIs(t *testing.T) {
 	ctx = TestContextWithLogger(t)
@@ -74,7 +74,7 @@ var _ = BeforeSuite(func() {
 	prov = provisioning.NewProvisioner(ctx, env.Client, corev1.NewForConfigOrDie(env.Config), recorder, cloudProvider, cluster, test.SettingsStore{})
 	controller = provisioning.NewController(env.Client, prov, recorder)
 	instanceTypes, _ := cloudProvider.GetInstanceTypes(context.Background(), nil)
-	instanceTypeMap = map[string]cloudprovider.InstanceType{}
+	instanceTypeMap = map[string]*cloudprovider.InstanceType{}
 	for _, it := range instanceTypes {
 		instanceTypeMap[it.Name] = it
 	}

--- a/pkg/controllers/provisioning/suite_test.go
+++ b/pkg/controllers/provisioning/suite_test.go
@@ -76,7 +76,7 @@ var _ = BeforeSuite(func() {
 	instanceTypes, _ := cloudProvider.GetInstanceTypes(context.Background(), nil)
 	instanceTypeMap = map[string]cloudprovider.InstanceType{}
 	for _, it := range instanceTypes {
-		instanceTypeMap[it.Name()] = it
+		instanceTypeMap[it.Name] = it
 	}
 	provisioning.WaitForClusterSync = false
 })
@@ -196,7 +196,7 @@ var _ = Describe("Provisioning", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
-					v1.LabelInstanceTypeStable:       its[0].Name(),
+					v1.LabelInstanceTypeStable:       its[0].Name,
 				},
 				Finalizers: []string{v1alpha5.TerminationFinalizer},
 			}},
@@ -339,7 +339,7 @@ var _ = Describe("Provisioning", func() {
 			))[0]
 			node := ExpectScheduled(ctx, env.Client, pod)
 
-			allocatable := instanceTypeMap[node.Labels[v1.LabelInstanceTypeStable]].Resources()
+			allocatable := instanceTypeMap[node.Labels[v1.LabelInstanceTypeStable]].Capacity
 			Expect(*allocatable.Cpu()).To(Equal(resource.MustParse("4")))
 			Expect(*allocatable.Memory()).To(Equal(resource.MustParse("4Gi")))
 		})
@@ -360,7 +360,7 @@ var _ = Describe("Provisioning", func() {
 			))[0]
 			node := ExpectScheduled(ctx, env.Client, pod)
 
-			allocatable := instanceTypeMap[node.Labels[v1.LabelInstanceTypeStable]].Resources()
+			allocatable := instanceTypeMap[node.Labels[v1.LabelInstanceTypeStable]].Capacity
 			Expect(*allocatable.Cpu()).To(Equal(resource.MustParse("4")))
 			Expect(*allocatable.Memory()).To(Equal(resource.MustParse("4Gi")))
 		})
@@ -401,7 +401,7 @@ var _ = Describe("Provisioning", func() {
 			))
 			pod := ExpectProvisioned(ctx, env.Client, recorder, controller, prov, test.UnschedulablePod(test.PodOptions{}))[0]
 			node := ExpectScheduled(ctx, env.Client, pod)
-			allocatable := instanceTypeMap[node.Labels[v1.LabelInstanceTypeStable]].Resources()
+			allocatable := instanceTypeMap[node.Labels[v1.LabelInstanceTypeStable]].Capacity
 			Expect(*allocatable.Cpu()).To(Equal(resource.MustParse("4")))
 			Expect(*allocatable.Memory()).To(Equal(resource.MustParse("4Gi")))
 		})
@@ -456,7 +456,7 @@ var _ = Describe("Provisioning", func() {
 				},
 			))[0]
 			node := ExpectScheduled(ctx, env.Client, pod)
-			allocatable := instanceTypeMap[node.Labels[v1.LabelInstanceTypeStable]].Resources()
+			allocatable := instanceTypeMap[node.Labels[v1.LabelInstanceTypeStable]].Capacity
 			Expect(*allocatable.Cpu()).To(Equal(resource.MustParse("2")))
 			Expect(*allocatable.Memory()).To(Equal(resource.MustParse("2Gi")))
 		})
@@ -473,7 +473,7 @@ var _ = Describe("Provisioning", func() {
 				},
 			))[0]
 			node := ExpectScheduled(ctx, env.Client, pod)
-			allocatable := instanceTypeMap[node.Labels[v1.LabelInstanceTypeStable]].Resources()
+			allocatable := instanceTypeMap[node.Labels[v1.LabelInstanceTypeStable]].Capacity
 			Expect(*allocatable.Cpu()).To(Equal(resource.MustParse("2")))
 			Expect(*allocatable.Memory()).To(Equal(resource.MustParse("2Gi")))
 		})
@@ -491,7 +491,7 @@ var _ = Describe("Provisioning", func() {
 				},
 			))[0]
 			node := ExpectScheduled(ctx, env.Client, pod)
-			allocatable := instanceTypeMap[node.Labels[v1.LabelInstanceTypeStable]].Resources()
+			allocatable := instanceTypeMap[node.Labels[v1.LabelInstanceTypeStable]].Capacity
 			Expect(*allocatable.Cpu()).To(Equal(resource.MustParse("4")))
 			Expect(*allocatable.Memory()).To(Equal(resource.MustParse("4Gi")))
 		})

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -278,7 +278,7 @@ func (c *Cluster) populateCapacity(ctx context.Context, node *v1.Node, n *Node) 
 	if err != nil {
 		return err
 	}
-	instanceType, ok := lo.Find(instanceTypes, func(it cloudprovider.InstanceType) bool { return it.Name == node.Labels[v1.LabelInstanceTypeStable] })
+	instanceType, ok := lo.Find(instanceTypes, func(it *cloudprovider.InstanceType) bool { return it.Name == node.Labels[v1.LabelInstanceTypeStable] })
 	if !ok {
 		return fmt.Errorf("instance type '%s' not found", node.Labels[v1.LabelInstanceTypeStable])
 	}

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -278,21 +278,21 @@ func (c *Cluster) populateCapacity(ctx context.Context, node *v1.Node, n *Node) 
 	if err != nil {
 		return err
 	}
-	instanceType, ok := lo.Find(instanceTypes, func(it cloudprovider.InstanceType) bool { return it.Name() == node.Labels[v1.LabelInstanceTypeStable] })
+	instanceType, ok := lo.Find(instanceTypes, func(it cloudprovider.InstanceType) bool { return it.Name == node.Labels[v1.LabelInstanceTypeStable] })
 	if !ok {
 		return fmt.Errorf("instance type '%s' not found", node.Labels[v1.LabelInstanceTypeStable])
 	}
 
 	n.Capacity = lo.Assign(node.Status.Capacity) // ensure map not nil
 	// Use instance type resource value if resource isn't currently registered in .Status.Capacity
-	for resourceName, quantity := range instanceType.Resources() {
+	for resourceName, quantity := range instanceType.Capacity {
 		if resources.IsZero(node.Status.Capacity[resourceName]) {
 			n.Capacity[resourceName] = quantity
 		}
 	}
 	n.Allocatable = lo.Assign(node.Status.Allocatable) // ensure map not nil
 	// Use instance type resource value if resource isn't currently registered in .Status.Allocatable
-	for resourceName, quantity := range instanceType.Resources() {
+	for resourceName, quantity := range instanceType.Capacity {
 		if resources.IsZero(node.Status.Allocatable[resourceName]) {
 			n.Allocatable[resourceName] = quantity
 		}

--- a/pkg/controllers/state/suite_test.go
+++ b/pkg/controllers/state/suite_test.go
@@ -106,7 +106,7 @@ var _ = Describe("Node Resource Level", func() {
 		node := test.Node(test.NodeOptions{
 			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
 				v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
-				v1.LabelInstanceTypeStable:       cloudProvider.InstanceTypes[0].Name(),
+				v1.LabelInstanceTypeStable:       cloudProvider.InstanceTypes[0].Name,
 			}},
 			Allocatable: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU: resource.MustParse("4"),
@@ -137,7 +137,7 @@ var _ = Describe("Node Resource Level", func() {
 		node := test.Node(test.NodeOptions{
 			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
 				v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
-				v1.LabelInstanceTypeStable:       cloudProvider.InstanceTypes[0].Name(),
+				v1.LabelInstanceTypeStable:       cloudProvider.InstanceTypes[0].Name,
 			}},
 			Allocatable: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU: resource.MustParse("4"),
@@ -175,7 +175,7 @@ var _ = Describe("Node Resource Level", func() {
 		node := test.Node(test.NodeOptions{
 			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
 				v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
-				v1.LabelInstanceTypeStable:       cloudProvider.InstanceTypes[0].Name(),
+				v1.LabelInstanceTypeStable:       cloudProvider.InstanceTypes[0].Name,
 			}},
 			Allocatable: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU: resource.MustParse("4"),
@@ -207,7 +207,7 @@ var _ = Describe("Node Resource Level", func() {
 		node := test.Node(test.NodeOptions{
 			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
 				v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
-				v1.LabelInstanceTypeStable:       cloudProvider.InstanceTypes[0].Name(),
+				v1.LabelInstanceTypeStable:       cloudProvider.InstanceTypes[0].Name,
 			}},
 			Allocatable: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU: resource.MustParse("4"),
@@ -253,7 +253,7 @@ var _ = Describe("Node Resource Level", func() {
 		node := test.Node(test.NodeOptions{
 			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
 				v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
-				v1.LabelInstanceTypeStable:       cloudProvider.InstanceTypes[0].Name(),
+				v1.LabelInstanceTypeStable:       cloudProvider.InstanceTypes[0].Name,
 			}},
 			Allocatable: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU: resource.MustParse("4"),
@@ -283,7 +283,7 @@ var _ = Describe("Node Resource Level", func() {
 		node := test.Node(test.NodeOptions{
 			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
 				v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
-				v1.LabelInstanceTypeStable:       cloudProvider.InstanceTypes[0].Name(),
+				v1.LabelInstanceTypeStable:       cloudProvider.InstanceTypes[0].Name,
 			}},
 			Allocatable: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU: resource.MustParse("4"),
@@ -325,7 +325,7 @@ var _ = Describe("Node Resource Level", func() {
 		node1 := test.Node(test.NodeOptions{
 			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
 				v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
-				v1.LabelInstanceTypeStable:       cloudProvider.InstanceTypes[0].Name(),
+				v1.LabelInstanceTypeStable:       cloudProvider.InstanceTypes[0].Name,
 			}},
 			Allocatable: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU: resource.MustParse("4"),
@@ -351,7 +351,7 @@ var _ = Describe("Node Resource Level", func() {
 		node2 := test.Node(test.NodeOptions{
 			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
 				v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
-				v1.LabelInstanceTypeStable:       cloudProvider.InstanceTypes[0].Name(),
+				v1.LabelInstanceTypeStable:       cloudProvider.InstanceTypes[0].Name,
 			}},
 			Allocatable: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU: resource.MustParse("8"),
@@ -401,7 +401,7 @@ var _ = Describe("Node Resource Level", func() {
 		node := test.Node(test.NodeOptions{
 			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
 				v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
-				v1.LabelInstanceTypeStable:       cloudProvider.InstanceTypes[0].Name(),
+				v1.LabelInstanceTypeStable:       cloudProvider.InstanceTypes[0].Name,
 			}},
 			Allocatable: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU:  resource.MustParse("200"),
@@ -480,7 +480,7 @@ var _ = Describe("Node Resource Level", func() {
 		node := test.Node(test.NodeOptions{
 			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
 				v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
-				v1.LabelInstanceTypeStable:       cloudProvider.InstanceTypes[0].Name(),
+				v1.LabelInstanceTypeStable:       cloudProvider.InstanceTypes[0].Name,
 			}},
 			Allocatable: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU:    resource.MustParse("4"),
@@ -515,7 +515,7 @@ var _ = Describe("Node Resource Level", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
-					v1.LabelInstanceTypeStable:       cloudProvider.InstanceTypes[0].Name(),
+					v1.LabelInstanceTypeStable:       cloudProvider.InstanceTypes[0].Name,
 				},
 				Finalizers: []string{v1alpha5.TerminationFinalizer},
 			},
@@ -541,7 +541,7 @@ var _ = Describe("Node Resource Level", func() {
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
-					v1.LabelInstanceTypeStable:       cloudProvider.InstanceTypes[0].Name(),
+					v1.LabelInstanceTypeStable:       cloudProvider.InstanceTypes[0].Name,
 				},
 				Finalizers: []string{v1alpha5.TerminationFinalizer},
 			},
@@ -583,7 +583,7 @@ var _ = Describe("Pod Anti-Affinity", func() {
 		node := test.Node(test.NodeOptions{
 			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
 				v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
-				v1.LabelInstanceTypeStable:       cloudProvider.InstanceTypes[0].Name(),
+				v1.LabelInstanceTypeStable:       cloudProvider.InstanceTypes[0].Name,
 			}},
 			Allocatable: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU: resource.MustParse("4"),
@@ -625,7 +625,7 @@ var _ = Describe("Pod Anti-Affinity", func() {
 		node := test.Node(test.NodeOptions{
 			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
 				v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
-				v1.LabelInstanceTypeStable:       cloudProvider.InstanceTypes[0].Name(),
+				v1.LabelInstanceTypeStable:       cloudProvider.InstanceTypes[0].Name,
 			}},
 			Allocatable: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU: resource.MustParse("4"),
@@ -664,7 +664,7 @@ var _ = Describe("Pod Anti-Affinity", func() {
 		node := test.Node(test.NodeOptions{
 			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
 				v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
-				v1.LabelInstanceTypeStable:       cloudProvider.InstanceTypes[0].Name(),
+				v1.LabelInstanceTypeStable:       cloudProvider.InstanceTypes[0].Name,
 			}},
 			Allocatable: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU: resource.MustParse("4"),
@@ -713,7 +713,7 @@ var _ = Describe("Pod Anti-Affinity", func() {
 		node := test.Node(test.NodeOptions{
 			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
 				v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
-				v1.LabelInstanceTypeStable:       cloudProvider.InstanceTypes[0].Name(),
+				v1.LabelInstanceTypeStable:       cloudProvider.InstanceTypes[0].Name,
 			}},
 			Allocatable: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU: resource.MustParse("4"),

--- a/pkg/scheduling/nodetemplate.go
+++ b/pkg/scheduling/nodetemplate.go
@@ -35,7 +35,6 @@ type NodeTemplate struct {
 	StartupTaints        Taints
 	Requirements         Requirements
 	KubeletConfiguration *v1alpha5.KubeletConfiguration
-	Requests             v1.ResourceList
 }
 
 func NewNodeTemplate(provisioner *v1alpha5.Provisioner) *NodeTemplate {
@@ -52,7 +51,6 @@ func NewNodeTemplate(provisioner *v1alpha5.Provisioner) *NodeTemplate {
 		Taints:               provisioner.Spec.Taints,
 		StartupTaints:        provisioner.Spec.StartupTaints,
 		Requirements:         requirements,
-		Requests:             v1.ResourceList{},
 	}
 }
 

--- a/pkg/scheduling/nodetemplate.go
+++ b/pkg/scheduling/nodetemplate.go
@@ -35,6 +35,7 @@ type NodeTemplate struct {
 	StartupTaints        Taints
 	Requirements         Requirements
 	KubeletConfiguration *v1alpha5.KubeletConfiguration
+	Requests             v1.ResourceList
 }
 
 func NewNodeTemplate(provisioner *v1alpha5.Provisioner) *NodeTemplate {
@@ -51,6 +52,7 @@ func NewNodeTemplate(provisioner *v1alpha5.Provisioner) *NodeTemplate {
 		Taints:               provisioner.Spec.Taints,
 		StartupTaints:        provisioner.Spec.StartupTaints,
 		Requirements:         requirements,
+		Requests:             v1.ResourceList{},
 	}
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

- Converts `InstanceType` interface to struct so values will be stored statically
- Expands instance types to expose values for default `kubeReserved`, `systemReserved`, and `evictionThresholds`

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
