### PR TITLE
chore: Add object key to Typed Controller in logger

### DIFF
--- a/pkg/controllers/inflightchecks/controller.go
+++ b/pkg/controllers/inflightchecks/controller.go
@@ -81,8 +81,6 @@ func (c *Controller) Name() string {
 }
 
 func (c *Controller) Reconcile(ctx context.Context, node *v1.Node) (reconcile.Result, error) {
-	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).With("node", node.Name))
-
 	// If we get an event before we should check for inflight checks, we ignore and wait
 	if lastTime, ok := c.lastScanned.Get(client.ObjectKeyFromObject(node).String()); ok {
 		if lastTime, ok := lastTime.(time.Time); ok {

--- a/pkg/controllers/metrics/pod/controller.go
+++ b/pkg/controllers/metrics/pod/controller.go
@@ -20,8 +20,6 @@ import (
 	"strings"
 	"sync"
 
-	"knative.dev/pkg/logging"
-
 	"github.com/prometheus/client_golang/prometheus"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -117,7 +115,6 @@ func (c *Controller) Name() string {
 
 // Reconcile executes a termination control loop for the resource
 func (c *Controller) Reconcile(ctx context.Context, pod *v1.Pod) (reconcile.Result, error) {
-	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).With("pod", pod.Name))
 	// Remove the previous gauge after pod labels are updated
 	if labels, ok := c.labelsMap.Load(client.ObjectKeyFromObject(pod)); ok {
 		podGaugeVec.Delete(labels.(prometheus.Labels))

--- a/pkg/controllers/metrics/provisioner/controller.go
+++ b/pkg/controllers/metrics/provisioner/controller.go
@@ -106,8 +106,6 @@ func (c *Controller) Name() string {
 
 // Reconcile executes a termination control loop for the resource
 func (c *Controller) Reconcile(ctx context.Context, provisioner *v1alpha5.Provisioner) (reconcile.Result, error) {
-	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).With("provisioner", provisioner.Name))
-
 	// Remove the previous gauge after provisioner labels are updated
 	c.cleanup(client.ObjectKeyFromObject(provisioner))
 	c.record(ctx, provisioner)

--- a/pkg/controllers/node/controller.go
+++ b/pkg/controllers/node/controller.go
@@ -69,7 +69,6 @@ func (c *Controller) Name() string {
 
 // Reconcile executes a reallocation control loop for the resource
 func (c *Controller) Reconcile(ctx context.Context, node *v1.Node) (reconcile.Result, error) {
-	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).With("node", node.Name))
 	provisioner := &v1alpha5.Provisioner{}
 	if err := c.kubeClient.Get(ctx, types.NamespacedName{Name: node.Labels[v1alpha5.ProvisionerNameLabelKey]}, provisioner); err != nil {
 		return reconcile.Result{}, client.IgnoreNotFound(err)

--- a/pkg/controllers/state/provisioner.go
+++ b/pkg/controllers/state/provisioner.go
@@ -58,7 +58,6 @@ func (c *ProvisionerController) Builder(_ context.Context, m manager.Manager) co
 	return corecontroller.Adapt(controllerruntime.
 		NewControllerManagedBy(m).
 		For(&v1alpha5.Provisioner{}).
-		Named(c.Name()).
 		WithOptions(controller.Options{MaxConcurrentReconciles: 10}).
 		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		WithEventFilter(predicate.Funcs{DeleteFunc: func(event event.DeleteEvent) bool { return false }}),


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

- Adds object key to the typed controller in logger

**How was this change tested?**

`make apply`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
