### PR TITLE
feat: added drift deprovisioner

### DIFF
--- a/pkg/apis/config/settings/settings.go
+++ b/pkg/apis/config/settings/settings.go
@@ -38,11 +38,14 @@ var Registration = &config.Registration{
 var defaultSettings = Settings{
 	BatchMaxDuration:  metav1.Duration{Duration: time.Second * 10},
 	BatchIdleDuration: metav1.Duration{Duration: time.Second * 1},
+	DriftEnabled:      false,
 }
 
 type Settings struct {
 	BatchMaxDuration  metav1.Duration `json:"batchMaxDuration"`
 	BatchIdleDuration metav1.Duration `json:"batchIdleDuration"`
+	// This feature flag is temporary and will be removed in the near future.
+	DriftEnabled bool `json:"driftEnabled"`
 }
 
 // NewSettingsFromConfigMap creates a Settings from the supplied ConfigMap
@@ -52,6 +55,7 @@ func NewSettingsFromConfigMap(cm *v1.ConfigMap) (Settings, error) {
 	if err := configmap.Parse(cm.Data,
 		AsMetaDuration("batchMaxDuration", &s.BatchMaxDuration),
 		AsMetaDuration("batchIdleDuration", &s.BatchIdleDuration),
+		configmap.AsBool("driftEnabled", &s.DriftEnabled),
 	); err != nil {
 		// Failing to parse means that there is some error in the Settings, so we should crash
 		panic(fmt.Sprintf("parsing settings, %v", err))

--- a/pkg/apis/config/settings/settings.go
+++ b/pkg/apis/config/settings/settings.go
@@ -42,10 +42,10 @@ var defaultSettings = Settings{
 }
 
 type Settings struct {
-	BatchMaxDuration  metav1.Duration `json:"batchMaxDuration"`
-	BatchIdleDuration metav1.Duration `json:"batchIdleDuration"`
+	BatchMaxDuration  metav1.Duration
+	BatchIdleDuration metav1.Duration
 	// This feature flag is temporary and will be removed in the near future.
-	DriftEnabled bool `json:"driftEnabled"`
+	DriftEnabled bool
 }
 
 // NewSettingsFromConfigMap creates a Settings from the supplied ConfigMap
@@ -55,7 +55,7 @@ func NewSettingsFromConfigMap(cm *v1.ConfigMap) (Settings, error) {
 	if err := configmap.Parse(cm.Data,
 		AsMetaDuration("batchMaxDuration", &s.BatchMaxDuration),
 		AsMetaDuration("batchIdleDuration", &s.BatchIdleDuration),
-		configmap.AsBool("driftEnabled", &s.DriftEnabled),
+		configmap.AsBool("featureGates.driftEnabled", &s.DriftEnabled),
 	); err != nil {
 		// Failing to parse means that there is some error in the Settings, so we should crash
 		panic(fmt.Sprintf("parsing settings, %v", err))

--- a/pkg/apis/config/settings/suite_test.go
+++ b/pkg/apis/config/settings/suite_test.go
@@ -50,9 +50,9 @@ var _ = Describe("Validation", func() {
 	It("should succeed to set custom values", func() {
 		cm := &v1.ConfigMap{
 			Data: map[string]string{
-				"batchMaxDuration":  "30s",
-				"batchIdleDuration": "5s",
-				"driftEnabled":      "true",
+				"batchMaxDuration":          "30s",
+				"batchIdleDuration":         "5s",
+				"featureGates.driftEnabled": "true",
 			},
 		}
 		s, _ := settings.NewSettingsFromConfigMap(cm)
@@ -82,7 +82,7 @@ var _ = Describe("Validation", func() {
 		defer ExpectPanic()
 		cm := &v1.ConfigMap{
 			Data: map[string]string{
-				"batchIdleDuration": "foobar",
+				"featureGates.driftEnabled": "foobar",
 			},
 		}
 		_, _ = settings.NewSettingsFromConfigMap(cm)

--- a/pkg/apis/config/settings/suite_test.go
+++ b/pkg/apis/config/settings/suite_test.go
@@ -45,17 +45,20 @@ var _ = Describe("Validation", func() {
 		s, _ := settings.NewSettingsFromConfigMap(cm)
 		Expect(s.BatchMaxDuration.Duration).To(Equal(time.Second * 10))
 		Expect(s.BatchIdleDuration.Duration).To(Equal(time.Second))
+		Expect(s.DriftEnabled).To(BeFalse())
 	})
 	It("should succeed to set custom values", func() {
 		cm := &v1.ConfigMap{
 			Data: map[string]string{
 				"batchMaxDuration":  "30s",
 				"batchIdleDuration": "5s",
+				"driftEnabled":      "true",
 			},
 		}
 		s, _ := settings.NewSettingsFromConfigMap(cm)
 		Expect(s.BatchMaxDuration.Duration).To(Equal(time.Second * 30))
 		Expect(s.BatchIdleDuration.Duration).To(Equal(time.Second * 5))
+		Expect(s.DriftEnabled).To(BeTrue())
 	})
 	It("should fail validation with panic when batchMaxDuration is negative", func() {
 		defer ExpectPanic()
@@ -71,6 +74,15 @@ var _ = Describe("Validation", func() {
 		cm := &v1.ConfigMap{
 			Data: map[string]string{
 				"batchIdleDuration": "-1s",
+			},
+		}
+		_, _ = settings.NewSettingsFromConfigMap(cm)
+	})
+	It("should fail validation with panic when driftEnabled is not a valid boolean value", func() {
+		defer ExpectPanic()
+		cm := &v1.ConfigMap{
+			Data: map[string]string{
+				"batchIdleDuration": "foobar",
 			},
 		}
 		_, _ = settings.NewSettingsFromConfigMap(cm)

--- a/pkg/apis/v1alpha5/labels.go
+++ b/pkg/apis/v1alpha5/labels.go
@@ -44,6 +44,10 @@ const (
 	DoNotConsolidateNodeAnnotationKey  = Group + "/do-not-consolidate"
 	EmptinessTimestampAnnotationKey    = Group + "/emptiness-timestamp"
 	ProviderCompatabilityAnnotationKey = Group + "/compatibility/provider"
+	VoluntaryDisruptionAnnotationKey   = Group + "/voluntary-disruption"
+
+	// Karpenter specific annotation values
+	VoluntaryDisruptionDriftedAnnotationValue = "drifted"
 )
 
 // Karpenter specific finalizers

--- a/pkg/controllers/deprovisioning/controller.go
+++ b/pkg/controllers/deprovisioning/controller.go
@@ -54,6 +54,7 @@ type Controller struct {
 	cloudProvider           cloudprovider.CloudProvider
 	emptiness               *Emptiness
 	expiration              *Expiration
+	drift                   *Drift
 	singleNodeConsolidation *SingleNodeConsolidation
 	multiNodeConsolidation  *MultiNodeConsolidation
 	emptyNodeConsolidation  *EmptyNodeConsolidation
@@ -85,6 +86,7 @@ func NewController(clk clock.Clock, kubeClient client.Client, provisioner *provi
 		cloudProvider:           cp,
 		expiration:              NewExpiration(clk, kubeClient, cluster, provisioner),
 		emptiness:               NewEmptiness(clk, kubeClient, cluster),
+		drift:                   NewDrift(kubeClient, cluster, provisioner),
 		emptyNodeConsolidation:  NewEmptyNodeConsolidation(clk, cluster, kubeClient, provisioner, cp),
 		multiNodeConsolidation:  NewMultiNodeConsolidation(clk, cluster, kubeClient, provisioner, cp),
 		singleNodeConsolidation: NewSingleNodeConsolidation(clk, cluster, kubeClient, provisioner, cp),
@@ -140,6 +142,9 @@ func (c *Controller) ProcessCluster(ctx context.Context) (Result, error) {
 		// Expire any nodes that must be deleted, allowing their pods to potentially land on currently
 		// empty nodes
 		c.expiration,
+
+		// Terminate any nodes that have drifted from provisioning specifications, allowing the pods to reschedule.
+		c.drift,
 
 		// Delete any remaining empty nodes as there is zero cost in terms of dirsuption.  Emptiness and
 		// emptyNodeConsolidation are mutually exclusive, only one of these will operate

--- a/pkg/controllers/deprovisioning/drift.go
+++ b/pkg/controllers/deprovisioning/drift.go
@@ -1,0 +1,103 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deprovisioning
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	v1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/logging"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/aws/karpenter-core/pkg/apis/config/settings"
+	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
+	"github.com/aws/karpenter-core/pkg/controllers/provisioning"
+	"github.com/aws/karpenter-core/pkg/controllers/state"
+	"github.com/aws/karpenter-core/pkg/metrics"
+)
+
+// Drift is a subreconciler that deletes empty nodes.
+// Drift will respect TTLSecondsAfterEmpty
+type Drift struct {
+	kubeClient  client.Client
+	cluster     *state.Cluster
+	provisioner *provisioning.Provisioner
+}
+
+func NewDrift(kubeClient client.Client, cluster *state.Cluster, provisioner *provisioning.Provisioner) *Drift {
+	return &Drift{
+		kubeClient:  kubeClient,
+		cluster:     cluster,
+		provisioner: provisioner,
+	}
+}
+
+// ShouldDeprovision is a predicate used to filter deprovisionable nodes
+func (d *Drift) ShouldDeprovision(ctx context.Context, n *state.Node, provisioner *v1alpha5.Provisioner, nodePods []*v1.Pod) bool {
+	// Look up the feature flag to see if we should deprovision the node because of drift.
+	if !settings.FromContext(ctx).DriftEnabled {
+		return false
+	}
+	return n.Node.Annotations[v1alpha5.VoluntaryDisruptionAnnotationKey] == v1alpha5.VoluntaryDisruptionDriftedAnnotationValue
+}
+
+// ComputeCommand generates a deprovisioning command given deprovisionable nodes
+func (d *Drift) ComputeCommand(ctx context.Context, candidates ...CandidateNode) (Command, error) {
+	pdbs, err := NewPDBLimits(ctx, d.kubeClient)
+	if err != nil {
+		return Command{}, fmt.Errorf("tracking PodDisruptionBudgets, %w", err)
+	}
+	for _, candidate := range candidates {
+		// is this a node that we can terminate?  This check is meant to be fast so we can save the expense of simulated
+		// scheduling unless its really needed
+		if !canBeTerminated(candidate, pdbs) {
+			continue
+		}
+
+		// Check if we need to create any nodes.
+		newNodes, allPodsScheduled, err := simulateScheduling(ctx, d.kubeClient, d.cluster, d.provisioner, candidate)
+		if err != nil {
+			// if a candidate node is now deleting, just retry
+			if errors.Is(err, errCandidateNodeDeleting) {
+				continue
+			}
+			return Command{}, err
+		}
+		// Log when all pods can't schedule, as the command will get executed immediately.
+		if !allPodsScheduled {
+			logging.FromContext(ctx).With("node", candidate.Name).Debug("Continuing to terminate drifted node after scheduling simulation failed to schedule all pods")
+		}
+		// were we able to schedule all the pods on the inflight nodes?
+		if len(newNodes) == 0 {
+			return Command{
+				nodesToRemove: []*v1.Node{candidate.Node},
+				action:        actionDelete,
+			}, nil
+		}
+		return Command{
+			nodesToRemove:    []*v1.Node{candidate.Node},
+			action:           actionReplace,
+			replacementNodes: newNodes,
+		}, nil
+	}
+	return Command{action: actionDoNothing}, nil
+}
+
+// String is the string representation of the deprovisioner
+func (d *Drift) String() string {
+	return metrics.DriftReason
+}

--- a/pkg/controllers/deprovisioning/drift.go
+++ b/pkg/controllers/deprovisioning/drift.go
@@ -89,9 +89,9 @@ func (d *Drift) ComputeCommand(ctx context.Context, candidates ...CandidateNode)
 			}, nil
 		}
 		return Command{
-			nodesToRemove:    []*v1.Node{candidate.Node},
-			action:           actionReplace,
-			replacementNodes: newNodes,
+			nodesToRemove:       []*v1.Node{candidate.Node},
+			action:              actionReplace,
+			replacementMachines: newNodes,
 		}, nil
 	}
 	return Command{action: actionDoNothing}, nil

--- a/pkg/controllers/deprovisioning/expiration.go
+++ b/pkg/controllers/deprovisioning/expiration.go
@@ -90,9 +90,9 @@ func (e *Expiration) ComputeCommand(ctx context.Context, candidates ...Candidate
 		}
 		// Log when all pods can't schedule, as the command will get executed immediately.
 		if !allPodsScheduled {
-			logging.FromContext(ctx).With("node", candidate.Name).Infof("Continuing to expire node after scheduling simulation failed to schedule all pods")
+			logging.FromContext(ctx).With("node", candidate.Name).Debugf("Continuing to expire node after scheduling simulation failed to schedule all pods")
 		}
-		logging.FromContext(ctx).Infof("triggering termination for expired node after %s (+%s)",
+		logging.FromContext(ctx).Infof("Triggering termination for expired node after %s (+%s)",
 			time.Duration(ptr.Int64Value(candidates[0].provisioner.Spec.TTLSecondsUntilExpired))*time.Second, time.Since(getExpirationTime(candidates[0].Node, candidates[0].provisioner)))
 		// were we able to schedule all the pods on the inflight nodes?
 		if len(newNodes) == 0 {

--- a/pkg/controllers/deprovisioning/expiration.go
+++ b/pkg/controllers/deprovisioning/expiration.go
@@ -90,10 +90,12 @@ func (e *Expiration) ComputeCommand(ctx context.Context, candidates ...Candidate
 		}
 		// Log when all pods can't schedule, as the command will get executed immediately.
 		if !allPodsScheduled {
-			logging.FromContext(ctx).With("node", candidate.Name).Debugf("Continuing to expire node after scheduling simulation failed to schedule all pods")
+			logging.FromContext(ctx).With("node", candidate.Name).Debugf("continuing to expire node after scheduling simulation failed to schedule all pods")
 		}
-		logging.FromContext(ctx).Infof("Triggering termination for expired node after %s (+%s)",
-			time.Duration(ptr.Int64Value(candidates[0].provisioner.Spec.TTLSecondsUntilExpired))*time.Second, time.Since(getExpirationTime(candidates[0].Node, candidates[0].provisioner)))
+
+		logging.FromContext(ctx).With("ttl", time.Duration(ptr.Int64Value(candidates[0].provisioner.Spec.TTLSecondsUntilExpired))*time.Second).
+			With("delay", time.Since(getExpirationTime(candidates[0].Node, candidates[0].provisioner))).Infof("triggering termination for expired node after TTL")
+
 		// were we able to schedule all the pods on the inflight nodes?
 		if len(newNodes) == 0 {
 			return Command{

--- a/pkg/controllers/deprovisioning/expiration.go
+++ b/pkg/controllers/deprovisioning/expiration.go
@@ -93,7 +93,7 @@ func (e *Expiration) ComputeCommand(ctx context.Context, candidates ...Candidate
 			logging.FromContext(ctx).With("node", candidate.Name).Debugf("continuing to expire node after scheduling simulation failed to schedule all pods")
 		}
 
-		logging.FromContext(ctx).With("ttl", time.Duration(ptr.Int64Value(candidates[0].provisioner.Spec.TTLSecondsUntilExpired))*time.Second).
+		logging.FromContext(ctx).With("expirationTTL", time.Duration(ptr.Int64Value(candidates[0].provisioner.Spec.TTLSecondsUntilExpired))*time.Second).
 			With("delay", time.Since(getExpirationTime(candidates[0].Node, candidates[0].provisioner))).Infof("triggering termination for expired node after TTL")
 
 		// were we able to schedule all the pods on the inflight nodes?

--- a/pkg/metrics/constants.go
+++ b/pkg/metrics/constants.go
@@ -33,6 +33,7 @@ const (
 	ProvisioningReason   = "provisioning"
 	ExpirationReason     = "expiration"
 	EmptinessReason      = "emptiness"
+	DriftReason          = "drift"
 )
 
 // DurationBuckets returns a []float64 of default threshold values for duration histograms.


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
This adds the drift deprovisioner that allows cloud provider controllers to implement the IsNodeDrifted function, and label nodes with `karpenter.sh/node-drifted: true` to deprovision nodes when they don't match provisioning specifications.

This also adds a feature flag in the global settings configmap to enable drift. It is disabled by default.
**How was this change tested?**
- make presubmit
- make apply && make e2etests


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
