### PR TITLE
chore: dynamically update cluster state, rather than waiting for sync

### DIFF
--- a/pkg/cloudprovider/fake/cloudprovider.go
+++ b/pkg/cloudprovider/fake/cloudprovider.go
@@ -66,7 +66,7 @@ func (c *CloudProvider) Create(ctx context.Context, nodeRequest *cloudprovider.N
 	// Labels
 	labels := map[string]string{}
 	for key, requirement := range instanceType.Requirements {
-		if requirement.Len() == 1 {
+		if requirement.Operator() == v1.NodeSelectorOpIn {
 			labels[key] = requirement.Values()[0]
 		}
 	}

--- a/pkg/controllers/deprovisioning/suite_test.go
+++ b/pkg/controllers/deprovisioning/suite_test.go
@@ -83,7 +83,6 @@ var _ = BeforeSuite(func() {
 	recorder = test.NewEventRecorder()
 	provisioner = provisioning.NewProvisioner(ctx, env.Client, env.KubernetesInterface.CoreV1(), recorder, cloudProvider, cluster)
 	provisioningController = provisioning.NewController(env.Client, provisioner, recorder)
-	provisioning.WaitForClusterSync = false
 })
 
 var _ = AfterSuite(func() {
@@ -2059,7 +2058,7 @@ var _ = Describe("Parallelization", func() {
 		pods := ExpectProvisionedNoBinding(ctx, env.Client, provisioningController, provisioner, test.UnschedulablePod())
 		nodes := &v1.NodeList{}
 		Expect(env.Client.List(ctx, nodes)).To(Succeed())
-		Expect(len(nodes.Items)).To(Equal(3))
+		Expect(len(nodes.Items)).To(Equal(2))
 		Expect(pods[0].Spec.NodeName).NotTo(Equal(node.Name))
 	})
 	It("should not consolidate a node that is launched for pods on a deleting node", func() {

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -333,7 +333,7 @@ func (p *Provisioner) launch(ctx context.Context, opts LaunchOptions, node *sche
 	}
 	p.cluster.NominateNodeForPod(k8sNode.Name)
 	if err := p.cluster.UpdateNode(ctx, k8sNode); err != nil {
-		return "", fmt.Errorf("upating cluster state, %w", err)
+		return "", fmt.Errorf("updating cluster state, %w", err)
 	}
 	if opts.RecordPodNomination {
 		for _, pod := range node.Pods {

--- a/pkg/controllers/provisioning/scheduling/instance_selection_test.go
+++ b/pkg/controllers/provisioning/scheduling/instance_selection_test.go
@@ -71,13 +71,13 @@ var _ = Describe("Instance Type Selection", func() {
 	// passed to the cloud provider is unique.
 	It("should schedule on one of the cheapest instances", func() {
 		ExpectApplied(ctx, env.Client, provisioner)
-		pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod())
+		pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod())
 		node := ExpectScheduled(ctx, env.Client, pod[0])
 		Expect(nodePrice(node)).To(Equal(minPrice))
 	})
 	It("should schedule on one of the cheapest instances (pod arch = amd64)", func() {
 		ExpectApplied(ctx, env.Client, provisioner)
-		pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+		pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 			test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{{
 				Key:      v1.LabelArchStable,
 				Operator: v1.NodeSelectorOpIn,
@@ -90,7 +90,7 @@ var _ = Describe("Instance Type Selection", func() {
 	})
 	It("should schedule on one of the cheapest instances (pod arch = arm64)", func() {
 		ExpectApplied(ctx, env.Client, provisioner)
-		pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+		pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 			test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{{
 				Key:      v1.LabelArchStable,
 				Operator: v1.NodeSelectorOpIn,
@@ -109,7 +109,7 @@ var _ = Describe("Instance Type Selection", func() {
 			},
 		}
 		ExpectApplied(ctx, env.Client, provisioner)
-		pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod())
+		pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod())
 		node := ExpectScheduled(ctx, env.Client, pod[0])
 		Expect(nodePrice(node)).To(Equal(minPrice))
 		ExpectInstancesWithLabel(cloudProv.CreateCalls[0].InstanceTypeOptions, v1.LabelArchStable, v1alpha5.ArchitectureAmd64)
@@ -123,7 +123,7 @@ var _ = Describe("Instance Type Selection", func() {
 			},
 		}
 		ExpectApplied(ctx, env.Client, provisioner)
-		pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod())
+		pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod())
 		node := ExpectScheduled(ctx, env.Client, pod[0])
 		Expect(nodePrice(node)).To(Equal(minPrice))
 		ExpectInstancesWithLabel(cloudProv.CreateCalls[0].InstanceTypeOptions, v1.LabelArchStable, v1alpha5.ArchitectureArm64)
@@ -137,14 +137,14 @@ var _ = Describe("Instance Type Selection", func() {
 			},
 		}
 		ExpectApplied(ctx, env.Client, provisioner)
-		pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod())
+		pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod())
 		node := ExpectScheduled(ctx, env.Client, pod[0])
 		Expect(nodePrice(node)).To(Equal(minPrice))
 		ExpectInstancesWithLabel(cloudProv.CreateCalls[0].InstanceTypeOptions, v1.LabelOSStable, string(v1.Windows))
 	})
 	It("should schedule on one of the cheapest instances (pod os = windows)", func() {
 		ExpectApplied(ctx, env.Client, provisioner)
-		pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+		pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 			test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{{
 				Key:      v1.LabelOSStable,
 				Operator: v1.NodeSelectorOpIn,
@@ -163,14 +163,14 @@ var _ = Describe("Instance Type Selection", func() {
 			},
 		}
 		ExpectApplied(ctx, env.Client, provisioner)
-		pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod())
+		pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod())
 		node := ExpectScheduled(ctx, env.Client, pod[0])
 		Expect(nodePrice(node)).To(Equal(minPrice))
 		ExpectInstancesWithLabel(cloudProv.CreateCalls[0].InstanceTypeOptions, v1.LabelOSStable, string(v1.Windows))
 	})
 	It("should schedule on one of the cheapest instances (pod os = linux)", func() {
 		ExpectApplied(ctx, env.Client, provisioner)
-		pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+		pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 			test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{{
 				Key:      v1.LabelOSStable,
 				Operator: v1.NodeSelectorOpIn,
@@ -182,7 +182,7 @@ var _ = Describe("Instance Type Selection", func() {
 	})
 	It("should schedule on one of the cheapest instances (pod os = linux)", func() {
 		ExpectApplied(ctx, env.Client, provisioner)
-		pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+		pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 			test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{{
 				Key:      v1.LabelOSStable,
 				Operator: v1.NodeSelectorOpIn,
@@ -201,14 +201,14 @@ var _ = Describe("Instance Type Selection", func() {
 			},
 		}
 		ExpectApplied(ctx, env.Client, provisioner)
-		pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod())
+		pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod())
 		node := ExpectScheduled(ctx, env.Client, pod[0])
 		Expect(nodePrice(node)).To(Equal(minPrice))
 		ExpectInstancesWithLabel(cloudProv.CreateCalls[0].InstanceTypeOptions, v1.LabelTopologyZone, "test-zone-2")
 	})
 	It("should schedule on one of the cheapest instances (pod zone = test-zone-2)", func() {
 		ExpectApplied(ctx, env.Client, provisioner)
-		pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+		pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 			test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{{
 				Key:      v1.LabelTopologyZone,
 				Operator: v1.NodeSelectorOpIn,
@@ -227,14 +227,14 @@ var _ = Describe("Instance Type Selection", func() {
 			},
 		}
 		ExpectApplied(ctx, env.Client, provisioner)
-		pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod())
+		pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod())
 		node := ExpectScheduled(ctx, env.Client, pod[0])
 		Expect(nodePrice(node)).To(Equal(minPrice))
 		ExpectInstancesWithLabel(cloudProv.CreateCalls[0].InstanceTypeOptions, v1alpha5.LabelCapacityType, v1alpha5.CapacityTypeSpot)
 	})
 	It("should schedule on one of the cheapest instances (pod ct = spot)", func() {
 		ExpectApplied(ctx, env.Client, provisioner)
-		pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+		pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 			test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{{
 				Key:      v1alpha5.LabelCapacityType,
 				Operator: v1.NodeSelectorOpIn,
@@ -258,14 +258,14 @@ var _ = Describe("Instance Type Selection", func() {
 			},
 		}
 		ExpectApplied(ctx, env.Client, provisioner)
-		pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod())
+		pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod())
 		node := ExpectScheduled(ctx, env.Client, pod[0])
 		Expect(nodePrice(node)).To(Equal(minPrice))
 		ExpectInstancesWithOffering(cloudProv.CreateCalls[0].InstanceTypeOptions, v1alpha5.CapacityTypeOnDemand, "test-zone-1")
 	})
 	It("should schedule on one of the cheapest instances (pod ct = spot, pod zone = test-zone-1)", func() {
 		ExpectApplied(ctx, env.Client, provisioner)
-		pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+		pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 			test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{{
 				Key:      v1alpha5.LabelCapacityType,
 				Operator: v1.NodeSelectorOpIn,
@@ -290,7 +290,7 @@ var _ = Describe("Instance Type Selection", func() {
 			},
 		}
 		ExpectApplied(ctx, env.Client, provisioner)
-		pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+		pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 			test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{{
 				Key:      v1.LabelTopologyZone,
 				Operator: v1.NodeSelectorOpIn,
@@ -324,7 +324,7 @@ var _ = Describe("Instance Type Selection", func() {
 			},
 		}
 		ExpectApplied(ctx, env.Client, provisioner)
-		pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod())
+		pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod())
 		node := ExpectScheduled(ctx, env.Client, pod[0])
 		Expect(nodePrice(node)).To(Equal(minPrice))
 		ExpectInstancesWithOffering(cloudProv.CreateCalls[0].InstanceTypeOptions, v1alpha5.CapacityTypeOnDemand, "test-zone-1")
@@ -345,7 +345,7 @@ var _ = Describe("Instance Type Selection", func() {
 			},
 		}
 		ExpectApplied(ctx, env.Client, provisioner)
-		pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+		pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 			test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{
 				{
 					Key:      v1alpha5.LabelCapacityType,
@@ -366,7 +366,7 @@ var _ = Describe("Instance Type Selection", func() {
 	})
 	It("should schedule on one of the cheapest instances (pod ct = spot/test-zone-2/amd64/linux)", func() {
 		ExpectApplied(ctx, env.Client, provisioner)
-		pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+		pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 			test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{
 				{
 					Key:      v1.LabelArchStable,
@@ -403,7 +403,7 @@ var _ = Describe("Instance Type Selection", func() {
 
 		Expect(len(cloudProv.InstanceTypes)).To(BeNumerically(">", 0))
 		ExpectApplied(ctx, env.Client, provisioner)
-		pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+		pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 			test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{
 				{
 					Key:      v1.LabelArchStable,
@@ -426,7 +426,7 @@ var _ = Describe("Instance Type Selection", func() {
 		})
 		Expect(len(cloudProv.InstanceTypes)).To(BeNumerically(">", 0))
 		ExpectApplied(ctx, env.Client, provisioner)
-		pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+		pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 			test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{
 				{
 					Key:      v1.LabelArchStable,
@@ -462,7 +462,7 @@ var _ = Describe("Instance Type Selection", func() {
 		}
 		Expect(len(cloudProv.InstanceTypes)).To(BeNumerically(">", 0))
 		ExpectApplied(ctx, env.Client, provisioner)
-		pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+		pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 			test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{
 				{
 					Key:      v1.LabelTopologyZone,
@@ -490,13 +490,14 @@ var _ = Describe("Instance Type Selection", func() {
 		// these values are constructed so that three of these pods can always fit on at least one of our instance types
 		for _, cpu := range []float64{0.1, 1.0, 2, 2.5, 4, 8, 16} {
 			for _, mem := range []float64{0.1, 1.0, 2, 4, 8, 16, 32} {
+				cluster.Reset(ctx)
 				cloudProv.CreateCalls = nil
 				opts := test.PodOptions{
 					ResourceRequirements: v1.ResourceRequirements{Requests: map[v1.ResourceName]resource.Quantity{
 						v1.ResourceCPU:    resource.MustParse(fmt.Sprintf("%0.1f", cpu)),
 						v1.ResourceMemory: resource.MustParse(fmt.Sprintf("%0.1fGi", mem)),
 					}}}
-				pods := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+				pods := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 					test.UnschedulablePod(opts), test.UnschedulablePod(opts), test.UnschedulablePod(opts))
 				nodeNames := sets.NewString()
 				for _, p := range pods {
@@ -562,7 +563,7 @@ var _ = Describe("Instance Type Selection", func() {
 		}
 
 		ExpectApplied(ctx, env.Client, provisioner)
-		pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod())
+		pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod())
 		node := ExpectScheduled(ctx, env.Client, pod[0])
 		Expect(node.Labels[v1.LabelInstanceTypeStable]).To(Equal("test-instance1"))
 	})

--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -84,7 +84,6 @@ var _ = BeforeSuite(func() {
 	recorder = test.NewEventRecorder()
 	prov = provisioning.NewProvisioner(ctx, env.Client, env.KubernetesInterface.CoreV1(), recorder, cloudProv, cluster)
 	provisioningController = provisioning.NewController(env.Client, prov, recorder)
-	provisioning.WaitForClusterSync = false
 })
 
 var _ = AfterSuite(func() {
@@ -105,28 +104,8 @@ var _ = BeforeEach(func() {
 })
 
 var _ = AfterEach(func() {
-	var nodes v1.NodeList
-	Expect(env.Client.List(ctx, &nodes)).To(Succeed())
-	var pods v1.PodList
-	Expect(env.Client.List(ctx, &pods)).To(Succeed())
-
 	ExpectCleanedUp(ctx, env.Client)
-
-	for i := range nodes.Items {
-		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(&nodes.Items[i]))
-	}
-	for i := range pods.Items {
-		ExpectReconcileSucceeded(ctx, podStateController, client.ObjectKeyFromObject(&pods.Items[i]))
-	}
-
-	cluster.ForEachNode(func(n *state.Node) bool {
-		Fail("expected to not be called")
-		return true
-	})
-	cluster.ForPodsWithAntiAffinity(func(p *v1.Pod, n *v1.Node) bool {
-		Fail("expected to not be called")
-		return true
-	})
+	cluster.Reset(ctx)
 })
 
 var _ = Describe("Custom Constraints", func() {
@@ -134,21 +113,21 @@ var _ = Describe("Custom Constraints", func() {
 		It("should schedule unconstrained pods that don't have matching node selectors", func() {
 			provisioner.Spec.Labels = map[string]string{"test-key": "test-value"}
 			ExpectApplied(ctx, env.Client, provisioner)
-			pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod())[0]
+			pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod())[0]
 			node := ExpectScheduled(ctx, env.Client, pod)
 			Expect(node.Labels).To(HaveKeyWithValue("test-key", "test-value"))
 		})
 		It("should not schedule pods that have conflicting node selectors", func() {
 			provisioner.Spec.Labels = map[string]string{"test-key": "test-value"}
 			ExpectApplied(ctx, env.Client, provisioner)
-			pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+			pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 				test.PodOptions{NodeSelector: map[string]string{"test-key": "different-value"}},
 			))[0]
 			ExpectNotScheduled(ctx, env.Client, pod)
 		})
 		It("should not schedule pods that have node selectors with undefined key", func() {
 			ExpectApplied(ctx, env.Client, provisioner)
-			pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+			pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 				test.PodOptions{NodeSelector: map[string]string{"test-key": "test-value"}},
 			))[0]
 			ExpectNotScheduled(ctx, env.Client, pod)
@@ -156,7 +135,7 @@ var _ = Describe("Custom Constraints", func() {
 		It("should schedule pods that have matching requirements", func() {
 			provisioner.Spec.Labels = map[string]string{"test-key": "test-value"}
 			ExpectApplied(ctx, env.Client, provisioner)
-			pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+			pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 				test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{
 					{Key: "test-key", Operator: v1.NodeSelectorOpIn, Values: []string{"test-value", "another-value"}},
 				}},
@@ -167,7 +146,7 @@ var _ = Describe("Custom Constraints", func() {
 		It("should not schedule pods that have conflicting requirements", func() {
 			provisioner.Spec.Labels = map[string]string{"test-key": "test-value"}
 			ExpectApplied(ctx, env.Client, provisioner)
-			pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+			pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 				test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{
 					{Key: "test-key", Operator: v1.NodeSelectorOpIn, Values: []string{"another-value"}},
 				}},
@@ -180,7 +159,7 @@ var _ = Describe("Custom Constraints", func() {
 			provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
 				{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-2"}}}
 			ExpectApplied(ctx, env.Client, provisioner)
-			pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod())[0]
+			pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod())[0]
 			node := ExpectScheduled(ctx, env.Client, pod)
 			Expect(node.Labels).To(HaveKeyWithValue(v1.LabelTopologyZone, "test-zone-2"))
 		})
@@ -188,7 +167,7 @@ var _ = Describe("Custom Constraints", func() {
 			provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
 				{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-1", "test-zone-2"}}}
 			ExpectApplied(ctx, env.Client, provisioner)
-			pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+			pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 				test.PodOptions{NodeSelector: map[string]string{v1.LabelTopologyZone: "test-zone-2"}},
 			))[0]
 			node := ExpectScheduled(ctx, env.Client, pod)
@@ -196,7 +175,7 @@ var _ = Describe("Custom Constraints", func() {
 		})
 		It("should not schedule nodes with a hostname selector", func() {
 			ExpectApplied(ctx, env.Client, provisioner)
-			pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+			pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 				test.PodOptions{NodeSelector: map[string]string{v1.LabelHostname: "red-node"}},
 			))[0]
 			ExpectNotScheduled(ctx, env.Client, pod)
@@ -205,7 +184,7 @@ var _ = Describe("Custom Constraints", func() {
 			provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
 				{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-1"}}}
 			ExpectApplied(ctx, env.Client, provisioner)
-			pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+			pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 				test.PodOptions{NodeSelector: map[string]string{v1.LabelTopologyZone: "unknown"}},
 			))[0]
 			ExpectNotScheduled(ctx, env.Client, pod)
@@ -214,14 +193,14 @@ var _ = Describe("Custom Constraints", func() {
 			provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
 				{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-1"}}}
 			ExpectApplied(ctx, env.Client, provisioner)
-			pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+			pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 				test.PodOptions{NodeSelector: map[string]string{v1.LabelTopologyZone: "test-zone-2"}},
 			))[0]
 			ExpectNotScheduled(ctx, env.Client, pod)
 		})
 		It("should schedule compatible requirements with Operator=In", func() {
 			ExpectApplied(ctx, env.Client, provisioner)
-			pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+			pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 				test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{
 					{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-3"}},
 				}},
@@ -234,7 +213,7 @@ var _ = Describe("Custom Constraints", func() {
 				Key: fake.IntegerInstanceLabelKey, Operator: v1.NodeSelectorOpGt, Values: []string{"8"},
 			}}
 			ExpectApplied(ctx, env.Client, provisioner)
-			pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod())[0]
+			pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod())[0]
 			node := ExpectScheduled(ctx, env.Client, pod)
 			Expect(node.Labels).To(HaveKeyWithValue(fake.IntegerInstanceLabelKey, "16"))
 		})
@@ -243,13 +222,13 @@ var _ = Describe("Custom Constraints", func() {
 				Key: fake.IntegerInstanceLabelKey, Operator: v1.NodeSelectorOpLt, Values: []string{"8"},
 			}}
 			ExpectApplied(ctx, env.Client, provisioner)
-			pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod())[0]
+			pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod())[0]
 			node := ExpectScheduled(ctx, env.Client, pod)
 			Expect(node.Labels).To(HaveKeyWithValue(fake.IntegerInstanceLabelKey, "2"))
 		})
 		It("should not schedule incompatible preferences and requirements with Operator=In", func() {
 			ExpectApplied(ctx, env.Client, provisioner)
-			pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+			pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 				test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{
 					{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"unknown"}},
 				}},
@@ -258,7 +237,7 @@ var _ = Describe("Custom Constraints", func() {
 		})
 		It("should schedule compatible requirements with Operator=NotIn", func() {
 			ExpectApplied(ctx, env.Client, provisioner)
-			pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+			pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 				test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{
 					{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpNotIn, Values: []string{"test-zone-1", "test-zone-2", "unknown"}},
 				}},
@@ -268,7 +247,7 @@ var _ = Describe("Custom Constraints", func() {
 		})
 		It("should not schedule incompatible preferences and requirements with Operator=NotIn", func() {
 			ExpectApplied(ctx, env.Client, provisioner)
-			pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+			pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 				test.PodOptions{
 					NodeRequirements: []v1.NodeSelectorRequirement{
 						{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpNotIn, Values: []string{"test-zone-1", "test-zone-2", "test-zone-3", "unknown"}},
@@ -278,7 +257,7 @@ var _ = Describe("Custom Constraints", func() {
 		})
 		It("should schedule compatible preferences and requirements with Operator=In", func() {
 			ExpectApplied(ctx, env.Client, provisioner)
-			pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+			pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 				test.PodOptions{
 					NodeRequirements: []v1.NodeSelectorRequirement{
 						{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-1", "test-zone-2", "test-zone-3", "unknown"}}},
@@ -291,7 +270,7 @@ var _ = Describe("Custom Constraints", func() {
 		})
 		It("should schedule incompatible preferences and requirements with Operator=In", func() {
 			ExpectApplied(ctx, env.Client, provisioner)
-			pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+			pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 				test.PodOptions{
 					NodeRequirements: []v1.NodeSelectorRequirement{
 						{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-1", "test-zone-2", "test-zone-3", "unknown"}}},
@@ -303,7 +282,7 @@ var _ = Describe("Custom Constraints", func() {
 		})
 		It("should schedule compatible preferences and requirements with Operator=NotIn", func() {
 			ExpectApplied(ctx, env.Client, provisioner)
-			pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+			pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 				test.PodOptions{
 					NodeRequirements: []v1.NodeSelectorRequirement{
 						{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-1", "test-zone-2", "test-zone-3", "unknown"}}},
@@ -316,7 +295,7 @@ var _ = Describe("Custom Constraints", func() {
 		})
 		It("should schedule incompatible preferences and requirements with Operator=NotIn", func() {
 			ExpectApplied(ctx, env.Client, provisioner)
-			pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+			pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 				test.PodOptions{
 					NodeRequirements: []v1.NodeSelectorRequirement{
 						{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-1", "test-zone-2", "test-zone-3", "unknown"}}},
@@ -328,7 +307,7 @@ var _ = Describe("Custom Constraints", func() {
 		})
 		It("should schedule compatible node selectors, preferences and requirements", func() {
 			ExpectApplied(ctx, env.Client, provisioner)
-			pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+			pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 				test.PodOptions{
 					NodeSelector: map[string]string{v1.LabelTopologyZone: "test-zone-3"},
 					NodeRequirements: []v1.NodeSelectorRequirement{
@@ -342,7 +321,7 @@ var _ = Describe("Custom Constraints", func() {
 		})
 		It("should combine multidimensional node selectors, preferences and requirements", func() {
 			ExpectApplied(ctx, env.Client, provisioner)
-			pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+			pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 				test.PodOptions{
 					NodeSelector: map[string]string{
 						v1.LabelTopologyZone:       "test-zone-3",
@@ -367,7 +346,7 @@ var _ = Describe("Custom Constraints", func() {
 		It("should not schedule pods that have node selectors with restricted labels", func() {
 			ExpectApplied(ctx, env.Client, provisioner)
 			for label := range v1alpha5.RestrictedLabels {
-				pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+				pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 					test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{
 						{Key: label, Operator: v1.NodeSelectorOpIn, Values: []string{"test"}},
 					}}))[0]
@@ -377,7 +356,7 @@ var _ = Describe("Custom Constraints", func() {
 		It("should not schedule pods that have node selectors with restricted domains", func() {
 			ExpectApplied(ctx, env.Client, provisioner)
 			for domain := range v1alpha5.RestrictedLabelDomains {
-				pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+				pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 					test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{
 						{Key: domain + "/test", Operator: v1.NodeSelectorOpIn, Values: []string{"test"}},
 					}}))[0]
@@ -392,7 +371,7 @@ var _ = Describe("Custom Constraints", func() {
 			provisioner.Spec.Requirements = requirements
 			ExpectApplied(ctx, env.Client, provisioner)
 			for domain := range v1alpha5.LabelDomainExceptions {
-				pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod())[0]
+				pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod())[0]
 				node := ExpectScheduled(ctx, env.Client, pod)
 				Expect(node.Labels).To(HaveKeyWithValue(domain+"/test", "test-value"))
 			}
@@ -411,7 +390,7 @@ var _ = Describe("Custom Constraints", func() {
 				test.UnschedulablePod(test.PodOptions{NodeSelector: map[string]string{v1alpha5.LabelCapacityType: "spot"}}),
 			}
 			ExpectApplied(ctx, env.Client, provisioner)
-			for _, pod := range ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, schedulable...) {
+			for _, pod := range ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, schedulable...) {
 				ExpectScheduled(ctx, env.Client, pod)
 			}
 		})
@@ -419,7 +398,7 @@ var _ = Describe("Custom Constraints", func() {
 	Context("Scheduling Logic", func() {
 		It("should not schedule pods that have node selectors with In operator and undefined key", func() {
 			ExpectApplied(ctx, env.Client, provisioner)
-			pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+			pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 				test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{
 					{Key: "test-key", Operator: v1.NodeSelectorOpIn, Values: []string{"test-value"}},
 				}}))[0]
@@ -427,7 +406,7 @@ var _ = Describe("Custom Constraints", func() {
 		})
 		It("should schedule pods that have node selectors with NotIn operator and undefined key", func() {
 			ExpectApplied(ctx, env.Client, provisioner)
-			pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+			pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 				test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{
 					{Key: "test-key", Operator: v1.NodeSelectorOpNotIn, Values: []string{"test-value"}},
 				}}))[0]
@@ -436,7 +415,7 @@ var _ = Describe("Custom Constraints", func() {
 		})
 		It("should not schedule pods that have node selectors with Exists operator and undefined key", func() {
 			ExpectApplied(ctx, env.Client, provisioner)
-			pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+			pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 				test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{
 					{Key: "test-key", Operator: v1.NodeSelectorOpExists},
 				}}))[0]
@@ -444,7 +423,7 @@ var _ = Describe("Custom Constraints", func() {
 		})
 		It("should schedule pods that with DoesNotExists operator and undefined key", func() {
 			ExpectApplied(ctx, env.Client, provisioner)
-			pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+			pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 				test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{
 					{Key: "test-key", Operator: v1.NodeSelectorOpDoesNotExist},
 				}}))[0]
@@ -455,7 +434,7 @@ var _ = Describe("Custom Constraints", func() {
 			provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
 				{Key: "test-key", Operator: v1.NodeSelectorOpIn, Values: []string{"test-value"}}}
 			ExpectApplied(ctx, env.Client, provisioner)
-			pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod())[0]
+			pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod())[0]
 			node := ExpectScheduled(ctx, env.Client, pod)
 			Expect(node.Labels).To(HaveKeyWithValue("test-key", "test-value"))
 		})
@@ -463,7 +442,7 @@ var _ = Describe("Custom Constraints", func() {
 			provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
 				{Key: "test-key", Operator: v1.NodeSelectorOpIn, Values: []string{"test-value"}}}
 			ExpectApplied(ctx, env.Client, provisioner)
-			pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+			pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 				test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{
 					{Key: "test-key", Operator: v1.NodeSelectorOpIn, Values: []string{"test-value"}},
 				}}))[0]
@@ -474,7 +453,7 @@ var _ = Describe("Custom Constraints", func() {
 			provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
 				{Key: "test-key", Operator: v1.NodeSelectorOpIn, Values: []string{"test-value"}}}
 			ExpectApplied(ctx, env.Client, provisioner)
-			pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+			pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 				test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{
 					{Key: "test-key", Operator: v1.NodeSelectorOpNotIn, Values: []string{"test-value"}},
 				}}))[0]
@@ -484,7 +463,7 @@ var _ = Describe("Custom Constraints", func() {
 			provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
 				{Key: "test-key", Operator: v1.NodeSelectorOpIn, Values: []string{"test-value"}}}
 			ExpectApplied(ctx, env.Client, provisioner)
-			pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+			pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 				test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{
 					{Key: "test-key", Operator: v1.NodeSelectorOpExists},
 				}},
@@ -495,7 +474,7 @@ var _ = Describe("Custom Constraints", func() {
 			provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
 				{Key: "test-key", Operator: v1.NodeSelectorOpIn, Values: []string{"test-value"}}}
 			ExpectApplied(ctx, env.Client, provisioner)
-			pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+			pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 				test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{
 					{Key: "test-key", Operator: v1.NodeSelectorOpDoesNotExist},
 				}},
@@ -506,7 +485,7 @@ var _ = Describe("Custom Constraints", func() {
 			provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
 				{Key: "test-key", Operator: v1.NodeSelectorOpIn, Values: []string{"test-value"}}}
 			ExpectApplied(ctx, env.Client, provisioner)
-			pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+			pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 				test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{
 					{Key: "test-key", Operator: v1.NodeSelectorOpIn, Values: []string{"another-value"}},
 				}}))[0]
@@ -516,7 +495,7 @@ var _ = Describe("Custom Constraints", func() {
 			provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
 				{Key: "test-key", Operator: v1.NodeSelectorOpIn, Values: []string{"test-value"}}}
 			ExpectApplied(ctx, env.Client, provisioner)
-			pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+			pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 				test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{
 					{Key: "test-key", Operator: v1.NodeSelectorOpNotIn, Values: []string{"another-value"}},
 				}}))[0]
@@ -527,7 +506,7 @@ var _ = Describe("Custom Constraints", func() {
 			provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
 				{Key: "test-key", Operator: v1.NodeSelectorOpIn, Values: []string{"test-value", "another-value"}}}
 			ExpectApplied(ctx, env.Client, provisioner)
-			pods := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+			pods := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 				test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{
 					{Key: "test-key", Operator: v1.NodeSelectorOpIn, Values: []string{"test-value"}},
 				}}),
@@ -544,7 +523,7 @@ var _ = Describe("Custom Constraints", func() {
 			provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
 				{Key: "test-key", Operator: v1.NodeSelectorOpIn, Values: []string{"test-value", "another-value"}}}
 			ExpectApplied(ctx, env.Client, provisioner)
-			pods := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+			pods := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 				test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{
 					{Key: "test-key", Operator: v1.NodeSelectorOpIn, Values: []string{"test-value"}},
 				}}),
@@ -559,7 +538,7 @@ var _ = Describe("Custom Constraints", func() {
 		})
 		It("Exists operator should not overwrite the existing value", func() {
 			ExpectApplied(ctx, env.Client, provisioner)
-			pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+			pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 				test.PodOptions{
 					NodeRequirements: []v1.NodeSelectorRequirement{
 						{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"non-existent-zone"}},
@@ -586,7 +565,7 @@ var _ = Describe("Preferential Fallback", func() {
 			}}}}
 			// Don't relax
 			ExpectApplied(ctx, env.Client, provisioner)
-			pod = ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, pod)[0]
+			pod = ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, pod)[0]
 			ExpectNotScheduled(ctx, env.Client, pod)
 		})
 		It("should relax multiple terms", func() {
@@ -607,7 +586,7 @@ var _ = Describe("Preferential Fallback", func() {
 			}}}}
 			// Success
 			ExpectApplied(ctx, env.Client, provisioner)
-			pod = ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, pod)[0]
+			pod = ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, pod)[0]
 			node := ExpectScheduled(ctx, env.Client, pod)
 			Expect(node.Labels).To(HaveKeyWithValue(v1.LabelTopologyZone, "test-zone-1"))
 		})
@@ -629,7 +608,7 @@ var _ = Describe("Preferential Fallback", func() {
 			}}}
 			// Success
 			ExpectApplied(ctx, env.Client, provisioner)
-			pod = ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, pod)[0]
+			pod = ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, pod)[0]
 			ExpectScheduled(ctx, env.Client, pod)
 		})
 		It("should relax to use lighter weights", func() {
@@ -655,7 +634,7 @@ var _ = Describe("Preferential Fallback", func() {
 			}}}
 			// Success
 			ExpectApplied(ctx, env.Client, provisioner)
-			pod = ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, pod)[0]
+			pod = ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, pod)[0]
 			node := ExpectScheduled(ctx, env.Client, pod)
 			Expect(node.Labels).To(HaveKeyWithValue(v1.LabelTopologyZone, "test-zone-2"))
 		})
@@ -676,7 +655,7 @@ var _ = Describe("Preferential Fallback", func() {
 			}}
 			// Success
 			ExpectApplied(ctx, env.Client, provisioner)
-			pod = ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, pod)[0]
+			pod = ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, pod)[0]
 			node := ExpectScheduled(ctx, env.Client, pod)
 			Expect(node.Labels).To(HaveKeyWithValue(v1.LabelTopologyZone, "test-zone-3"))
 		})
@@ -686,7 +665,7 @@ var _ = Describe("Preferential Fallback", func() {
 				{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpNotIn, Values: []string{"invalid"}},
 			}})
 			ExpectApplied(ctx, env.Client, provisioner)
-			pod = ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, pod)[0]
+			pod = ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, pod)[0]
 			ExpectScheduled(ctx, env.Client, pod)
 		})
 	})
@@ -697,7 +676,7 @@ var _ = Describe("Topology", func() {
 
 	It("should ignore unknown topology keys", func() {
 		ExpectApplied(ctx, env.Client, provisioner)
-		pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+		pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 			test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: []v1.TopologySpreadConstraint{{
 				TopologyKey:       "unknown",
 				WhenUnsatisfiable: v1.DoNotSchedule,
@@ -716,7 +695,7 @@ var _ = Describe("Topology", func() {
 				MaxSkew:           1,
 			}}
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology}),
 				test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology}),
 				test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology}),
@@ -740,7 +719,7 @@ var _ = Describe("Topology", func() {
 				MaxSkew: 1,
 			}}
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology}),
 				test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology}),
 				test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology}),
@@ -758,7 +737,7 @@ var _ = Describe("Topology", func() {
 				MaxSkew:           1,
 			}}
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology}),
 				test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology}),
 				test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology}),
@@ -775,14 +754,14 @@ var _ = Describe("Topology", func() {
 					v1.ResourceCPU: resource.MustParse("1.1"),
 				},
 			}
-			pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			pods := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels},
 					ResourceRequirements: rr,
 					NodeSelector: map[string]string{
 						v1.LabelTopologyZone: "test-zone-3",
 					},
 				}))
-			ExpectScheduled(ctx, env.Client, pod[0])
+			ExpectScheduled(ctx, env.Client, pods[0])
 
 			provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
 				{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-1", "test-zone-2"}}}
@@ -793,7 +772,7 @@ var _ = Describe("Topology", func() {
 				MaxSkew:           1,
 			}}
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, ResourceRequirements: rr, TopologySpreadConstraints: topology}),
 				test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, ResourceRequirements: rr, TopologySpreadConstraints: topology}),
 				test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, ResourceRequirements: rr, TopologySpreadConstraints: topology}),
@@ -821,7 +800,7 @@ var _ = Describe("Topology", func() {
 			provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
 				{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-1"}}}
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels},
 					ResourceRequirements: rr, TopologySpreadConstraints: topology}))
 			ExpectSkew(ctx, env.Client, "default", &topology[0]).To(ConsistOf(1))
@@ -830,7 +809,7 @@ var _ = Describe("Topology", func() {
 			provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
 				{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-2"}}}
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels},
 					ResourceRequirements: rr, TopologySpreadConstraints: topology}))
 			ExpectSkew(ctx, env.Client, "default", &topology[0]).To(ConsistOf(1, 1))
@@ -839,7 +818,7 @@ var _ = Describe("Topology", func() {
 			provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
 				{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-3"}}}
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				MakePods(10, test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels},
 					ResourceRequirements: rr, TopologySpreadConstraints: topology})...,
 			)
@@ -869,7 +848,7 @@ var _ = Describe("Topology", func() {
 			}
 			// Spread 9 pods
 			ExpectApplied(ctx, env.Client, provisioner)
-			pods := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, createPods(9)...)
+			pods := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, createPods(9)...)
 			ExpectSkew(ctx, env.Client, "default", &topology[0]).To(ConsistOf(3, 3, 3))
 
 			// Delete pods to create a skew
@@ -882,7 +861,7 @@ var _ = Describe("Topology", func() {
 			ExpectSkew(ctx, env.Client, "default", &topology[0]).To(ConsistOf(3))
 
 			// Create 3 more pods, skew should recover
-			_ = ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, createPods(3)...)
+			_ = ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, createPods(3)...)
 			ExpectSkew(ctx, env.Client, "default", &topology[0]).To(ConsistOf(3, 1, 2))
 		})
 		It("should not violate max-skew when unsat = do not schedule", func() {
@@ -901,7 +880,7 @@ var _ = Describe("Topology", func() {
 			provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
 				{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-1"}}}
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels},
 					ResourceRequirements: rr, TopologySpreadConstraints: topology}))
 			ExpectSkew(ctx, env.Client, "default", &topology[0]).To(ConsistOf(1))
@@ -910,7 +889,7 @@ var _ = Describe("Topology", func() {
 			provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
 				{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-2", "test-zone-3"}}}
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				MakePods(10, test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels},
 					ResourceRequirements: rr, TopologySpreadConstraints: topology})...,
 			)
@@ -934,14 +913,14 @@ var _ = Describe("Topology", func() {
 			provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
 				{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-1"}}}
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, ResourceRequirements: rr}))
 
 			// now only allow scheduling pods on zone-2 and zone-3
 			provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
 				{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-2", "test-zone-3"}}}
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				MakePods(10, test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels},
 					TopologySpreadConstraints: topology, ResourceRequirements: rr})...,
 			)
@@ -962,7 +941,7 @@ var _ = Describe("Topology", func() {
 				MaxSkew:           1,
 			}}
 			ExpectApplied(ctx, env.Client, provisioner, firstNode, secondNode, thirdNode, &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: wrongNamespace}})
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				test.Pod(test.PodOptions{NodeName: firstNode.Name}),                                                                                                                         // ignored, missing labels
 				test.Pod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}}),                                                                                                    // ignored, pending
 				test.Pod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, NodeName: thirdNode.Name}),                                                                          // ignored, no domain on node
@@ -987,7 +966,7 @@ var _ = Describe("Topology", func() {
 				MaxSkew:           1,
 			}}
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				test.UnschedulablePod(),
 			)
 			ExpectSkew(ctx, env.Client, "default", &topology[0]).To(ConsistOf(1))
@@ -1000,7 +979,7 @@ var _ = Describe("Topology", func() {
 				MaxSkew:           1,
 			}}
 			ExpectApplied(ctx, env.Client, provisioner)
-			pods := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			pods := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				MakePods(5, test.PodOptions{TopologySpreadConstraints: topology})...,
 			)
 			// This is weird, but the topology label selector is used for determining domain counts. The pod that
@@ -1027,7 +1006,7 @@ var _ = Describe("Topology", func() {
 				MaxSkew:           1,
 			}}
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology}),
 				test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology}),
 				test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology}),
@@ -1043,7 +1022,7 @@ var _ = Describe("Topology", func() {
 				MaxSkew:           4,
 			}}
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology}),
 				test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology}),
 				test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology}),
@@ -1074,7 +1053,7 @@ var _ = Describe("Topology", func() {
 			}
 
 			ExpectApplied(ctx, env.Client, provisioner)
-			scheduled := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			scheduled := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				test.UnschedulablePod(spreadPod("app1")), test.UnschedulablePod(spreadPod("app1")),
 				test.UnschedulablePod(spreadPod("app2")), test.UnschedulablePod(spreadPod("app2")))
 
@@ -1116,7 +1095,7 @@ var _ = Describe("Topology", func() {
 			}
 
 			ExpectApplied(ctx, env.Client, provisioner)
-			scheduled := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			scheduled := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				test.UnschedulablePod(spreadPod("app1", v1alpha5.ArchitectureAmd64)), test.UnschedulablePod(spreadPod("app1", v1alpha5.ArchitectureAmd64)),
 				test.UnschedulablePod(spreadPod("app2", v1alpha5.ArchitectureArm64)), test.UnschedulablePod(spreadPod("app2", v1alpha5.ArchitectureArm64)))
 
@@ -1139,7 +1118,7 @@ var _ = Describe("Topology", func() {
 				MaxSkew:           1,
 			}}
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology}),
 				test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology}),
 				test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology}),
@@ -1157,7 +1136,7 @@ var _ = Describe("Topology", func() {
 				MaxSkew:           1,
 			}}
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology}),
 				test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology}),
 				test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology}),
@@ -1183,7 +1162,7 @@ var _ = Describe("Topology", func() {
 			provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
 				{Key: v1alpha5.LabelCapacityType, Operator: v1.NodeSelectorOpIn, Values: []string{v1alpha5.CapacityTypeSpot}}}
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels},
 					ResourceRequirements: rr, TopologySpreadConstraints: topology}))
 			ExpectSkew(ctx, env.Client, "default", &topology[0]).To(ConsistOf(1))
@@ -1192,7 +1171,7 @@ var _ = Describe("Topology", func() {
 			provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
 				{Key: v1alpha5.LabelCapacityType, Operator: v1.NodeSelectorOpIn, Values: []string{v1alpha5.CapacityTypeOnDemand}}}
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				MakePods(5, test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels},
 					ResourceRequirements: rr, TopologySpreadConstraints: topology})...,
 			)
@@ -1215,7 +1194,7 @@ var _ = Describe("Topology", func() {
 			provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
 				{Key: v1alpha5.LabelCapacityType, Operator: v1.NodeSelectorOpIn, Values: []string{v1alpha5.CapacityTypeSpot}}}
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels},
 					ResourceRequirements: rr, TopologySpreadConstraints: topology}))
 			ExpectSkew(ctx, env.Client, "default", &topology[0]).To(ConsistOf(1))
@@ -1223,7 +1202,7 @@ var _ = Describe("Topology", func() {
 			provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
 				{Key: v1alpha5.LabelCapacityType, Operator: v1.NodeSelectorOpIn, Values: []string{v1alpha5.CapacityTypeOnDemand}}}
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				MakePods(5, test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels},
 					ResourceRequirements: rr, TopologySpreadConstraints: topology})...,
 			)
@@ -1243,7 +1222,7 @@ var _ = Describe("Topology", func() {
 				MaxSkew:           1,
 			}}
 			ExpectApplied(ctx, env.Client, provisioner, firstNode, secondNode, thirdNode, &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: wrongNamespace}})
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				test.Pod(test.PodOptions{NodeName: firstNode.Name}),                                                                                                                         // ignored, missing labels
 				test.Pod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}}),                                                                                                    // ignored, pending
 				test.Pod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, NodeName: thirdNode.Name}),                                                                          // ignored, no domain on node
@@ -1268,7 +1247,7 @@ var _ = Describe("Topology", func() {
 				MaxSkew:           1,
 			}}
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				test.UnschedulablePod(),
 			)
 			ExpectSkew(ctx, env.Client, "default", &topology[0]).To(ConsistOf(1))
@@ -1281,7 +1260,7 @@ var _ = Describe("Topology", func() {
 				MaxSkew:           1,
 			}}
 			ExpectApplied(ctx, env.Client, provisioner)
-			pods := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			pods := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				MakePods(5, test.PodOptions{TopologySpreadConstraints: topology})...,
 			)
 			// This is weird, but the topology label selector is used for determining domain counts. The pod that
@@ -1299,7 +1278,7 @@ var _ = Describe("Topology", func() {
 		})
 		It("should balance pods across capacity-types (node required affinity constrained)", func() {
 			ExpectApplied(ctx, env.Client, provisioner)
-			pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, MakePods(1, test.PodOptions{
+			pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, MakePods(1, test.PodOptions{
 				ObjectMeta: metav1.ObjectMeta{Labels: labels},
 				NodeRequirements: []v1.NodeSelectorRequirement{
 					// launch this on-demand pod in zone-1
@@ -1320,7 +1299,7 @@ var _ = Describe("Topology", func() {
 			// spot node. This doesn't violate the max-skew of 1 as the node selector requirement here excludes the
 			// existing on-demand pod from counting within this topology.
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				MakePods(5, test.PodOptions{
 					ObjectMeta: metav1.ObjectMeta{Labels: labels},
 					// limit our provisioner to only creating spot nodes
@@ -1338,8 +1317,9 @@ var _ = Describe("Topology", func() {
 				Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("2")},
 			}
 			ExpectApplied(ctx, env.Client, provisioner)
-			pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(test.PodOptions{
-				ObjectMeta: metav1.ObjectMeta{Labels: labels},
+			pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(test.PodOptions{
+				ObjectMeta:   metav1.ObjectMeta{Labels: labels},
+				NodeSelector: map[string]string{v1.LabelInstanceTypeStable: "single-pod-instance-type"},
 				NodeRequirements: []v1.NodeSelectorRequirement{
 					{
 						Key:      v1alpha5.LabelCapacityType,
@@ -1347,9 +1327,9 @@ var _ = Describe("Topology", func() {
 						Values:   []string{"on-demand"},
 					},
 				},
-			}))
+			}))[0]
 
-			ExpectScheduled(ctx, env.Client, pod[0])
+			ExpectScheduled(ctx, env.Client, pod)
 
 			topology := []v1.TopologySpreadConstraint{{
 				TopologyKey:       v1alpha5.LabelCapacityType,
@@ -1360,12 +1340,13 @@ var _ = Describe("Topology", func() {
 
 			// limit our provisioner to only creating spot nodes
 			provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
-				{Key: v1alpha5.LabelCapacityType, Operator: v1.NodeSelectorOpIn, Values: []string{"spot"}}}
+				{Key: v1alpha5.LabelCapacityType, Operator: v1.NodeSelectorOpIn, Values: []string{"spot"}},
+			}
 
 			// since there is no node selector on this pod, the topology can see the single on-demand node that already
 			// exists and that limits us to scheduling 2 more spot pods before we would violate max-skew
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				MakePods(5, test.PodOptions{
 					ObjectMeta:                metav1.ObjectMeta{Labels: labels},
 					ResourceRequirements:      rr,
@@ -1379,8 +1360,9 @@ var _ = Describe("Topology", func() {
 				Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("2")},
 			}
 			ExpectApplied(ctx, env.Client, provisioner)
-			pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(test.PodOptions{
-				ObjectMeta: metav1.ObjectMeta{Labels: labels},
+			pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(test.PodOptions{
+				ObjectMeta:   metav1.ObjectMeta{Labels: labels},
+				NodeSelector: map[string]string{v1.LabelInstanceTypeStable: "single-pod-instance-type"},
 				NodeRequirements: []v1.NodeSelectorRequirement{
 					{
 						Key:      v1.LabelArchStable,
@@ -1403,10 +1385,10 @@ var _ = Describe("Topology", func() {
 			provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
 				{Key: v1.LabelArchStable, Operator: v1.NodeSelectorOpIn, Values: []string{"arm64"}}}
 
-			// since there is no node selector on this pod, the topology can see the single on-demand node that already
+			// since there is no node selector on this pod, the topology can see the single arm64 node that already
 			// exists and that limits us to scheduling 2 more spot pods before we would violate max-skew
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				MakePods(5, test.PodOptions{
 					ObjectMeta:                metav1.ObjectMeta{Labels: labels},
 					ResourceRequirements:      rr,
@@ -1431,28 +1413,28 @@ var _ = Describe("Topology", func() {
 				MaxSkew:           3,
 			}}
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				MakePods(2, test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology})...,
 			)
 			ExpectSkew(ctx, env.Client, "default", &topology[0]).To(ConsistOf(1, 1))
 			ExpectSkew(ctx, env.Client, "default", &topology[1]).ToNot(ContainElements(BeNumerically(">", 3)))
 
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				MakePods(3, test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology})...,
 			)
 			ExpectSkew(ctx, env.Client, "default", &topology[0]).To(ConsistOf(2, 2, 1))
 			ExpectSkew(ctx, env.Client, "default", &topology[1]).ToNot(ContainElements(BeNumerically(">", 3)))
 
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				MakePods(5, test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology})...,
 			)
 			ExpectSkew(ctx, env.Client, "default", &topology[0]).To(ConsistOf(4, 3, 3))
 			ExpectSkew(ctx, env.Client, "default", &topology[1]).ToNot(ContainElements(BeNumerically(">", 3)))
 
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				MakePods(11, test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology})...,
 			)
 			ExpectSkew(ctx, env.Client, "default", &topology[0]).To(ConsistOf(7, 7, 7))
@@ -1495,7 +1477,7 @@ var _ = Describe("Topology", func() {
 				MaxSkew:           1,
 			}}
 			ExpectApplied(ctx, env.Client, spotProv, onDemandProv)
-			pods := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, MakePods(20, test.PodOptions{
+			pods := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, MakePods(20, test.PodOptions{
 				ObjectMeta:                metav1.ObjectMeta{Labels: labels},
 				TopologySpreadConstraints: topology,
 			})...)
@@ -1531,7 +1513,7 @@ var _ = Describe("Topology", func() {
 				{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-1", "test-zone-2"}}}
 
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				MakePods(10, test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology})...,
 			)
 
@@ -1556,28 +1538,28 @@ var _ = Describe("Topology", func() {
 				MaxSkew:           3,
 			}}
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				MakePods(2, test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology})...,
 			)
 			ExpectSkew(ctx, env.Client, "default", &topology[0]).To(ConsistOf(1, 1))
 			ExpectSkew(ctx, env.Client, "default", &topology[1]).ToNot(ContainElements(BeNumerically(">", 3)))
 
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				MakePods(3, test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology})...,
 			)
 			ExpectSkew(ctx, env.Client, "default", &topology[0]).To(ConsistOf(3, 2))
 			ExpectSkew(ctx, env.Client, "default", &topology[1]).ToNot(ContainElements(BeNumerically(">", 3)))
 
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				MakePods(5, test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology})...,
 			)
 			ExpectSkew(ctx, env.Client, "default", &topology[0]).To(ConsistOf(5, 5))
 			ExpectSkew(ctx, env.Client, "default", &topology[1]).ToNot(ContainElements(BeNumerically(">", 3)))
 
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				MakePods(11, test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology})...,
 			)
 			ExpectSkew(ctx, env.Client, "default", &topology[0]).To(ConsistOf(11, 10))
@@ -1599,25 +1581,25 @@ var _ = Describe("Topology", func() {
 				MaxSkew:           1,
 			}}
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				MakePods(2, test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology})...,
 			)
 			ExpectSkew(ctx, env.Client, "default", &topology[0]).ToNot(ContainElements(BeNumerically(">", 1)))
 			ExpectSkew(ctx, env.Client, "default", &topology[1]).ToNot(ContainElements(BeNumerically(">", 1)))
 
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				MakePods(3, test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology})...,
 			)
 			ExpectSkew(ctx, env.Client, "default", &topology[0]).ToNot(ContainElements(BeNumerically(">", 3)))
 			ExpectSkew(ctx, env.Client, "default", &topology[1]).ToNot(ContainElements(BeNumerically(">", 2)))
 
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				MakePods(5, test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology})...,
 			)
 			ExpectSkew(ctx, env.Client, "default", &topology[0]).ToNot(ContainElements(BeNumerically(">", 5)))
 			ExpectSkew(ctx, env.Client, "default", &topology[1]).ToNot(ContainElements(BeNumerically(">", 4)))
 
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				MakePods(11, test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology})...,
 			)
 			ExpectSkew(ctx, env.Client, "default", &topology[0]).ToNot(ContainElements(BeNumerically(">", 11)))
@@ -1651,7 +1633,7 @@ var _ = Describe("Topology", func() {
 			for i := 1; i < 15; i++ {
 				pods := MakePods(i, test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology})
 				ExpectApplied(ctx, env.Client, provisioner)
-				ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, pods...)
+				ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, pods...)
 				ExpectMaxSkew(ctx, env.Client, "default", &topology[0]).To(BeNumerically("<=", 1))
 				ExpectMaxSkew(ctx, env.Client, "default", &topology[1]).To(BeNumerically("<=", 2))
 				ExpectMaxSkew(ctx, env.Client, "default", &topology[2]).To(BeNumerically("<=", 3))
@@ -1672,7 +1654,7 @@ var _ = Describe("Topology", func() {
 				MaxSkew:           1,
 			}}
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				append(
 					MakePods(5, test.PodOptions{
 						ObjectMeta:                metav1.ObjectMeta{Labels: labels},
@@ -1698,7 +1680,7 @@ var _ = Describe("Topology", func() {
 				MaxSkew:           1,
 			}}
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				MakePods(10, test.PodOptions{
 					ObjectMeta:                metav1.ObjectMeta{Labels: labels},
 					TopologySpreadConstraints: topology,
@@ -1721,7 +1703,7 @@ var _ = Describe("Topology", func() {
 			}}
 
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				MakePods(6, test.PodOptions{
 					ObjectMeta:                metav1.ObjectMeta{Labels: labels},
 					TopologySpreadConstraints: topology,
@@ -1736,7 +1718,7 @@ var _ = Describe("Topology", func() {
 				{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-1", "test-zone-2", "test-zone-3"}}}
 
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, MakePods(1, test.PodOptions{
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, MakePods(1, test.PodOptions{
 				ObjectMeta:                metav1.ObjectMeta{Labels: labels},
 				TopologySpreadConstraints: topology,
 				NodeRequirements: []v1.NodeSelectorRequirement{{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{
@@ -1748,7 +1730,7 @@ var _ = Describe("Topology", func() {
 			ExpectSkew(ctx, env.Client, "default", &topology[0]).To(ConsistOf(3, 3, 1))
 
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				MakePods(5, test.PodOptions{
 					ObjectMeta:                metav1.ObjectMeta{Labels: labels},
 					TopologySpreadConstraints: topology,
@@ -1768,7 +1750,7 @@ var _ = Describe("Topology", func() {
 				MaxSkew:           1,
 			}}
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				append(
 					MakePods(5, test.PodOptions{
 						ObjectMeta:                metav1.ObjectMeta{Labels: labels},
@@ -1794,7 +1776,7 @@ var _ = Describe("Topology", func() {
 
 			// need to limit the rules to spot or else it will know that on-demand has 0 pods and won't violate the max-skew
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				MakePods(3, test.PodOptions{
 					ObjectMeta:                metav1.ObjectMeta{Labels: labels},
 					TopologySpreadConstraints: topology,
@@ -1806,7 +1788,7 @@ var _ = Describe("Topology", func() {
 
 			// open the rules back to up so it can see all capacity types
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, MakePods(1, test.PodOptions{
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, MakePods(1, test.PodOptions{
 				ObjectMeta:                metav1.ObjectMeta{Labels: labels},
 				TopologySpreadConstraints: topology,
 				NodeRequirements: []v1.NodeSelectorRequirement{
@@ -1818,7 +1800,7 @@ var _ = Describe("Topology", func() {
 			ExpectSkew(ctx, env.Client, "default", &topology[0]).To(ConsistOf(3, 1))
 
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				MakePods(5, test.PodOptions{
 					ObjectMeta:                metav1.ObjectMeta{Labels: labels},
 					TopologySpreadConstraints: topology,
@@ -1832,7 +1814,7 @@ var _ = Describe("Topology", func() {
 		It("should schedule a pod with empty pod affinity and anti-affinity", func() {
 			ExpectApplied(ctx, env.Client)
 			ExpectApplied(ctx, env.Client, provisioner)
-			pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(test.PodOptions{
+			pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(test.PodOptions{
 				PodRequirements:     []v1.PodAffinityTerm{},
 				PodAntiRequirements: []v1.PodAffinityTerm{},
 			}))[0]
@@ -1866,7 +1848,7 @@ var _ = Describe("Topology", func() {
 			pods = append(pods, affPod2)
 
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, pods...)
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, pods...)
 			n1 := ExpectScheduled(ctx, env.Client, affPod1)
 			n2 := ExpectScheduled(ctx, env.Client, affPod2)
 			// should be scheduled on the same node
@@ -1907,7 +1889,7 @@ var _ = Describe("Topology", func() {
 			pods := []*v1.Pod{affPod1, affPod2}
 
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, pods...)
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, pods...)
 			n1 := ExpectScheduled(ctx, env.Client, affPod1)
 			n2 := ExpectScheduled(ctx, env.Client, affPod2)
 			// should be scheduled on a node with the same arch
@@ -1931,7 +1913,7 @@ var _ = Describe("Topology", func() {
 			})
 
 			ExpectApplied(ctx, env.Client, provisioner)
-			pods = ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, pods...)
+			pods = ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, pods...)
 			nodeNames := map[string]struct{}{}
 			for _, p := range pods {
 				n := ExpectScheduled(ctx, env.Client, p)
@@ -1955,7 +1937,7 @@ var _ = Describe("Topology", func() {
 				})
 			}
 			ExpectApplied(ctx, env.Client, provisioner)
-			pods := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, createPods()...)
+			pods := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, createPods()...)
 			nodeNames := map[string]struct{}{}
 			unscheduledCount := 0
 			scheduledCount := 0
@@ -1974,7 +1956,7 @@ var _ = Describe("Topology", func() {
 			Expect(unscheduledCount).To(BeNumerically("==", 5))
 
 			// and pods in a different batch should not schedule as well even if the node is not ready yet
-			pods = ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, createPods()...)
+			pods = ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, createPods()...)
 			for _, p := range pods {
 				ExpectNotScheduled(ctx, env.Client, p)
 			}
@@ -1984,7 +1966,7 @@ var _ = Describe("Topology", func() {
 			// put one pod in test-zone-1, this does affect pod affinity even though we have different node selectors.
 			// The node selector and required node affinity restrictions to topology counting only apply to topology spread.
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(test.PodOptions{
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(test.PodOptions{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: affLabels,
 				},
@@ -2017,7 +1999,7 @@ var _ = Describe("Topology", func() {
 					TopologyKey: v1.LabelHostname,
 				}},
 			})
-			pods = ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, pods...)
+			pods = ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, pods...)
 			for _, p := range pods {
 				// none of this should schedule
 				ExpectNotScheduled(ctx, env.Client, p)
@@ -2039,7 +2021,7 @@ var _ = Describe("Topology", func() {
 			})
 
 			ExpectApplied(ctx, env.Client, provisioner)
-			pods = ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, pods...)
+			pods = ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, pods...)
 			nodeNames := map[string]struct{}{}
 			for _, p := range pods {
 				n := ExpectScheduled(ctx, env.Client, p)
@@ -2069,7 +2051,7 @@ var _ = Describe("Topology", func() {
 				},
 			})
 			ExpectApplied(ctx, env.Client, provisioner)
-			pods = ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, pods...)
+			pods = ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, pods...)
 			nodeNames := map[string]struct{}{}
 			for _, p := range pods {
 				n := ExpectScheduled(ctx, env.Client, p)
@@ -2105,7 +2087,7 @@ var _ = Describe("Topology", func() {
 			pods = append(pods, affPod2)
 
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, pods...)
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, pods...)
 			// should be scheduled as the pod it has affinity to doesn't exist, but it's only a preference and not a
 			// hard constraints
 			ExpectScheduled(ctx, env.Client, affPod2)
@@ -2138,7 +2120,7 @@ var _ = Describe("Topology", func() {
 			pods = append(pods, affPods...)
 
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, pods...)
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, pods...)
 			for _, aff := range affPods {
 				ExpectScheduled(ctx, env.Client, aff)
 			}
@@ -2159,7 +2141,7 @@ var _ = Describe("Topology", func() {
 					TopologyKey: v1.LabelHostname,
 				}}})
 
-				ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, affPod2, affPod1)
+				ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, affPod2, affPod1)
 				n1 := ExpectScheduled(ctx, env.Client, affPod1)
 				n2 := ExpectScheduled(ctx, env.Client, affPod2)
 				// should not be scheduled on the same node
@@ -2196,7 +2178,7 @@ var _ = Describe("Topology", func() {
 				}}})
 
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, zone1Pod, zone2Pod, zone3Pod, affPod)
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, zone1Pod, zone2Pod, zone3Pod, affPod)
 			// the three larger zone specific pods should get scheduled first due to first fit descending onto one
 			// node per zone.
 			ExpectScheduled(ctx, env.Client, zone1Pod)
@@ -2221,7 +2203,7 @@ var _ = Describe("Topology", func() {
 				}}})
 
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, pod, affPod)
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, pod, affPod)
 			// the pod we need to avoid schedules first, but we don't know where.
 			ExpectScheduled(ctx, env.Client, pod)
 			// the pod with anti-affinity
@@ -2264,7 +2246,7 @@ var _ = Describe("Topology", func() {
 			pods := []*v1.Pod{affPod1, affPod2}
 
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, pods...)
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, pods...)
 			n1 := ExpectScheduled(ctx, env.Client, affPod1)
 			n2 := ExpectScheduled(ctx, env.Client, affPod2)
 			// should not be scheduled on nodes with the same arch
@@ -2302,7 +2284,7 @@ var _ = Describe("Topology", func() {
 			affPod := test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: affLabels}})
 
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, zone1Pod, zone2Pod, zone3Pod, affPod)
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, zone1Pod, zone2Pod, zone3Pod, affPod)
 			// three pods with anti-affinity will schedule first due to first fit-descending
 			ExpectScheduled(ctx, env.Client, zone1Pod)
 			ExpectScheduled(ctx, env.Client, zone2Pod)
@@ -2337,7 +2319,7 @@ var _ = Describe("Topology", func() {
 			affPod := test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: affLabels}})
 
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, zone1Pod, zone2Pod, zone3Pod, affPod)
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, zone1Pod, zone2Pod, zone3Pod, affPod)
 			// three pods with anti-affinity will schedule first due to first fit-descending
 			ExpectScheduled(ctx, env.Client, zone1Pod)
 			ExpectScheduled(ctx, env.Client, zone2Pod)
@@ -2364,9 +2346,7 @@ var _ = Describe("Topology", func() {
 			affPod := test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: affLabels}})
 
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, zoneAnywherePod, affPod)
-			ExpectReconcileSucceeded(ctx, podStateController, client.ObjectKeyFromObject(zoneAnywherePod))
-			ExpectReconcileSucceeded(ctx, podStateController, client.ObjectKeyFromObject(affPod))
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, zoneAnywherePod, affPod)
 			// the pod with anti-affinity will schedule first due to first fit-descending, but we don't know which zone it landed in
 			node1 := ExpectScheduled(ctx, env.Client, zoneAnywherePod)
 
@@ -2375,11 +2355,8 @@ var _ = Describe("Topology", func() {
 
 			// a second batching will now allow the pod to schedule as the zoneAnywherePod has been committed to a zone
 			// by the actual node creation
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, affPod)
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, affPod)
 			node2 := ExpectScheduled(ctx, env.Client, affPod)
-			ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node2))
-			ExpectReconcileSucceeded(ctx, podStateController, client.ObjectKeyFromObject(affPod))
-
 			Expect(node1.Labels[v1.LabelTopologyZone]).ToNot(Equal(node2.Labels[v1.LabelTopologyZone]))
 
 		})
@@ -2412,7 +2389,7 @@ var _ = Describe("Topology", func() {
 			// provision these so we get three nodes that exist in the cluster with anti-affinity to a pod that we will
 			// then try to schedule
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, zone1Pod, zone2Pod, zone3Pod)
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, zone1Pod, zone2Pod, zone3Pod)
 			node1 := ExpectScheduled(ctx, env.Client, zone1Pod)
 			node2 := ExpectScheduled(ctx, env.Client, zone2Pod)
 			node3 := ExpectScheduled(ctx, env.Client, zone3Pod)
@@ -2430,7 +2407,7 @@ var _ = Describe("Topology", func() {
 
 			// this pod with no anti-affinity rules can't schedule. It has no anti-affinity rules, but every zone has an
 			// existing pod (not from this batch) with anti-affinity rules that prevent it from scheduling
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, affPod)
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, affPod)
 			ExpectNotScheduled(ctx, env.Client, affPod)
 		})
 		It("should violate preferred pod anti-affinity on zone (inverse w/existing nodes)", func() {
@@ -2467,7 +2444,7 @@ var _ = Describe("Topology", func() {
 			// provision these so we get three nodes that exist in the cluster with anti-affinity to a pod that we will
 			// then try to schedule
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, zone1Pod, zone2Pod, zone3Pod)
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, zone1Pod, zone2Pod, zone3Pod)
 			node1 := ExpectScheduled(ctx, env.Client, zone1Pod)
 			node2 := ExpectScheduled(ctx, env.Client, zone2Pod)
 			node3 := ExpectScheduled(ctx, env.Client, zone3Pod)
@@ -2480,7 +2457,7 @@ var _ = Describe("Topology", func() {
 			ExpectReconcileSucceeded(ctx, podStateController, client.ObjectKeyFromObject(zone3Pod))
 
 			// this pod with no anti-affinity rules can schedule, though it couldn't if the anti-affinity were required
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, affPod)
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, affPod)
 			ExpectScheduled(ctx, env.Client, affPod)
 		})
 		It("should allow violation of a pod affinity preference with a conflicting required constraint", func() {
@@ -2509,7 +2486,7 @@ var _ = Describe("Topology", func() {
 					},
 				}}})
 			ExpectApplied(ctx, env.Client, provisioner)
-			pods := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, append(affPods, affPod1)...)
+			pods := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, append(affPods, affPod1)...)
 			// all pods should be scheduled since the affinity term is just a preference
 			for _, pod := range pods {
 				ExpectScheduled(ctx, env.Client, pod)
@@ -2541,24 +2518,24 @@ var _ = Describe("Topology", func() {
 
 			// one pod pod will schedule
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, createPods()...)
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, createPods()...)
 			ExpectSkew(ctx, env.Client, "default", top).To(ConsistOf(1))
 			// delete all of the unscheduled ones as provisioning will only bind pods passed into the provisioning call
 			// the scheduler looks at all pods though, so it may assume a pod from this batch schedules and no others do
 			ExpectDeleteAllUnscheduledPods(ctx, env.Client)
 
 			// second pod in a second zone
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, createPods()...)
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, createPods()...)
 			ExpectSkew(ctx, env.Client, "default", top).To(ConsistOf(1, 1))
 			ExpectDeleteAllUnscheduledPods(ctx, env.Client)
 
 			// third pod in the last zone
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, createPods()...)
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, createPods()...)
 			ExpectSkew(ctx, env.Client, "default", top).To(ConsistOf(1, 1, 1))
 			ExpectDeleteAllUnscheduledPods(ctx, env.Client)
 
 			// and nothing else can schedule
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, createPods()...)
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, createPods()...)
 			ExpectSkew(ctx, env.Client, "default", top).To(ConsistOf(1, 1, 1))
 			ExpectDeleteAllUnscheduledPods(ctx, env.Client)
 		})
@@ -2573,7 +2550,7 @@ var _ = Describe("Topology", func() {
 				}}})
 
 			ExpectApplied(ctx, env.Client, provisioner)
-			pods := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, affPods...)
+			pods := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, affPods...)
 			// the pod we have affinity to is not in the cluster, so all of these pods are unschedulable
 			for _, p := range pods {
 				ExpectNotScheduled(ctx, env.Client, p)
@@ -2595,7 +2572,7 @@ var _ = Describe("Topology", func() {
 				}}})
 
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, append(affPods, targetPod)...)
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, append(affPods, targetPod)...)
 			top := &v1.TopologySpreadConstraint{TopologyKey: v1.LabelTopologyZone}
 			// these pods can't schedule as the pod they have affinity to isn't limited to any particular zone
 			for i := range affPods {
@@ -2606,7 +2583,7 @@ var _ = Describe("Topology", func() {
 
 			// now that targetPod has been scheduled to a node, it's zone is committed and the pods with affinity to it
 			// should schedule in the same zone
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, affPods...)
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, affPods...)
 			for _, pod := range affPods {
 				ExpectScheduled(ctx, env.Client, pod)
 			}
@@ -2637,7 +2614,7 @@ var _ = Describe("Topology", func() {
 			affPods = append(affPods, affPod1)
 
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, affPods...)
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, affPods...)
 			top := &v1.TopologySpreadConstraint{TopologyKey: v1.LabelTopologyZone}
 			ExpectSkew(ctx, env.Client, "default", top).To(ConsistOf(11))
 		})
@@ -2649,7 +2626,7 @@ var _ = Describe("Topology", func() {
 			for i := 0; i < 50; i++ {
 				ExpectApplied(ctx, env.Client, provisioner.DeepCopy())
 				// we have to schedule DB -> Web -> Cache -> UI in that order or else there are pod affinity violations
-				pods := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+				pods := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 					test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: dbLabels}}),
 					test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: webLabels},
 						PodRequirements: []v1.PodAffinityTerm{{
@@ -2672,6 +2649,7 @@ var _ = Describe("Topology", func() {
 					ExpectScheduled(ctx, env.Client, pods[i])
 				}
 				ExpectCleanedUp(ctx, env.Client)
+				cluster.Reset(ctx)
 			}
 		})
 		It("should fail to schedule pods with unsatisfiable dependencies", func() {
@@ -2680,7 +2658,7 @@ var _ = Describe("Topology", func() {
 			ExpectApplied(ctx, env.Client, provisioner)
 			// this pods wants to schedule with a non-existent pod, this test just ensures that the scheduling loop
 			// doesn't infinite loop
-			pods := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			pods := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: dbLabels},
 					PodRequirements: []v1.PodAffinityTerm{
 						{
@@ -2721,7 +2699,7 @@ var _ = Describe("Topology", func() {
 			pods = append(pods, affPod2)
 
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, pods...)
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, pods...)
 
 			// the target pod gets scheduled
 			ExpectScheduled(ctx, env.Client, affPod1)
@@ -2762,7 +2740,7 @@ var _ = Describe("Topology", func() {
 			pods = append(pods, affPod2)
 
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, pods...)
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, pods...)
 			n1 := ExpectScheduled(ctx, env.Client, affPod1)
 			n2 := ExpectScheduled(ctx, env.Client, affPod2)
 			// should be scheduled on the same node
@@ -2805,7 +2783,7 @@ var _ = Describe("Topology", func() {
 			pods = append(pods, affPod2)
 
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, pods...)
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, pods...)
 			n1 := ExpectScheduled(ctx, env.Client, affPod1)
 			n2 := ExpectScheduled(ctx, env.Client, affPod2)
 			// should be scheduled on the same node due to the empty namespace selector
@@ -2827,7 +2805,7 @@ var _ = Describe("Topology", func() {
 				LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
 				WhenUnsatisfiable: v1.DoNotSchedule,
 			}
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.Pods(10, test.UnscheduleablePodOptions(test.PodOptions{
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.Pods(10, test.UnscheduleablePodOptions(test.PodOptions{
 				ObjectMeta:                metav1.ObjectMeta{Labels: labels},
 				TopologySpreadConstraints: []v1.TopologySpreadConstraint{topology},
 			}))...)
@@ -2850,7 +2828,7 @@ var _ = Describe("Taints", func() {
 	It("should taint nodes with provisioner taints", func() {
 		provisioner.Spec.Taints = []v1.Taint{{Key: "test", Value: "bar", Effect: v1.TaintEffectNoSchedule}}
 		ExpectApplied(ctx, env.Client, provisioner)
-		pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+		pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 			test.PodOptions{Tolerations: []v1.Toleration{{Effect: v1.TaintEffectNoSchedule, Operator: v1.TolerationOpExists}}},
 		))[0]
 		node := ExpectScheduled(ctx, env.Client, pod)
@@ -2859,7 +2837,7 @@ var _ = Describe("Taints", func() {
 	It("should schedule pods that tolerate provisioner constraints", func() {
 		provisioner.Spec.Taints = []v1.Taint{{Key: "test-key", Value: "test-value", Effect: v1.TaintEffectNoSchedule}}
 		ExpectApplied(ctx, env.Client, provisioner)
-		for _, pod := range ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+		for _, pod := range ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 			// Tolerates with OpExists
 			test.UnschedulablePod(test.PodOptions{Tolerations: []v1.Toleration{{Key: "test-key", Operator: v1.TolerationOpExists, Effect: v1.TaintEffectNoSchedule}}}),
 			// Tolerates with OpEqual
@@ -2868,7 +2846,7 @@ var _ = Describe("Taints", func() {
 			ExpectScheduled(ctx, env.Client, pod)
 		}
 		ExpectApplied(ctx, env.Client, provisioner)
-		for _, pod := range ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+		for _, pod := range ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 			// Missing toleration
 			test.UnschedulablePod(),
 			// key mismatch with OpExists
@@ -2883,12 +2861,12 @@ var _ = Describe("Taints", func() {
 		provisioner.Spec.StartupTaints = []v1.Taint{{Key: "ignore-me", Value: "nothing-to-see-here", Effect: v1.TaintEffectNoSchedule}}
 
 		ExpectApplied(ctx, env.Client, provisioner)
-		pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod())[0]
+		pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod())[0]
 		ExpectScheduled(ctx, env.Client, pod)
 	})
 	It("should not generate taints for OpExists", func() {
 		ExpectApplied(ctx, env.Client, provisioner)
-		pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+		pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 			test.UnschedulablePod(test.PodOptions{Tolerations: []v1.Toleration{{Key: "test-key", Operator: v1.TolerationOpExists, Effect: v1.TaintEffectNoExecute}}}),
 		)[0]
 		node := ExpectScheduled(ctx, env.Client, pod)
@@ -2899,7 +2877,7 @@ var _ = Describe("Taints", func() {
 var _ = Describe("Instance Type Compatibility", func() {
 	It("should not schedule if requesting more resources than any instance type has", func() {
 		ExpectApplied(ctx, env.Client, provisioner)
-		pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+		pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 			test.UnschedulablePod(test.PodOptions{
 				ResourceRequirements: v1.ResourceRequirements{
 					Requests: map[v1.ResourceName]resource.Quantity{
@@ -2916,7 +2894,7 @@ var _ = Describe("Instance Type Compatibility", func() {
 		}}
 		nodeNames := sets.NewString()
 		ExpectApplied(ctx, env.Client, provisioner)
-		for _, pod := range ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+		for _, pod := range ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 			test.UnschedulablePod(test.PodOptions{
 				NodeSelector: map[string]string{v1.LabelArchStable: v1alpha5.ArchitectureAmd64},
 			}),
@@ -2935,7 +2913,7 @@ var _ = Describe("Instance Type Compatibility", func() {
 			Values:   []string{v1alpha5.ArchitectureAmd64},
 		}}
 		ExpectApplied(ctx, env.Client, provisioner)
-		pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+		pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 			test.UnschedulablePod(test.PodOptions{
 				NodeRequirements: []v1.NodeSelectorRequirement{
 					{
@@ -2954,7 +2932,7 @@ var _ = Describe("Instance Type Compatibility", func() {
 			Values:   []string{v1alpha5.ArchitectureAmd64},
 		}}
 		ExpectApplied(ctx, env.Client, provisioner)
-		pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+		pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 			test.UnschedulablePod(test.PodOptions{
 				NodeRequirements: []v1.NodeSelectorRequirement{
 					{
@@ -2974,7 +2952,7 @@ var _ = Describe("Instance Type Compatibility", func() {
 			Values:   []string{v1alpha5.ArchitectureAmd64},
 		}}
 		ExpectApplied(ctx, env.Client, provisioner)
-		pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+		pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 			test.UnschedulablePod(test.PodOptions{ResourceRequirements: v1.ResourceRequirements{
 				Limits: map[v1.ResourceName]resource.Quantity{v1.ResourceCPU: resource.MustParse("14")}}}))
 		// only the ARM instance has enough CPU, but it's not allowed per the provisioner
@@ -2988,7 +2966,7 @@ var _ = Describe("Instance Type Compatibility", func() {
 		}}
 		nodeNames := sets.NewString()
 		ExpectApplied(ctx, env.Client, provisioner)
-		for _, pod := range ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+		for _, pod := range ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 			test.UnschedulablePod(test.PodOptions{
 				NodeSelector: map[string]string{v1.LabelOSStable: string(v1.Linux)},
 			}),
@@ -3008,7 +2986,7 @@ var _ = Describe("Instance Type Compatibility", func() {
 		}}
 		nodeNames := sets.NewString()
 		ExpectApplied(ctx, env.Client, provisioner)
-		for _, pod := range ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+		for _, pod := range ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 			test.UnschedulablePod(test.PodOptions{
 				NodeSelector: map[string]string{v1.LabelInstanceType: "small-instance-type"},
 			}),
@@ -3028,7 +3006,7 @@ var _ = Describe("Instance Type Compatibility", func() {
 		}}
 		nodeNames := sets.NewString()
 		ExpectApplied(ctx, env.Client, provisioner)
-		for _, pod := range ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+		for _, pod := range ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 			test.UnschedulablePod(test.PodOptions{
 				NodeSelector: map[string]string{v1.LabelTopologyZone: "test-zone-1"},
 			}),
@@ -3049,7 +3027,7 @@ var _ = Describe("Instance Type Compatibility", func() {
 
 		nodeNames := sets.NewString()
 		ExpectApplied(ctx, env.Client, provisioner)
-		for _, pod := range ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+		for _, pod := range ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 			test.UnschedulablePod(test.PodOptions{
 				ResourceRequirements: v1.ResourceRequirements{
 					Limits: v1.ResourceList{fakeGPU1: resource.MustParse("1")},
@@ -3074,7 +3052,7 @@ var _ = Describe("Instance Type Compatibility", func() {
 		cloudProv.InstanceTypes[1].Capacity[fakeGPU2] = resource.MustParse("25")
 
 		ExpectApplied(ctx, env.Client, provisioner)
-		pods := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+		pods := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 			test.UnschedulablePod(test.PodOptions{
 				ResourceRequirements: v1.ResourceRequirements{
 					Limits: v1.ResourceList{
@@ -3088,7 +3066,7 @@ var _ = Describe("Instance Type Compatibility", func() {
 		It("should filter instance types that match labels", func() {
 			cloudProv.InstanceTypes = fake.InstanceTypes(5)
 			ExpectApplied(ctx, env.Client, provisioner)
-			pods := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			pods := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				test.UnschedulablePod(test.PodOptions{NodeSelector: map[string]string{fake.LabelInstanceSize: "large"}}),
 				test.UnschedulablePod(test.PodOptions{NodeSelector: map[string]string{fake.LabelInstanceSize: "small"}}),
 			)
@@ -3100,7 +3078,7 @@ var _ = Describe("Instance Type Compatibility", func() {
 		It("should not schedule with incompatible labels", func() {
 			cloudProv.InstanceTypes = fake.InstanceTypes(5)
 			ExpectApplied(ctx, env.Client, provisioner)
-			pods := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			pods := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				test.UnschedulablePod(test.PodOptions{NodeSelector: map[string]string{
 					fake.LabelInstanceSize:     "large",
 					v1.LabelInstanceTypeStable: cloudProv.InstanceTypes[0].Name,
@@ -3116,7 +3094,7 @@ var _ = Describe("Instance Type Compatibility", func() {
 		It("should schedule optional labels", func() {
 			cloudProv.InstanceTypes = fake.InstanceTypes(5)
 			ExpectApplied(ctx, env.Client, provisioner)
-			pods := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			pods := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				test.UnschedulablePod(test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{
 					// Only some instance types have this key
 					{Key: fake.ExoticInstanceLabelKey, Operator: v1.NodeSelectorOpExists},
@@ -3129,7 +3107,7 @@ var _ = Describe("Instance Type Compatibility", func() {
 		It("should schedule without optional labels if disallowed", func() {
 			cloudProv.InstanceTypes = fake.InstanceTypes(5)
 			ExpectApplied(ctx, env.Client, test.Provisioner())
-			pods := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			pods := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				test.UnschedulablePod(test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{
 					// Only some instance types have this key
 					{Key: fake.ExoticInstanceLabelKey, Operator: v1.NodeSelectorOpDoesNotExist},
@@ -3155,7 +3133,7 @@ var _ = Describe("Networking constraints", func() {
 			pod2.Spec.Containers[0].Ports = append(pod2.Spec.Containers[0].Ports, port)
 
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, pod1, pod2)
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, pod1, pod2)
 			node1 := ExpectScheduled(ctx, env.Client, pod1)
 			node2 := ExpectScheduled(ctx, env.Client, pod2)
 			Expect(node1.Name).ToNot(Equal(node2.Name))
@@ -3173,7 +3151,7 @@ var _ = Describe("Networking constraints", func() {
 			pod2.Spec.Containers[0].Ports = append(pod2.Spec.Containers[0].Ports, port)
 
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, pod1, pod2)
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, pod1, pod2)
 			node1 := ExpectScheduled(ctx, env.Client, pod1)
 			node2 := ExpectScheduled(ctx, env.Client, pod2)
 			Expect(node1.Name).ToNot(Equal(node2.Name))
@@ -3191,7 +3169,7 @@ var _ = Describe("Networking constraints", func() {
 			pod2.Spec.Containers[0].Ports = append(pod2.Spec.Containers[0].Ports, port)
 
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, pod1, pod2)
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, pod1, pod2)
 			node1 := ExpectScheduled(ctx, env.Client, pod1)
 			node2 := ExpectScheduled(ctx, env.Client, pod2)
 			Expect(node1.Name).ToNot(Equal(node2.Name))
@@ -3211,7 +3189,7 @@ var _ = Describe("Networking constraints", func() {
 			pod2.Spec.Containers[0].Ports = append(pod2.Spec.Containers[0].Ports, port)
 
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, pod1, pod2)
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, pod1, pod2)
 			node1 := ExpectScheduled(ctx, env.Client, pod1)
 			node2 := ExpectScheduled(ctx, env.Client, pod2)
 			Expect(node1.Name).ToNot(Equal(node2.Name))
@@ -3231,11 +3209,11 @@ var _ = Describe("Networking constraints", func() {
 			pod2.Spec.Containers[0].Ports = append(pod2.Spec.Containers[0].Ports, port)
 
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, pod1)
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, pod1)
 			node1 := ExpectScheduled(ctx, env.Client, pod1)
 			ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node1))
 
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, pod2)
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, pod2)
 			node2 := ExpectScheduled(ctx, env.Client, pod2)
 			Expect(node1.Name).ToNot(Equal(node2.Name))
 		})
@@ -3253,7 +3231,7 @@ var _ = Describe("Networking constraints", func() {
 			pod2.Spec.Containers[0].Ports = append(pod2.Spec.Containers[0].Ports, port)
 
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, pod1, pod2)
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, pod1, pod2)
 			node1 := ExpectScheduled(ctx, env.Client, pod1)
 			node2 := ExpectScheduled(ctx, env.Client, pod2)
 			Expect(node1.Name).To(Equal(node2.Name))
@@ -3273,7 +3251,7 @@ var _ = Describe("Networking constraints", func() {
 			pod2.Spec.Containers[0].Ports = append(pod2.Spec.Containers[0].Ports, port)
 
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, pod1, pod2)
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, pod1, pod2)
 			node1 := ExpectScheduled(ctx, env.Client, pod1)
 			node2 := ExpectScheduled(ctx, env.Client, pod2)
 			Expect(node1.Name).To(Equal(node2.Name))
@@ -3290,7 +3268,7 @@ var _ = Describe("Networking constraints", func() {
 			pod2.Spec.Containers[0].Ports = append(pod2.Spec.Containers[0].Ports, port)
 
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, pod1, pod2)
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, pod1, pod2)
 			node1 := ExpectScheduled(ctx, env.Client, pod1)
 			node2 := ExpectScheduled(ctx, env.Client, pod2)
 			Expect(node1.Name).To(Equal(node2.Name))
@@ -3301,7 +3279,7 @@ var _ = Describe("Networking constraints", func() {
 var _ = Describe("Binpacking", func() {
 	It("should schedule a small pod on the smallest instance", func() {
 		ExpectApplied(ctx, env.Client, provisioner)
-		pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+		pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 			test.PodOptions{ResourceRequirements: v1.ResourceRequirements{
 				Requests: map[v1.ResourceName]resource.Quantity{
 					v1.ResourceMemory: resource.MustParse("100M"),
@@ -3312,7 +3290,7 @@ var _ = Describe("Binpacking", func() {
 	})
 	It("should schedule a small pod on the smallest possible instance type", func() {
 		ExpectApplied(ctx, env.Client, provisioner)
-		pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+		pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 			test.PodOptions{ResourceRequirements: v1.ResourceRequirements{
 				Requests: map[v1.ResourceName]resource.Quantity{
 					v1.ResourceMemory: resource.MustParse("2000M"),
@@ -3330,7 +3308,7 @@ var _ = Describe("Binpacking", func() {
 				},
 			}}
 		ExpectApplied(ctx, env.Client, provisioner)
-		pods := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.Pods(5, opts)...)
+		pods := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.Pods(5, opts)...)
 		nodeNames := sets.NewString()
 		for _, p := range pods {
 			node := ExpectScheduled(ctx, env.Client, p)
@@ -3349,7 +3327,7 @@ var _ = Describe("Binpacking", func() {
 				},
 			}}
 		ExpectApplied(ctx, env.Client, provisioner)
-		pods := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.Pods(40, opts)...)
+		pods := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.Pods(40, opts)...)
 		nodeNames := sets.NewString()
 		for _, p := range pods {
 			node := ExpectScheduled(ctx, env.Client, p)
@@ -3381,7 +3359,7 @@ var _ = Describe("Binpacking", func() {
 		// should only end up with 20 nodes total.
 		provPods := append(test.Pods(40, largeOpts), test.Pods(20, smallOpts)...)
 		ExpectApplied(ctx, env.Client, provisioner)
-		pods := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, provPods...)
+		pods := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, provPods...)
 		nodeNames := sets.NewString()
 		for _, p := range pods {
 			node := ExpectScheduled(ctx, env.Client, p)
@@ -3394,7 +3372,7 @@ var _ = Describe("Binpacking", func() {
 		cloudProv.InstanceTypes = fake.InstanceTypes(5)
 		var nodes []*v1.Node
 		ExpectApplied(ctx, env.Client, provisioner)
-		for _, pod := range ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+		for _, pod := range ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 			test.UnschedulablePod(test.PodOptions{
 				ResourceRequirements: v1.ResourceRequirements{
 					Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("4.5")},
@@ -3415,7 +3393,7 @@ var _ = Describe("Binpacking", func() {
 	})
 	It("should handle zero-quantity resource requests", func() {
 		ExpectApplied(ctx, env.Client, provisioner)
-		pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+		pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 			test.UnschedulablePod(test.PodOptions{
 				ResourceRequirements: v1.ResourceRequirements{
 					Requests: v1.ResourceList{"foo.com/weird-resources": resource.MustParse("0")},
@@ -3427,7 +3405,7 @@ var _ = Describe("Binpacking", func() {
 	})
 	It("should not schedule pods that exceed every instance type's capacity", func() {
 		ExpectApplied(ctx, env.Client, provisioner)
-		pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+		pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 			test.PodOptions{ResourceRequirements: v1.ResourceRequirements{
 				Requests: map[v1.ResourceName]resource.Quantity{
 					v1.ResourceMemory: resource.MustParse("2Ti"),
@@ -3446,7 +3424,7 @@ var _ = Describe("Binpacking", func() {
 				},
 			}}
 		ExpectApplied(ctx, env.Client, provisioner)
-		pods := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.Pods(25, opts)...)
+		pods := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.Pods(25, opts)...)
 		nodeNames := sets.NewString()
 		// all of the test instance types support 5 pods each, so we use the 5 instances of the smallest one for our 25 pods
 		for _, p := range pods {
@@ -3458,7 +3436,7 @@ var _ = Describe("Binpacking", func() {
 	})
 	It("should take into account initContainer resource requests when binpacking", func() {
 		ExpectApplied(ctx, env.Client, provisioner)
-		pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+		pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 			test.PodOptions{ResourceRequirements: v1.ResourceRequirements{
 				Requests: map[v1.ResourceName]resource.Quantity{
 					v1.ResourceMemory: resource.MustParse("1Gi"),
@@ -3478,7 +3456,7 @@ var _ = Describe("Binpacking", func() {
 	})
 	It("should not schedule pods when initContainer resource requests are greater than available instance types", func() {
 		ExpectApplied(ctx, env.Client, provisioner)
-		pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+		pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 			test.PodOptions{ResourceRequirements: v1.ResourceRequirements{
 				Requests: map[v1.ResourceName]resource.Quantity{
 					v1.ResourceMemory: resource.MustParse("1Gi"),
@@ -3546,7 +3524,7 @@ var _ = Describe("Binpacking", func() {
 			}),
 		}
 		ExpectApplied(ctx, env.Client, provisioner)
-		pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(
+		pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(
 			test.PodOptions{ResourceRequirements: v1.ResourceRequirements{
 				Limits: map[v1.ResourceName]resource.Quantity{
 					v1.ResourceCPU:    resource.MustParse("1m"),
@@ -3574,17 +3552,17 @@ var _ = Describe("In-Flight Nodes", func() {
 			},
 		}}
 		ExpectApplied(ctx, env.Client, provisioner)
-		initialPod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(opts))
+		initialPod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(opts))
 		node1 := ExpectScheduled(ctx, env.Client, initialPod[0])
 		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node1))
 
-		secondPod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(opts))
+		secondPod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(opts))
 		node2 := ExpectScheduled(ctx, env.Client, secondPod[0])
 		Expect(node1.Name).To(Equal(node2.Name))
 	})
 	It("should not launch a second node if there is an in-flight node that can support the pod (node selectors)", func() {
 		ExpectApplied(ctx, env.Client, provisioner)
-		initialPod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(test.PodOptions{ResourceRequirements: v1.ResourceRequirements{
+		initialPod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(test.PodOptions{ResourceRequirements: v1.ResourceRequirements{
 			Limits: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU: resource.MustParse("10m"),
 			},
@@ -3598,7 +3576,7 @@ var _ = Describe("In-Flight Nodes", func() {
 		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node1))
 
 		// the node gets created in test-zone-2
-		secondPod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(test.PodOptions{ResourceRequirements: v1.ResourceRequirements{
+		secondPod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(test.PodOptions{ResourceRequirements: v1.ResourceRequirements{
 			Limits: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU: resource.MustParse("10m"),
 			},
@@ -3614,7 +3592,7 @@ var _ = Describe("In-Flight Nodes", func() {
 		Expect(node1.Name).To(Equal(node2.Name))
 
 		// the node gets created in test-zone-2
-		thirdPod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(test.PodOptions{ResourceRequirements: v1.ResourceRequirements{
+		thirdPod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(test.PodOptions{ResourceRequirements: v1.ResourceRequirements{
 			Limits: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU: resource.MustParse("10m"),
 			},
@@ -3635,13 +3613,13 @@ var _ = Describe("In-Flight Nodes", func() {
 				v1.ResourceCPU: resource.MustParse("1001m"),
 			},
 		}}
-		initialPod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(opts))
+		initialPod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(opts))
 		node1 := ExpectScheduled(ctx, env.Client, initialPod[0])
 		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node1))
 
 		// the node will have 2000m CPU, so these two pods can't both fit on it
 		opts.ResourceRequirements.Limits[v1.ResourceCPU] = resource.MustParse("1")
-		secondPod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(opts))
+		secondPod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(opts))
 		node2 := ExpectScheduled(ctx, env.Client, secondPod[0])
 		Expect(node1.Name).ToNot(Equal(node2.Name))
 	})
@@ -3652,11 +3630,11 @@ var _ = Describe("In-Flight Nodes", func() {
 				v1.ResourceCPU: resource.MustParse("10m"),
 			},
 		}}
-		initialPod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(opts))
+		initialPod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(opts))
 		node1 := ExpectScheduled(ctx, env.Client, initialPod[0])
 		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node1))
 
-		secondPod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+		secondPod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 			test.UnschedulablePod(test.PodOptions{NodeSelector: map[string]string{v1.LabelArchStable: "arm64"}}))
 		node2 := ExpectScheduled(ctx, env.Client, secondPod[0])
 		Expect(node1.Name).ToNot(Equal(node2.Name))
@@ -3668,7 +3646,7 @@ var _ = Describe("In-Flight Nodes", func() {
 			},
 		}}
 		ExpectApplied(ctx, env.Client, provisioner)
-		initialPod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(opts))
+		initialPod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(opts))
 		node1 := ExpectScheduled(ctx, env.Client, initialPod[0])
 		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node1))
 
@@ -3678,7 +3656,7 @@ var _ = Describe("In-Flight Nodes", func() {
 		ExpectDeleted(ctx, env.Client, node1)
 		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node1))
 
-		secondPod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(opts))
+		secondPod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(opts))
 		node2 := ExpectScheduled(ctx, env.Client, secondPod[0])
 		Expect(node1.Name).ToNot(Equal(node2.Name))
 	})
@@ -3692,7 +3670,7 @@ var _ = Describe("In-Flight Nodes", func() {
 				MaxSkew:           1,
 			}}
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology}),
 				test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology}),
 				test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology}),
@@ -3708,7 +3686,7 @@ var _ = Describe("In-Flight Nodes", func() {
 			}
 
 			firstRoundNumNodes := len(nodeList.Items)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology}),
 				test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology}),
 				test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology}),
@@ -3730,7 +3708,7 @@ var _ = Describe("In-Flight Nodes", func() {
 				MaxSkew:           1,
 			}}
 			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology}),
 				test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology}),
 				test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology}),
@@ -3745,7 +3723,7 @@ var _ = Describe("In-Flight Nodes", func() {
 				ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKey{Name: node.Name})
 			}
 
-			ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov,
+			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
 				test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology}),
 				test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology}),
 				test.UnschedulablePod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology}),
@@ -3764,7 +3742,7 @@ var _ = Describe("In-Flight Nodes", func() {
 				},
 			}}
 			ExpectApplied(ctx, env.Client, provisioner)
-			initialPod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(opts))
+			initialPod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(opts))
 			node1 := ExpectScheduled(ctx, env.Client, initialPod[0])
 
 			// delete the pod so that the node is empty
@@ -3773,7 +3751,7 @@ var _ = Describe("In-Flight Nodes", func() {
 			ExpectApplied(ctx, env.Client, node1)
 			ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node1))
 
-			secondPod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod())
+			secondPod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod())
 			node2 := ExpectScheduled(ctx, env.Client, secondPod[0])
 			Expect(node1.Name).To(Equal(node2.Name))
 		})
@@ -3784,7 +3762,7 @@ var _ = Describe("In-Flight Nodes", func() {
 				},
 			}}
 			ExpectApplied(ctx, env.Client, provisioner)
-			initialPod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(opts))
+			initialPod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(opts))
 			node1 := ExpectScheduled(ctx, env.Client, initialPod[0])
 
 			// delete the pod so that the node is empty
@@ -3798,7 +3776,7 @@ var _ = Describe("In-Flight Nodes", func() {
 			ExpectApplied(ctx, env.Client, node1)
 			ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node1))
 
-			secondPod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod())
+			secondPod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod())
 			node2 := ExpectScheduled(ctx, env.Client, secondPod[0])
 			Expect(node1.Name).ToNot(Equal(node2.Name))
 		})
@@ -3814,7 +3792,7 @@ var _ = Describe("In-Flight Nodes", func() {
 				Effect: v1.TaintEffectNoSchedule,
 			})
 			ExpectApplied(ctx, env.Client, provisioner)
-			initialPod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(opts))
+			initialPod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(opts))
 			node1 := ExpectScheduled(ctx, env.Client, initialPod[0])
 
 			// delete the pod so that the node is empty
@@ -3829,7 +3807,7 @@ var _ = Describe("In-Flight Nodes", func() {
 			ExpectApplied(ctx, env.Client, node1)
 			ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node1))
 
-			secondPod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod())
+			secondPod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod())
 			node2 := ExpectScheduled(ctx, env.Client, secondPod[0])
 			Expect(node1.Name).To(Equal(node2.Name))
 		})
@@ -3837,7 +3815,7 @@ var _ = Describe("In-Flight Nodes", func() {
 			startupTaint := v1.Taint{Key: "ignore-me", Value: "nothing-to-see-here", Effect: v1.TaintEffectNoSchedule}
 			provisioner.Spec.StartupTaints = []v1.Taint{startupTaint}
 			ExpectApplied(ctx, env.Client, provisioner)
-			initialPod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod())
+			initialPod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod())
 			node1 := ExpectScheduled(ctx, env.Client, initialPod[0])
 
 			// delete the pod so that the node is empty
@@ -3853,7 +3831,7 @@ var _ = Describe("In-Flight Nodes", func() {
 			ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node1))
 
 			// we should launch a new node since the startup taint is there, but was gone at some point
-			secondPod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod())
+			secondPod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod())
 			node2 := ExpectScheduled(ctx, env.Client, secondPod[0])
 			Expect(node1.Name).ToNot(Equal(node2.Name))
 		})
@@ -3864,7 +3842,7 @@ var _ = Describe("In-Flight Nodes", func() {
 			ExpectApplied(ctx, env.Client, provisioner)
 
 			// Schedule to New Node
-			pod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(opts))[0]
+			pod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(opts))[0]
 			node1 := ExpectScheduled(ctx, env.Client, pod)
 			ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node1))
 			// Mark Initialized
@@ -3875,7 +3853,7 @@ var _ = Describe("In-Flight Nodes", func() {
 			}
 			ExpectApplied(ctx, env.Client, node1)
 			// Schedule to In Flight Node
-			pod = ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(opts))[0]
+			pod = ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(opts))[0]
 			node2 := ExpectScheduled(ctx, env.Client, pod)
 			ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node2))
 
@@ -3899,7 +3877,7 @@ var _ = Describe("In-Flight Nodes", func() {
 					v1.ResourceCPU: resource.MustParse("8"),
 				},
 			}}
-			initialPod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(opts))
+			initialPod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(opts))
 			node1 := ExpectScheduled(ctx, env.Client, initialPod[0])
 
 			// create our daemonset pod and manually bind it to the node
@@ -3947,7 +3925,7 @@ var _ = Describe("In-Flight Nodes", func() {
 			}}
 			// this pod should schedule on the existingNodes node as the daemonset pod has already bound, meaning that the
 			// remaining daemonset resources should be zero leaving 15 CPUs for the pod
-			secondPod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(opts))
+			secondPod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(opts))
 			node2 := ExpectScheduled(ctx, env.Client, secondPod[0])
 			Expect(node1.Name).To(Equal(node2.Name))
 		})
@@ -3975,7 +3953,7 @@ var _ = Describe("In-Flight Nodes", func() {
 					v1.ResourceCPU: resource.MustParse("8"),
 				},
 			}}
-			initialPod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(opts))
+			initialPod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(opts))
 			node1 := ExpectScheduled(ctx, env.Client, initialPod[0])
 			// this label appears on the node for some reason that Karpenter can't track
 			node1.Labels["my-node-label"] = "value"
@@ -4031,7 +4009,7 @@ var _ = Describe("In-Flight Nodes", func() {
 			// we don't reintroduce a bug where more daemonsets scheduled than anticipated due to unexepected labels
 			// appearing on the node which caused us to compute a negative amount of resources remaining for daemonsets
 			// which in turn caused us to mis-calculate the amount of resources that were free on the node.
-			secondPod := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod(opts))
+			secondPod := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod(opts))
 			node2 := ExpectScheduled(ctx, env.Client, secondPod[0])
 			// must create a new node
 			Expect(node1.Name).ToNot(Equal(node2.Name))
@@ -4060,7 +4038,7 @@ var _ = Describe("In-Flight Nodes", func() {
 
 		// scheduling in multiple batches random sets of pods
 		for i := 0; i < 10; i++ {
-			initialPods := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, MakePods(rand.Intn(10), opts)...)
+			initialPods := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, MakePods(rand.Intn(10), opts)...)
 			for _, pod := range initialPods {
 				node := ExpectScheduled(ctx, env.Client, pod)
 				ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node))
@@ -4224,7 +4202,7 @@ var _ = Describe("Volume Limits", func() {
 
 		provisioner.Spec.Limits = nil
 		ExpectApplied(ctx, env.Client, provisioner)
-		initialPods := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod())
+		initialPods := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod())
 		node := ExpectScheduled(ctx, env.Client, initialPods[0])
 		csiNode := &storagev1.CSINode{
 			ObjectMeta: metav1.ObjectMeta{
@@ -4266,7 +4244,7 @@ var _ = Describe("Volume Limits", func() {
 				PersistentVolumeClaims: []string{pvcA.Name, pvcB.Name},
 			}))
 		}
-		ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, pods...)
+		ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, pods...)
 		var nodeList v1.NodeList
 		Expect(env.Client.List(ctx, &nodeList)).To(Succeed())
 		// we need to create a new node as the in-flight one can only contain 5 pods due to the CSINode volume limit
@@ -4287,7 +4265,7 @@ var _ = Describe("Volume Limits", func() {
 
 		provisioner.Spec.Limits = nil
 		ExpectApplied(ctx, env.Client, provisioner)
-		initialPods := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod())
+		initialPods := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod())
 		node := ExpectScheduled(ctx, env.Client, initialPods[0])
 		csiNode := &storagev1.CSINode{
 			ObjectMeta: metav1.ObjectMeta{
@@ -4332,7 +4310,7 @@ var _ = Describe("Volume Limits", func() {
 			}))
 		}
 		ExpectApplied(ctx, env.Client, provisioner)
-		ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, pods...)
+		ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, pods...)
 		var nodeList v1.NodeList
 		Expect(env.Client.List(ctx, &nodeList)).To(Succeed())
 		// 100 of the same PVC should all be schedulable on the same node
@@ -4353,7 +4331,7 @@ var _ = Describe("Volume Limits", func() {
 
 		provisioner.Spec.Limits = nil
 		ExpectApplied(ctx, env.Client, provisioner)
-		initialPods := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod())
+		initialPods := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod())
 		node := ExpectScheduled(ctx, env.Client, initialPods[0])
 		csiNode := &storagev1.CSINode{
 			ObjectMeta: metav1.ObjectMeta{
@@ -4399,7 +4377,7 @@ var _ = Describe("Volume Limits", func() {
 			}))
 		}
 		ExpectApplied(ctx, env.Client, provisioner)
-		_ = ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, pods...)
+		_ = ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, pods...)
 
 		var nodeList v1.NodeList
 		Expect(env.Client.List(ctx, &nodeList)).To(Succeed())
@@ -4420,7 +4398,7 @@ var _ = Describe("Volume Limits", func() {
 
 		provisioner.Spec.Limits = nil
 		ExpectApplied(ctx, env.Client, provisioner)
-		initialPods := ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, test.UnschedulablePod())
+		initialPods := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod())
 		node := ExpectScheduled(ctx, env.Client, initialPods[0])
 		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node))
 
@@ -4448,7 +4426,7 @@ var _ = Describe("Volume Limits", func() {
 			}))
 		}
 		ExpectApplied(ctx, env.Client, provisioner)
-		_ = ExpectProvisioned(ctx, env.Client, recorder, provisioningController, prov, pods...)
+		_ = ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, pods...)
 
 		var nodeList v1.NodeList
 		Expect(env.Client.List(ctx, &nodeList)).To(Succeed())

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -29,7 +29,6 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/clock"
 	"knative.dev/pkg/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -47,20 +46,17 @@ type observerFunc func(string)
 
 // Cluster maintains cluster state that is often needed but expensive to compute.
 type Cluster struct {
-	kubeClient    client.Client
-	cloudProvider cloudprovider.CloudProvider
-	clock         clock.Clock
-
-	// Pod Specific Tracking
-	antiAffinityPods sync.Map // mapping of pod namespaced name to *v1.Pod of pods that have required anti affinities
-
-	nominatedNodes         *cache.Cache
+	kubeClient             client.Client
+	cloudProvider          cloudprovider.CloudProvider
+	clock                  clock.Clock
 	nominatedNodeObservers atomicutils.Slice[observerFunc]
 
-	// Node Status & Pod -> Node Binding
-	mu       sync.RWMutex
-	nodes    map[string]*Node                // node name -> node
-	bindings map[types.NamespacedName]string // pod namespaced named -> node name
+	// State: Node Status & Pod -> Node Binding
+	mu               sync.RWMutex
+	nodes            map[string]*Node // node name -> node
+	nominatedNodes   *cache.Cache
+	bindings         map[types.NamespacedName]string // pod namespaced named -> node name
+	antiAffinityPods sync.Map                        // mapping of pod namespaced name to *v1.Pod of pods that have required anti affinities
 
 	// consolidationState is a number indicating the state of the cluster with respect to consolidation.  If this number
 	// hasn't changed, it indicates that the cluster hasn't changed in a state which would enable consolidation if
@@ -352,7 +348,7 @@ func (c *Cluster) populateVolumeLimits(ctx context.Context, node *v1.Node, n *No
 	return nil
 }
 
-func (c *Cluster) deleteNode(nodeName string) {
+func (c *Cluster) DeleteNode(nodeName string) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	delete(c.nodes, nodeName)
@@ -360,13 +356,13 @@ func (c *Cluster) deleteNode(nodeName string) {
 }
 
 // updateNode is called for every node reconciliation
-func (c *Cluster) updateNode(ctx context.Context, node *v1.Node) error {
+func (c *Cluster) UpdateNode(ctx context.Context, node *v1.Node) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	n, err := c.newNode(ctx, node)
 	if err != nil {
 		// ensure that the out of date node is forgotten
-		delete(c.nodes, node.Name)
+		c.DeleteNode(node.Name)
 		return err
 	}
 
@@ -423,7 +419,7 @@ func (c *Cluster) LastNodeCreationTime() time.Time {
 }
 
 // deletePod is called when the pod has been deleted
-func (c *Cluster) deletePod(podKey types.NamespacedName) {
+func (c *Cluster) DeletePod(podKey types.NamespacedName) {
 	c.antiAffinityPods.Delete(podKey)
 	c.updateNodeUsageFromPodCompletion(podKey)
 	c.recordConsolidationChange()
@@ -461,7 +457,7 @@ func (c *Cluster) updateNodeUsageFromPodCompletion(podKey types.NamespacedName) 
 }
 
 // updatePod is called every time the pod is reconciled
-func (c *Cluster) updatePod(ctx context.Context, pod *v1.Pod) error {
+func (c *Cluster) UpdatePod(ctx context.Context, pod *v1.Pod) error {
 	var err error
 	if podutils.IsTerminal(pod) {
 		c.updateNodeUsageFromPodCompletion(client.ObjectKeyFromObject(pod))
@@ -560,32 +556,14 @@ func (c *Cluster) updateNodeUsageFromPod(ctx context.Context, pod *v1.Pod) error
 	return nil
 }
 
-// Synchronized ensures that our cluster state is aware of at least all of the nodes that our list cache has.
-// Since we launch nodes in parallel, we can create many node objects which may not all be reconciled by the cluster
-// state before we start trying to schedule again.  In this case, we would over-provision as we weren't aware of the
-// inflight nodes.
-func (c *Cluster) Synchronized(ctx context.Context) error {
-	// collect the nodes known by the kube API server
-	var nodes v1.NodeList
-	if err := c.kubeClient.List(ctx, &nodes); err != nil {
-		return err
-	}
-	unknownNodes := sets.NewString()
-	for _, n := range nodes.Items {
-		unknownNodes.Insert(n.Name)
-	}
-	// delete any that cluster state already knows about
-	c.ForEachNode(func(n *Node) bool {
-		unknownNodes.Delete(n.Node.Name)
-		return true
-	})
-	// and we're left with nodes which exist, but haven't reconciled with cluster state yet
-	if len(unknownNodes) != 0 {
-		return fmt.Errorf("%d/%d nodes not yet synchronized", unknownNodes.Len(), len(nodes.Items))
-	}
-	return nil
-}
-
 func (c *Cluster) recordConsolidationChange() {
 	atomic.StoreInt64(&c.consolidationState, c.clock.Now().UnixMilli())
+}
+
+func (c *Cluster) Reset(ctx context.Context) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.nodes = map[string]*Node{}
+	c.bindings = map[types.NamespacedName]string{}
+	c.antiAffinityPods = sync.Map{}
 }

--- a/pkg/controllers/state/node.go
+++ b/pkg/controllers/state/node.go
@@ -53,11 +53,11 @@ func (c *NodeController) Reconcile(ctx context.Context, req reconcile.Request) (
 	if err := c.kubeClient.Get(ctx, req.NamespacedName, node); err != nil {
 		if errors.IsNotFound(err) {
 			// notify cluster state of the node deletion
-			c.cluster.deleteNode(req.Name)
+			c.cluster.DeleteNode(req.Name)
 		}
 		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
-	if err := c.cluster.updateNode(ctx, node); err != nil {
+	if err := c.cluster.UpdateNode(ctx, node); err != nil {
 		return reconcile.Result{}, err
 	}
 	// ensure it's aware of any nodes we discover, this is a no-op if the node is already known to our cluster state

--- a/pkg/controllers/state/pod.go
+++ b/pkg/controllers/state/pod.go
@@ -55,11 +55,11 @@ func (c *PodController) Reconcile(ctx context.Context, req reconcile.Request) (r
 	if err := c.kubeClient.Get(ctx, req.NamespacedName, pod); err != nil {
 		if errors.IsNotFound(err) {
 			// notify cluster state of the node deletion
-			c.cluster.deletePod(req.NamespacedName)
+			c.cluster.DeletePod(req.NamespacedName)
 		}
 		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
-	if err := c.cluster.updatePod(ctx, pod); err != nil {
+	if err := c.cluster.UpdatePod(ctx, pod); err != nil {
 		return reconcile.Result{}, err
 	}
 	return reconcile.Result{Requeue: true, RequeueAfter: stateRetryPeriod}, nil


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

dynamically update cluster state, rather than waiting for sync

Remove the special testing flow in the provisioner and more accurately model cluster state during tests.

**How was this change tested?**

`make test`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
