### PR TITLE
fix: add our volume selector zone requirement to all terms

### DIFF
--- a/pkg/controllers/provisioning/volumetopology.go
+++ b/pkg/controllers/provisioning/volumetopology.go
@@ -57,8 +57,13 @@ func (v *VolumeTopology) Inject(ctx context.Context, pod *v1.Pod) error {
 	if len(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms) == 0 {
 		pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = []v1.NodeSelectorTerm{{}}
 	}
-	pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions = append(
-		pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions, requirements...)
+
+	// We add our volume topology zonal requirement to every node selector term.  This causes it to be AND'd with every existing
+	// requirement so that relaxation won't remove our volume requirement.
+	for i := 0; i < len(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms); i++ {
+		pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[i].MatchExpressions = append(
+			pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[i].MatchExpressions, requirements...)
+	}
 	return nil
 }
 

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -93,7 +93,7 @@ func ExpectNotFoundWithOffset(offset int, ctx context.Context, c client.Client, 
 
 func ExpectScheduled(ctx context.Context, c client.Client, pod *v1.Pod) *v1.Node {
 	p := ExpectPodExistsWithOffset(1, ctx, c, pod.Name, pod.Namespace)
-	Expect(p.Spec.NodeName).ToNot(BeEmpty(), fmt.Sprintf("expected %s/%s to be scheduled", pod.Namespace, pod.Name))
+	ExpectWithOffset(1, p.Spec.NodeName).ToNot(BeEmpty(), fmt.Sprintf("expected %s/%s to be scheduled", pod.Namespace, pod.Name))
 	return ExpectNodeExistsWithOffset(1, ctx, c, p.Spec.NodeName)
 }
 


### PR DESCRIPTION
Fixes [#2971](https://github.com/aws/karpenter/issues/2971)

**Description**

Node selector terms are OR'd together, so our relaxation removes them one at a time when we are unable to schedule.  This change ensures we add the volume topology zone requirement to all terms instead of just  the first one so the relaxation process won't remove it causing us to think a pod will schedule, when it won't.


**How was this change tested?**
Unit testing & deployed to EKS.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
