### PR TITLE
chore: remove K8s 1.20 from CI

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
         matrix:
-          k8sVersion: ["1.20.x", "1.21.x", "1.22.x", "1.23.x", "1.24.x"]
+          k8sVersion: ["1.21.x", "1.22.x", "1.23.x", "1.24.x"]
     env:
       K8S_VERSION: ${{ matrix.k8sVersion }}
     steps:


### PR DESCRIPTION
**Description**
chore: remove K8s 1.20 from CI
**How was this change tested?**


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
