### PR TITLE
Use a machine generated from a node for the termination loop

### DIFF
--- a/pkg/cloudprovider/fake/cloudprovider.go
+++ b/pkg/cloudprovider/fake/cloudprovider.go
@@ -157,7 +157,7 @@ func (c *CloudProvider) GetInstanceTypes(_ context.Context, _ *v1alpha5.Provisio
 	}, nil
 }
 
-func (c *CloudProvider) Delete(context.Context, *v1.Node) error {
+func (c *CloudProvider) Delete(context.Context, *v1alpha1.Machine) error {
 	return nil
 }
 

--- a/pkg/cloudprovider/metrics/cloudprovider.go
+++ b/pkg/cloudprovider/metrics/cloudprovider.go
@@ -73,9 +73,9 @@ func (d *decorator) Create(ctx context.Context, machine *v1alpha1.Machine) (*v1.
 	return d.CloudProvider.Create(ctx, machine)
 }
 
-func (d *decorator) Delete(ctx context.Context, node *v1.Node) error {
+func (d *decorator) Delete(ctx context.Context, machine *v1alpha1.Machine) error {
 	defer metrics.Measure(methodDurationHistogramVec.WithLabelValues(injection.GetControllerName(ctx), "Delete", d.Name()))()
-	return d.CloudProvider.Delete(ctx, node)
+	return d.CloudProvider.Delete(ctx, machine)
 }
 
 func (d *decorator) GetInstanceTypes(ctx context.Context, provisioner *v1alpha5.Provisioner) ([]*cloudprovider.InstanceType, error) {

--- a/pkg/cloudprovider/types.go
+++ b/pkg/cloudprovider/types.go
@@ -53,7 +53,7 @@ type CloudProvider interface {
 	// is fulfilled by the cloud providers capacity creation request.
 	Create(context.Context, *v1alpha1.Machine) (*v1.Node, error)
 	// Delete node in cloudprovider
-	Delete(context.Context, *v1.Node) error
+	Delete(context.Context, *v1alpha1.Machine) error
 	// GetInstanceTypes returns instance types supported by the cloudprovider.
 	// Availability of types or zone may vary by provisioner or over time.  Regardless of
 	// availability, the GetInstanceTypes method should always return all instance types,

--- a/pkg/controllers/termination/terminate.go
+++ b/pkg/controllers/termination/terminate.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/samber/lo"
 
+	"github.com/aws/karpenter-core/pkg/apis/v1alpha1"
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
 	podutil "github.com/aws/karpenter-core/pkg/utils/pod"
@@ -98,7 +99,7 @@ func (t *Terminator) drain(ctx context.Context, node *v1.Node) error {
 func (t *Terminator) terminate(ctx context.Context, node *v1.Node) error {
 	stored := node.DeepCopy()
 	// Delete the instance associated with node
-	if err := t.CloudProvider.Delete(ctx, node); err != nil {
+	if err := t.CloudProvider.Delete(ctx, v1alpha1.MachineFromNode(node)); err != nil {
 		return fmt.Errorf("terminating cloudprovider instance, %w", err)
 	}
 	controllerutil.RemoveFinalizer(node, v1alpha5.TerminationFinalizer)


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

- Use a machine generated from a node for termination

**How was this change tested?**

`make presubmit`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
