### PR TITLE
fix: Fix bug where metric gauges are not deleted on pod/provisioner delete

### DIFF
--- a/pkg/controllers/metrics/pod/suite_test.go
+++ b/pkg/controllers/metrics/pod/suite_test.go
@@ -16,12 +16,10 @@ package pod_test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	prometheus "github.com/prometheus/client_model/go"
 	. "knative.dev/pkg/logging/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -57,21 +55,22 @@ var _ = Describe("Pod Metrics", func() {
 		ExpectApplied(ctx, env.Client, p)
 		ExpectReconcileSucceeded(ctx, podController, client.ObjectKeyFromObject(p))
 
-		podState := ExpectMetric("karpenter_pods_state")
-		ExpectMetricLabel(podState, "name", p.GetName())
-		ExpectMetricLabel(podState, "namespace", p.GetNamespace())
+		ExpectMetricExistsWithLabelValues("karpenter_pods_state", map[string]string{
+			"name":      p.GetName(),
+			"namespace": p.GetNamespace(),
+		}).To(BeTrue())
+	})
+	It("should delete the pod state metric on pod delete", func() {
+		p := test.Pod()
+		ExpectApplied(ctx, env.Client, p)
+		ExpectReconcileSucceeded(ctx, podController, client.ObjectKeyFromObject(p))
+
+		ExpectDeleted(ctx, env.Client, p)
+		ExpectReconcileSucceeded(ctx, podController, client.ObjectKeyFromObject(p))
+
+		ExpectMetricExistsWithLabelValues("karpenter_pods_state", map[string]string{
+			"name":      p.GetName(),
+			"namespace": p.GetNamespace(),
+		}).To(BeFalse())
 	})
 })
-
-func ExpectMetricLabel(mf *prometheus.MetricFamily, name string, value string) {
-	found := false
-	for _, m := range mf.Metric {
-		for _, l := range m.Label {
-			if l.GetName() == name {
-				Expect(l.GetValue()).To(Equal(value), fmt.Sprintf("expected metrics %s = %s", name, value))
-				found = true
-			}
-		}
-	}
-	Expect(found).To(BeTrue())
-}

--- a/pkg/controllers/metrics/provisioner/suite_test.go
+++ b/pkg/controllers/metrics/provisioner/suite_test.go
@@ -1,0 +1,169 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provisioner_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	. "knative.dev/pkg/logging/testing"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/aws/karpenter-core/pkg/apis"
+	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
+	"github.com/aws/karpenter-core/pkg/controllers/metrics/provisioner"
+	"github.com/aws/karpenter-core/pkg/operator/controller"
+	"github.com/aws/karpenter-core/pkg/operator/scheme"
+	"github.com/aws/karpenter-core/pkg/test"
+	. "github.com/aws/karpenter-core/pkg/test/expectations"
+)
+
+var provisionerController controller.Controller
+var ctx context.Context
+var env *test.Environment
+
+func TestAPIs(t *testing.T) {
+	ctx = TestContextWithLogger(t)
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Controllers/Metrics/Provisioner")
+}
+
+var _ = BeforeSuite(func() {
+	env = test.NewEnvironment(scheme.Scheme, apis.CRDs...)
+	provisionerController = provisioner.NewController(env.Client)
+})
+
+var _ = AfterSuite(func() {
+	Expect(env.Stop()).To(Succeed(), "Failed to stop environment")
+})
+
+var _ = Describe("Provisioner Metrics", func() {
+	It("should update the provisioner limit metrics", func() {
+		limits := v1.ResourceList{
+			v1.ResourceCPU:              resource.MustParse("10"),
+			v1.ResourceMemory:           resource.MustParse("10Mi"),
+			v1.ResourceEphemeralStorage: resource.MustParse("100Gi"),
+		}
+		provisioner := test.Provisioner(test.ProvisionerOptions{
+			Limits: limits,
+		})
+		ExpectApplied(ctx, env.Client, provisioner)
+		ExpectReconcileSucceeded(ctx, provisionerController, client.ObjectKeyFromObject(provisioner))
+
+		for k, v := range limits {
+			m, found := FindMetricWithLabelValues("karpenter_provisioner_limit", map[string]string{
+				"provisioner":   provisioner.GetName(),
+				"resource_type": strings.ReplaceAll(k.String(), "-", "_"),
+			})
+			Expect(found).To(BeTrue())
+			Expect(m.GetGauge().GetValue()).To(BeNumerically("~", v.AsApproximateFloat64()))
+		}
+	})
+	It("should update the provisioner usage metrics", func() {
+		resources := v1.ResourceList{
+			v1.ResourceCPU:              resource.MustParse("10"),
+			v1.ResourceMemory:           resource.MustParse("10Mi"),
+			v1.ResourceEphemeralStorage: resource.MustParse("100Gi"),
+		}
+
+		provisioner := test.Provisioner(test.ProvisionerOptions{
+			Status: v1alpha5.ProvisionerStatus{
+				Resources: resources,
+			},
+		})
+		ExpectApplied(ctx, env.Client, provisioner)
+		ExpectReconcileSucceeded(ctx, provisionerController, client.ObjectKeyFromObject(provisioner))
+
+		for k, v := range resources {
+			m, found := FindMetricWithLabelValues("karpenter_provisioner_usage", map[string]string{
+				"provisioner":   provisioner.GetName(),
+				"resource_type": strings.ReplaceAll(k.String(), "-", "_"),
+			})
+			Expect(found).To(BeTrue())
+			Expect(m.GetGauge().GetValue()).To(BeNumerically("~", v.AsApproximateFloat64()))
+		}
+	})
+	It("should update the usage percentage metrics correctly", func() {
+		resources := v1.ResourceList{
+			v1.ResourceCPU:              resource.MustParse("10"),
+			v1.ResourceMemory:           resource.MustParse("10Mi"),
+			v1.ResourceEphemeralStorage: resource.MustParse("100Gi"),
+		}
+		limits := v1.ResourceList{
+			v1.ResourceCPU:              resource.MustParse("100"),
+			v1.ResourceMemory:           resource.MustParse("100Mi"),
+			v1.ResourceEphemeralStorage: resource.MustParse("1000Gi"),
+		}
+
+		provisioner := test.Provisioner(test.ProvisionerOptions{
+			Limits: limits,
+			Status: v1alpha5.ProvisionerStatus{
+				Resources: resources,
+			},
+		})
+		ExpectApplied(ctx, env.Client, provisioner)
+		ExpectReconcileSucceeded(ctx, provisionerController, client.ObjectKeyFromObject(provisioner))
+
+		for k := range resources {
+			m, found := FindMetricWithLabelValues("karpenter_provisioner_usage_pct", map[string]string{
+				"provisioner":   provisioner.GetName(),
+				"resource_type": strings.ReplaceAll(k.String(), "-", "_"),
+			})
+			Expect(found).To(BeTrue())
+			Expect(m.GetGauge().GetValue()).To(BeNumerically("~", 10))
+		}
+	})
+	It("should delete the provisioner state metrics on provisioner delete", func() {
+		expectedMetrics := []string{"karpenter_provisioner_limit", "karpenter_provisioner_usage", "karpenter_provisioner_usage_pct"}
+		provisioner := test.Provisioner(test.ProvisionerOptions{
+			Limits: v1.ResourceList{
+				v1.ResourceCPU:              resource.MustParse("100"),
+				v1.ResourceMemory:           resource.MustParse("100Mi"),
+				v1.ResourceEphemeralStorage: resource.MustParse("1000Gi"),
+			},
+			Status: v1alpha5.ProvisionerStatus{
+				Resources: v1.ResourceList{
+					v1.ResourceCPU:              resource.MustParse("10"),
+					v1.ResourceMemory:           resource.MustParse("10Mi"),
+					v1.ResourceEphemeralStorage: resource.MustParse("100Gi"),
+				},
+			},
+		})
+		ExpectApplied(ctx, env.Client, provisioner)
+		ExpectReconcileSucceeded(ctx, provisionerController, client.ObjectKeyFromObject(provisioner))
+
+		for _, name := range expectedMetrics {
+			_, found := FindMetricWithLabelValues(name, map[string]string{
+				"provisioner": provisioner.GetName(),
+			})
+			Expect(found).To(BeTrue())
+		}
+
+		ExpectDeleted(ctx, env.Client, provisioner)
+		ExpectReconcileSucceeded(ctx, provisionerController, client.ObjectKeyFromObject(provisioner))
+
+		for _, name := range expectedMetrics {
+			_, found := FindMetricWithLabelValues(name, map[string]string{
+				"provisioner": provisioner.GetName(),
+			})
+			Expect(found).To(BeFalse())
+		}
+	})
+})

--- a/pkg/controllers/metrics/state/suite_test.go
+++ b/pkg/controllers/metrics/state/suite_test.go
@@ -16,13 +16,12 @@ package metrics_test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 	"time"
 
+	"k8s.io/apimachinery/pkg/types"
 	clock "k8s.io/utils/clock/testing"
 
-	io_prometheus_client "github.com/prometheus/client_model/go"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,7 +30,7 @@ import (
 	"github.com/aws/karpenter-core/pkg/apis"
 	"github.com/aws/karpenter-core/pkg/apis/config/settings"
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
-	statemetrics "github.com/aws/karpenter-core/pkg/controllers/metrics/state/scraper"
+	metricsstate "github.com/aws/karpenter-core/pkg/controllers/metrics/state"
 	"github.com/aws/karpenter-core/pkg/operator/controller"
 	"github.com/aws/karpenter-core/pkg/operator/scheme"
 
@@ -52,9 +51,9 @@ var env *test.Environment
 var cluster *state.Cluster
 var nodeController controller.Controller
 var podController controller.Controller
+var metricsStateController controller.Controller
 var cloudProvider *fake.CloudProvider
 var provisioner *v1alpha5.Provisioner
-var nodeScraper *statemetrics.NodeScraper
 
 func TestAPIs(t *testing.T) {
 	ctx = TestContextWithLogger(t)
@@ -73,7 +72,7 @@ var _ = BeforeSuite(func() {
 	provisioner = test.Provisioner(test.ProvisionerOptions{ObjectMeta: metav1.ObjectMeta{Name: "default"}})
 	nodeController = state.NewNodeController(env.Client, cluster)
 	podController = state.NewPodController(env.Client, cluster)
-	nodeScraper = statemetrics.NewNodeScraper(cluster)
+	metricsStateController = metricsstate.NewController(cluster)
 	ExpectApplied(ctx, env.Client, provisioner)
 })
 
@@ -93,34 +92,41 @@ var _ = Describe("Node Metrics", func() {
 		node := test.Node(test.NodeOptions{Allocatable: resources})
 		ExpectApplied(ctx, env.Client, node)
 		ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(node))
+		ExpectReconcileSucceeded(ctx, metricsStateController, types.NamespacedName{})
 
-		// metrics should now be tracking the allocatable capacity of our single node
-		nodeScraper.Scrape(ctx)
-		nodeAllocation := ExpectMetric("karpenter_nodes_allocatable")
-
-		expectedValues := map[string]float64{
-			"cpu":    float64(resources.Cpu().MilliValue()) / float64(1000),
-			"pods":   float64(resources.Pods().Value()),
-			"memory": float64(resources.Memory().Value()),
+		for k, v := range resources {
+			metric, found := FindMetricWithLabelValues("karpenter_nodes_allocatable", map[string]string{
+				"node_name":     node.GetName(),
+				"resource_type": k.String(),
+			})
+			Expect(found).To(BeTrue())
+			Expect(metric.GetGauge().GetValue()).To(BeNumerically("~", v.AsApproximateFloat64()))
+		}
+	})
+	It("should remove the node metric gauge when the node is deleted", func() {
+		resources := v1.ResourceList{
+			v1.ResourcePods:   resource.MustParse("100"),
+			v1.ResourceCPU:    resource.MustParse("5000"),
+			v1.ResourceMemory: resource.MustParse("32Gi"),
 		}
 
-		var metrics []*io_prometheus_client.Metric
-		for _, m := range nodeAllocation.Metric {
-			for _, l := range m.Label {
-				if l.GetName() == "node_name" && l.GetValue() == node.GetName() {
-					metrics = append(metrics, m)
-				}
-			}
-		}
+		node := test.Node(test.NodeOptions{Allocatable: resources})
+		ExpectApplied(ctx, env.Client, node)
+		ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(node))
+		ExpectReconcileSucceeded(ctx, metricsStateController, types.NamespacedName{})
 
-		for _, metric := range metrics {
-			for _, l := range metric.Label {
-				if l.GetName() == "resource_type" {
-					Expect(metric.GetGauge().GetValue()).To(Equal(expectedValues[l.GetValue()]),
-						fmt.Sprintf("%s, %f to equal %f", l.GetValue(), metric.GetGauge().GetValue(),
-							expectedValues[l.GetValue()]))
-				}
-			}
-		}
+		_, found := FindMetricWithLabelValues("karpenter_nodes_allocatable", map[string]string{
+			"node_name": node.GetName(),
+		})
+		Expect(found).To(BeTrue())
+
+		ExpectDeleted(ctx, env.Client, node)
+		ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(node))
+		ExpectReconcileSucceeded(ctx, metricsStateController, types.NamespacedName{})
+
+		_, found = FindMetricWithLabelValues("karpenter_nodes_allocatable", map[string]string{
+			"node_name": node.GetName(),
+		})
+		Expect(found).To(BeFalse())
 	})
 })

--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -943,13 +943,13 @@ var _ = Describe("Topology", func() {
 			}}
 			ExpectApplied(ctx, env.Client, provisioner, firstNode, secondNode, thirdNode, &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: wrongNamespace}})
 			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
-				test.Pod(test.PodOptions{NodeName: firstNode.Name}),                                                                                                                         // ignored, missing labels
-				test.Pod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}}),                                                                                                    // ignored, pending
-				test.Pod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, NodeName: thirdNode.Name}),                                                                          // ignored, no domain on node
-				test.Pod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels, Namespace: wrongNamespace}, NodeName: firstNode.Name}),                                               // ignored, wrong namespace
-				test.Pod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels, DeletionTimestamp: &metav1.Time{Time: time.Now().Add(10 * time.Second)}}, NodeName: firstNode.Name}), // ignored, terminating
-				test.Pod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, NodeName: firstNode.Name, Phase: v1.PodFailed}),                                                     // ignored, phase=Failed
-				test.Pod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, NodeName: firstNode.Name, Phase: v1.PodSucceeded}),                                                  // ignored, phase=Succeeded
+				test.Pod(test.PodOptions{NodeName: firstNode.Name}),                                                                                               // ignored, missing labels
+				test.Pod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}}),                                                                          // ignored, pending
+				test.Pod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, NodeName: thirdNode.Name}),                                                // ignored, no domain on node
+				test.Pod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels, Namespace: wrongNamespace}, NodeName: firstNode.Name}),                     // ignored, wrong namespace
+				test.Pod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels, DeletionTimestamp: &metav1.Time{Time: time.Now().Add(10 * time.Second)}}}), // ignored, terminating
+				test.Pod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, NodeName: firstNode.Name, Phase: v1.PodFailed}),                           // ignored, phase=Failed
+				test.Pod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, NodeName: firstNode.Name, Phase: v1.PodSucceeded}),                        // ignored, phase=Succeeded
 				test.Pod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, NodeName: firstNode.Name}),
 				test.Pod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, NodeName: firstNode.Name}),
 				test.Pod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, NodeName: secondNode.Name}),
@@ -1224,13 +1224,13 @@ var _ = Describe("Topology", func() {
 			}}
 			ExpectApplied(ctx, env.Client, provisioner, firstNode, secondNode, thirdNode, &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: wrongNamespace}})
 			ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov,
-				test.Pod(test.PodOptions{NodeName: firstNode.Name}),                                                                                                                         // ignored, missing labels
-				test.Pod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}}),                                                                                                    // ignored, pending
-				test.Pod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, NodeName: thirdNode.Name}),                                                                          // ignored, no domain on node
-				test.Pod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels, Namespace: wrongNamespace}, NodeName: firstNode.Name}),                                               // ignored, wrong namespace
-				test.Pod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels, DeletionTimestamp: &metav1.Time{Time: time.Now().Add(10 * time.Second)}}, NodeName: firstNode.Name}), // ignored, terminating
-				test.Pod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, NodeName: firstNode.Name, Phase: v1.PodFailed}),                                                     // ignored, phase=Failed
-				test.Pod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, NodeName: firstNode.Name, Phase: v1.PodSucceeded}),                                                  // ignored, phase=Succeeded
+				test.Pod(test.PodOptions{NodeName: firstNode.Name}),                                                                                               // ignored, missing labels
+				test.Pod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}}),                                                                          // ignored, pending
+				test.Pod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, NodeName: thirdNode.Name}),                                                // ignored, no domain on node
+				test.Pod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels, Namespace: wrongNamespace}, NodeName: firstNode.Name}),                     // ignored, wrong namespace
+				test.Pod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels, DeletionTimestamp: &metav1.Time{Time: time.Now().Add(10 * time.Second)}}}), // ignored, terminating
+				test.Pod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, NodeName: firstNode.Name, Phase: v1.PodFailed}),                           // ignored, phase=Failed
+				test.Pod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, NodeName: firstNode.Name, Phase: v1.PodSucceeded}),                        // ignored, phase=Succeeded
 				test.Pod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, NodeName: firstNode.Name}),
 				test.Pod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, NodeName: firstNode.Name}),
 				test.Pod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, NodeName: secondNode.Name}),

--- a/pkg/controllers/provisioning/suite_test.go
+++ b/pkg/controllers/provisioning/suite_test.go
@@ -112,7 +112,9 @@ var _ = Describe("Provisioning", func() {
 		}
 	})
 	It("should ignore provisioners that are deleting", func() {
-		ExpectApplied(ctx, env.Client, test.Provisioner(test.ProvisionerOptions{ObjectMeta: metav1.ObjectMeta{DeletionTimestamp: &metav1.Time{Time: time.Now()}}}))
+		provisioner := test.Provisioner()
+		ExpectApplied(ctx, env.Client, provisioner)
+		ExpectDeletionTimestampSet(ctx, env.Client, provisioner)
 		pods := ExpectProvisioned(ctx, env.Client, cluster, recorder, provisioningController, prov, test.UnschedulablePod())
 		nodes := &v1.NodeList{}
 		Expect(env.Client.List(ctx, nodes)).To(Succeed())

--- a/pkg/controllers/termination/suite_test.go
+++ b/pkg/controllers/termination/suite_test.go
@@ -500,6 +500,7 @@ var _ = Describe("Termination", func() {
 			ExpectNotFound(ctx, env.Client, node)
 		})
 		It("should not evict static pods", func() {
+			ExpectApplied(ctx, env.Client, node)
 			podEvict := test.Pod(test.PodOptions{NodeName: node.Name, ObjectMeta: metav1.ObjectMeta{OwnerReferences: defaultOwnerRefs}})
 			ExpectApplied(ctx, env.Client, node, podEvict)
 


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes https://github.com/aws/karpenter/issues/3064

**Description**

- Delete events were being ignored for the two metric state controllers as a result of https://github.com/aws/karpenter-core/pull/51

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
