### PR TITLE
fix: Enable HA on webhook reconcilers

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -71,9 +71,6 @@ func NewOperator() (context.Context, *Operator) {
 	// Root Context
 	ctx := signals.NewContext()
 	ctx = knativeinjection.WithNamespaceScope(ctx, system.Namespace())
-	// TODO: This can be removed if we eventually decide that we need leader election. Having leader election has resulted in the webhook
-	// having issues described in https://github.com/aws/karpenter/issues/2562 so these issues need to be resolved if this line is removed
-	ctx = sharedmain.WithHADisabled(ctx) // Disable leader election for webhook
 
 	// Options
 	opts := options.New().MustParse()


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes #https://github.com/aws/karpenter/issues/2902#issuecomment-1366907523

**Description**
Enable's knative/pkg's HA for webhooks
**How was this change tested?**
Manually
* Fresh Install
* Delete Pods

No errors other than shutdown.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
