### PR TITLE
test: Add a `cacheSyncingClient` for testing that allows for custom FieldIndexers

### DIFF
--- a/pkg/controllers/deprovisioning/suite_test.go
+++ b/pkg/controllers/deprovisioning/suite_test.go
@@ -74,7 +74,7 @@ func TestAPIs(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	env = test.NewEnvironment(scheme.Scheme, apis.CRDs...)
+	env = test.NewEnvironment(scheme.Scheme, test.WithCRDs(apis.CRDs...))
 	ctx = settings.ToContext(ctx, test.Settings(test.SettingsOptions{DriftEnabled: true}))
 	cloudProvider = fake.NewCloudProvider()
 	fakeClock = clock.NewFakeClock(time.Now())

--- a/pkg/controllers/inflightchecks/suite_test.go
+++ b/pkg/controllers/inflightchecks/suite_test.go
@@ -57,7 +57,7 @@ func TestAPIs(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	fakeClock = clock.NewFakeClock(time.Now())
-	env = test.NewEnvironment(scheme.Scheme, apis.CRDs...)
+	env = test.NewEnvironment(scheme.Scheme, test.WithCRDs(apis.CRDs...))
 	ctx = settings.ToContext(ctx, test.Settings())
 	cp = &fake.CloudProvider{}
 	recorder = test.NewEventRecorder()

--- a/pkg/controllers/metrics/provisioner/suite_test.go
+++ b/pkg/controllers/metrics/provisioner/suite_test.go
@@ -46,7 +46,7 @@ func TestAPIs(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	env = test.NewEnvironment(scheme.Scheme, apis.CRDs...)
+	env = test.NewEnvironment(scheme.Scheme, test.WithCRDs(apis.CRDs...))
 	provisionerController = provisioner.NewController(env.Client)
 })
 

--- a/pkg/controllers/metrics/state/suite_test.go
+++ b/pkg/controllers/metrics/state/suite_test.go
@@ -62,7 +62,7 @@ func TestAPIs(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	env = test.NewEnvironment(scheme.Scheme, apis.CRDs...)
+	env = test.NewEnvironment(scheme.Scheme, test.WithCRDs(apis.CRDs...))
 
 	ctx = settings.ToContext(ctx, test.Settings())
 	cloudProvider = fake.NewCloudProvider()

--- a/pkg/controllers/node/suite_test.go
+++ b/pkg/controllers/node/suite_test.go
@@ -59,7 +59,7 @@ func TestAPIs(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	fakeClock = clock.NewFakeClock(time.Now())
-	env = test.NewEnvironment(scheme.Scheme, apis.CRDs...)
+	env = test.NewEnvironment(scheme.Scheme, test.WithCRDs(apis.CRDs...))
 	ctx = settings.ToContext(ctx, test.Settings())
 	cp := fake.NewCloudProvider()
 	cluster := state.NewCluster(ctx, fakeClock, env.Client, cp)

--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -72,7 +72,7 @@ func TestScheduling(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	env = test.NewEnvironment(scheme.Scheme, apis.CRDs...)
+	env = test.NewEnvironment(scheme.Scheme, test.WithCRDs(apis.CRDs...))
 	ctx = settings.ToContext(ctx, test.Settings())
 	cloudProv = fake.NewCloudProvider()
 	instanceTypes, _ := cloudProv.GetInstanceTypes(ctx, nil)

--- a/pkg/controllers/provisioning/suite_test.go
+++ b/pkg/controllers/provisioning/suite_test.go
@@ -68,7 +68,7 @@ func TestAPIs(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	env = test.NewEnvironment(scheme.Scheme, apis.CRDs...)
+	env = test.NewEnvironment(scheme.Scheme, test.WithCRDs(apis.CRDs...))
 	ctx = settings.ToContext(ctx, test.Settings())
 	cloudProvider = fake.NewCloudProvider()
 	recorder = test.NewEventRecorder()

--- a/pkg/controllers/state/suite_test.go
+++ b/pkg/controllers/state/suite_test.go
@@ -66,7 +66,7 @@ func TestAPIs(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	env = test.NewEnvironment(scheme.Scheme, apis.CRDs...)
+	env = test.NewEnvironment(scheme.Scheme, test.WithCRDs(apis.CRDs...))
 })
 
 var _ = AfterSuite(func() {

--- a/pkg/controllers/termination/suite_test.go
+++ b/pkg/controllers/termination/suite_test.go
@@ -60,7 +60,7 @@ func TestAPIs(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	fakeClock = clock.NewFakeClock(time.Now())
-	env = test.NewEnvironment(scheme.Scheme, apis.CRDs...)
+	env = test.NewEnvironment(scheme.Scheme, test.WithCRDs(apis.CRDs...))
 
 	cloudProvider := fake.NewCloudProvider()
 	eventRecorder := test.NewEventRecorder()

--- a/pkg/operator/controller/suite_test.go
+++ b/pkg/operator/controller/suite_test.go
@@ -49,7 +49,7 @@ func TestAPIs(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	env = test.NewEnvironment(scheme.Scheme, apis.CRDs...)
+	env = test.NewEnvironment(scheme.Scheme, test.WithCRDs(apis.CRDs...))
 	cmw = informer.NewInformedWatcher(env.KubernetesInterface, system.Namespace())
 	defaultConfigMap = &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/test/cachesyncingclient.go
+++ b/pkg/test/cachesyncingclient.go
@@ -1,0 +1,160 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/avast/retry-go"
+	"github.com/samber/lo"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+)
+
+// CacheSyncingClient exists for tests that need to use custom fieldSelectors (thus, they need a client cache)
+// and also need consistency in their testing by waiting for caches to sync after performing WRITE operations
+// NOTE: This cache sync doesn't sync with third-party operations on the api-server
+type CacheSyncingClient struct {
+	client.Client
+}
+
+// If we timeout on polling, the assumption is that the cache updated to a newer version
+// and we missed the current WRITE operation that we just performed
+var pollingOptions = []retry.Option{
+	retry.Attempts(100), // This whole poll should take ~1s
+	retry.Delay(time.Millisecond * 10),
+	retry.DelayType(retry.FixedDelay),
+}
+
+func (c *CacheSyncingClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	if err := c.Client.Create(ctx, obj, opts...); err != nil {
+		return err
+	}
+	_ = retry.Do(func() error {
+		if err := c.Client.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
+			return fmt.Errorf("getting object, %w", err)
+		}
+		return nil
+	}, pollingOptions...)
+	return nil
+}
+
+func (c *CacheSyncingClient) Delete(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error {
+	if err := c.Client.Delete(ctx, obj, opts...); err != nil {
+		return err
+	}
+	_ = retry.Do(func() error {
+		if err := c.Client.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
+			if errors.IsNotFound(err) {
+				return nil
+			}
+			return fmt.Errorf("getting object, %w", err)
+		}
+		return fmt.Errorf("object still exists")
+	}, pollingOptions...)
+	return nil
+}
+
+func (c *CacheSyncingClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	if err := c.Client.Update(ctx, obj, opts...); err != nil {
+		return err
+	}
+	_ = retry.Do(func() error {
+		return objectSynced(ctx, c.Client, obj)
+	}, pollingOptions...)
+	return nil
+}
+
+func (c *CacheSyncingClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	if err := c.Client.Patch(ctx, obj, patch, opts...); err != nil {
+		return err
+	}
+	_ = retry.Do(func() error {
+		return objectSynced(ctx, c.Client, obj)
+	}, pollingOptions...)
+	return nil
+}
+
+func (c *CacheSyncingClient) DeleteAllOf(ctx context.Context, obj client.Object, opts ...client.DeleteAllOfOption) error {
+	options := &client.DeleteAllOfOptions{}
+	for _, o := range opts {
+		o.ApplyToDeleteAllOf(options)
+	}
+	if err := c.Client.DeleteAllOf(ctx, obj, opts...); err != nil {
+		return err
+	}
+	metaList := &metav1.PartialObjectMetadataList{}
+	metaList.SetGroupVersionKind(lo.Must(apiutil.GVKForObject(obj, c.Scheme())))
+
+	_ = retry.Do(func() error {
+		listOptions := []client.ListOption{client.Limit(1)}
+		if options.ListOptions.Namespace != "" {
+			listOptions = append(listOptions, client.InNamespace(options.ListOptions.Namespace))
+		}
+		if err := c.Client.List(ctx, metaList, listOptions...); err != nil {
+			return fmt.Errorf("listing objects, %w", err)
+		}
+		if len(metaList.Items) != 0 {
+			return fmt.Errorf("objects still exist")
+		}
+		return nil
+	}, pollingOptions...)
+	return nil
+}
+
+func (c *CacheSyncingClient) Status() client.StatusWriter {
+	return &cacheSyncingStatusWriter{
+		client: c.Client,
+	}
+}
+
+type cacheSyncingStatusWriter struct {
+	client client.Client
+}
+
+func (c *cacheSyncingStatusWriter) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	if err := c.client.Status().Update(ctx, obj, opts...); err != nil {
+		return err
+	}
+	_ = retry.Do(func() error {
+		return objectSynced(ctx, c.client, obj)
+	}, pollingOptions...)
+	return nil
+}
+
+func (c *cacheSyncingStatusWriter) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
+	if err := c.client.Status().Patch(ctx, obj, patch, opts...); err != nil {
+		return err
+	}
+	_ = retry.Do(func() error {
+		return objectSynced(ctx, c.client, obj)
+	}, pollingOptions...)
+	return nil
+}
+
+func objectSynced(ctx context.Context, c client.Client, obj client.Object) error {
+	stored := obj.DeepCopyObject().(client.Object)
+	if err := c.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
+		return fmt.Errorf("getting object, %w", err)
+	}
+	if obj.GetResourceVersion() != stored.GetResourceVersion() {
+		return fmt.Errorf("object hasn't updated")
+	}
+	return nil
+}

--- a/pkg/test/nodes.go
+++ b/pkg/test/nodes.go
@@ -62,7 +62,3 @@ func Node(overrides ...NodeOptions) *v1.Node {
 		},
 	}
 }
-
-func ProviderID() string {
-	return fmt.Sprintf("fake://%s", RandomName())
-}

--- a/pkg/test/nodes.go
+++ b/pkg/test/nodes.go
@@ -62,3 +62,7 @@ func Node(overrides ...NodeOptions) *v1.Node {
 		},
 	}
 }
+
+func ProviderID() string {
+	return fmt.Sprintf("fake://%s", RandomName())
+}

--- a/pkg/utils/machine/machine.go
+++ b/pkg/utils/machine/machine.go
@@ -18,8 +18,10 @@ import (
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
+	"github.com/aws/karpenter-core/pkg/operator/scheme"
 	"github.com/aws/karpenter-core/pkg/scheduling"
 )
 
@@ -33,6 +35,7 @@ func New(node *v1.Node, provisioner *v1alpha5.Provisioner) *v1alpha5.Machine {
 	machine.Spec.Requirements = provisioner.Spec.Requirements
 	machine.Spec.StartupTaints = provisioner.Spec.StartupTaints
 	machine.Spec.MachineTemplateRef = provisioner.Spec.ProviderRef
+	lo.Must0(controllerutil.SetOwnerReference(provisioner, machine, scheme.Scheme))
 
 	return machine
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

- Adds a `cacheSyncingClient` that waits for WRITE operations to be propagated to the cache before proceeding
- It is meant to mock a direct client while also giving a client-side cache for indexing `fieldSelectors`

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
