### PR TITLE
chore: Add `karpenter.sh/cluster-name` label key for machine idempotency

### DIFF
--- a/pkg/apis/v1alpha5/labels.go
+++ b/pkg/apis/v1alpha5/labels.go
@@ -34,6 +34,7 @@ const (
 const (
 	ProvisionerNameLabelKey = Group + "/provisioner-name"
 	MachineNameLabelKey     = Group + "/machine-name"
+	ClusterNameLabelKey     = Group + "/cluster-name"
 	LabelNodeInitialized    = Group + "/initialized"
 	LabelCapacityType       = Group + "/capacity-type"
 )
@@ -54,12 +55,6 @@ const (
 // Karpenter specific finalizers
 const (
 	TerminationFinalizer = Group + "/termination"
-)
-
-// Tags for infrastructure resources deployed into Cloud Provider's accounts
-const (
-	DiscoveryTagKey = Group + "/discovery"
-	ManagedByTagKey = Group + "/managed-by"
 )
 
 var (


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

- Add `karpenter.sh/cluster-name` label key for machine idempotency
- This is needed so that machine-controller knows that a machine with a given name is associated with a specific cluster. This gives cloudproviders a mechanism to associate cloudprovider instances through tagging
- Because we are taking a heavy dependency on this label for determining whether a machine is tied to an instance, I'm proposing that this be used on top of the `kubernetes.io/cluster-name/` tag that is already being used in `aws/karpenter` since the `karpenter.sh/cluster-name` label will be used in deep association with the Karpenter logic

**How was this change tested?**

`make presubmit`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
