### PR TITLE
chore: Fix `MachineNotFound` custom error type checking

### DIFF
--- a/pkg/cloudprovider/types.go
+++ b/pkg/cloudprovider/types.go
@@ -17,6 +17,7 @@ package cloudprovider
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
@@ -140,13 +141,25 @@ func (ofs Offerings) Cheapest() Offering {
 }
 
 // MachineNotFoundError is an error type returned by CloudProviders when the reason for failure is NotFound
-type MachineNotFoundError error
+type MachineNotFoundError struct {
+	Err error
+}
+
+func NewMachineNotFoundError(err error) *MachineNotFoundError {
+	return &MachineNotFoundError{
+		Err: err,
+	}
+}
+
+func (e *MachineNotFoundError) Error() string {
+	return fmt.Sprintf("machine not found, %s", e.Err)
+}
 
 func IsMachineNotFoundError(err error) bool {
 	if err == nil {
 		return false
 	}
-	var mnfErr MachineNotFoundError
+	var mnfErr *MachineNotFoundError
 	return errors.As(err, &mnfErr)
 }
 


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

- Fix `MachineNotFound` custom error type checking
- Updates the type appropriately since `errors.As` does not perform correctly when simply typing errors with `cloudprovider.MachineNotFoundError(err)`

This is a similar change to https://github.com/aws/karpenter/pull/2253

**How was this change tested?**

- `make presubmit`
- https://go.dev/play/p/cjKCHV_Htfx


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
