### PR TITLE
fix: remove machine from webhook-gen

### DIFF
--- a/pkg/apis/apis.go
+++ b/pkg/apis/apis.go
@@ -40,7 +40,6 @@ var (
 	// Resources defined in the project
 	Resources = map[schema.GroupVersionKind]resourcesemantics.GenericCRD{
 		v1alpha5.SchemeGroupVersion.WithKind("Provisioner"): &v1alpha5.Provisioner{},
-		v1alpha5.SchemeGroupVersion.WithKind("Machine"):     &v1alpha5.Machine{},
 	}
 	Settings = sets.New(settings.Registration)
 )


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

https://kubernetes.slack.com/archives/C02SFFZSA2K/p1672755352432249

**How was this change tested?**
`make test`
`make diff`

### Before
```
make diff
helm diff upgrade karpenter charts/karpenter --namespace karpenter --reuse-values --three-way-merge
karpenter, defaulting.webhook.karpenter.sh, MutatingWebhookConfiguration (admissionregistration.k8s.io) has changed:
  apiVersion: admissionregistration.k8s.io/v1
  kind: MutatingWebhookConfiguration
  metadata:
    creationTimestamp: "2023-01-03T21:42:18Z"
    labels:
      app.kubernetes.io/instance: karpenter
      app.kubernetes.io/managed-by: Helm
      app.kubernetes.io/name: karpenter
      app.kubernetes.io/version: 0.21.1
      helm.sh/chart: karpenter-0.21.1
    name: defaulting.webhook.karpenter.sh
    ownerReferences:
    - apiVersion: v1
      blockOwnerDeletion: true
      controller: true
      kind: Namespace
      name: karpenter
      uid: fb3894d7-8366-4faf-b925-6dcd13ba5939
    resourceVersion: "9424081"
    uid: 75ce6e4c-b3d6-40c8-8922-2a67c4568361
  webhooks:
  - admissionReviewVersions:
    - v1
    clientConfig:
      caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNQVENDQWVPZ0F3SUJBZ0lSQU03YmllK3R5cGNMUElvOUhFUkg4UXN3Q2dZSUtvWkl6ajBFQXdJd09ERVUKTUJJR0ExVUVDaE1MYTI1aGRHbDJaUzVrWlhZeElEQWVCZ05WQkFNVEYydGhjbkJsYm5SbGNpNXJZWEp3Wlc1MApaWEl1YzNaak1CNFhEVEl6TURFd016SXhOREl5TUZvWERUSXpNREV4TURJeE5ESXlNRm93T0RFVU1CSUdBMVVFCkNoTUxhMjVoZEdsMlpTNWtaWFl4SURBZUJnTlZCQU1URjJ0aGNuQmxiblJsY2k1cllYSndaVzUwWlhJdWMzWmoKTUZrd0V3WUhLb1pJemowQ0FRWUlLb1pJemowREFRY0RRZ0FFTU5XQ3plRnNyRFVmaG52RS9KcEsyNmNBRHBiYgp1UUpNTnQ4WE1XN2hocjlxZkxwbTdmZURrcXpJVTFDTTdWMWR1dmpqUDFaU05UenVZVUpRVkRRa0VxT0J6VENCCnlqQU9CZ05WSFE4QkFmOEVCQU1DQW9Rd0hRWURWUjBsQkJZd0ZBWUlLd1lCQlFVSEF3RUdDQ3NHQVFVRkJ3TUMKTUE4R0ExVWRFd0VCL3dRRk1BTUJBZjh3SFFZRFZSME9CQllFRkF6QkZjWCtsVVlvMkErcHJiME1SeTFWTzNMYwpNR2tHQTFVZEVRUmlNR0NDQ1d0aGNuQmxiblJsY29JVGEyRnljR1Z1ZEdWeUxtdGhjbkJsYm5SbGNvSVhhMkZ5CmNHVnVkR1Z5TG10aGNuQmxiblJsY2k1emRtT0NKV3RoY25CbGJuUmxjaTVyWVhKd1pXNTBaWEl1YzNaakxtTnMKZFhOMFpYSXViRzlqWVd3d0NnWUlLb1pJemowRUF3SURTQUF3UlFJaEFOeXZGdUE5N1ZPTldvT1RrZjVwR1gzaApzZERJVVRqZ1RuZmhvWUluRGpUQUFpQnQ1Z3htSnB3ZjJ0SCtSK0ZJN1Z1WUhqS0xlUG0rUXVWMnZhd3NMSTg4CjN3PT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
      service:
        name: karpenter
        namespace: karpenter
        path: /default/karpenter.sh
        port: 443
    failurePolicy: Fail
    matchPolicy: Equivalent
    name: defaulting.webhook.karpenter.sh
    namespaceSelector:
      matchExpressions:
      - key: webhooks.knative.dev/exclude
        operator: DoesNotExist
    objectSelector: {}
    reinvocationPolicy: IfNeeded
    rules:
    - apiGroups:
      - karpenter.sh
      apiVersions:
      - v1alpha5
      operations:
      - CREATE
      - UPDATE
      resources:
-     - machines
-     - machines/status
-     scope: '*'
-   - apiGroups:
-     - karpenter.sh
-     apiVersions:
-     - v1alpha5
-     operations:
-     - CREATE
-     - UPDATE
-     resources:
      - provisioners
      - provisioners/status
      scope: '*'
    sideEffects: None
    timeoutSeconds: 10
karpenter, validation.webhook.karpenter.sh, ValidatingWebhookConfiguration (admissionregistration.k8s.io) has changed:
  apiVersion: admissionregistration.k8s.io/v1
  kind: ValidatingWebhookConfiguration
  metadata:
    creationTimestamp: "2023-01-03T21:42:18Z"
    labels:
      app.kubernetes.io/instance: karpenter
      app.kubernetes.io/managed-by: Helm
      app.kubernetes.io/name: karpenter
      app.kubernetes.io/version: 0.21.1
      helm.sh/chart: karpenter-0.21.1
    name: validation.webhook.karpenter.sh
    ownerReferences:
    - apiVersion: v1
      blockOwnerDeletion: true
      controller: true
      kind: Namespace
      name: karpenter
      uid: fb3894d7-8366-4faf-b925-6dcd13ba5939
    resourceVersion: "9424080"
    uid: b3315539-3011-4697-a2a5-b85103f0368f
  webhooks:
  - admissionReviewVersions:
    - v1
    clientConfig:
      caBundle: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUNQVENDQWVPZ0F3SUJBZ0lSQU03YmllK3R5cGNMUElvOUhFUkg4UXN3Q2dZSUtvWkl6ajBFQXdJd09ERVUKTUJJR0ExVUVDaE1MYTI1aGRHbDJaUzVrWlhZeElEQWVCZ05WQkFNVEYydGhjbkJsYm5SbGNpNXJZWEp3Wlc1MApaWEl1YzNaak1CNFhEVEl6TURFd016SXhOREl5TUZvWERUSXpNREV4TURJeE5ESXlNRm93T0RFVU1CSUdBMVVFCkNoTUxhMjVoZEdsMlpTNWtaWFl4SURBZUJnTlZCQU1URjJ0aGNuQmxiblJsY2k1cllYSndaVzUwWlhJdWMzWmoKTUZrd0V3WUhLb1pJemowQ0FRWUlLb1pJemowREFRY0RRZ0FFTU5XQ3plRnNyRFVmaG52RS9KcEsyNmNBRHBiYgp1UUpNTnQ4WE1XN2hocjlxZkxwbTdmZURrcXpJVTFDTTdWMWR1dmpqUDFaU05UenVZVUpRVkRRa0VxT0J6VENCCnlqQU9CZ05WSFE4QkFmOEVCQU1DQW9Rd0hRWURWUjBsQkJZd0ZBWUlLd1lCQlFVSEF3RUdDQ3NHQVFVRkJ3TUMKTUE4R0ExVWRFd0VCL3dRRk1BTUJBZjh3SFFZRFZSME9CQllFRkF6QkZjWCtsVVlvMkErcHJiME1SeTFWTzNMYwpNR2tHQTFVZEVRUmlNR0NDQ1d0aGNuQmxiblJsY29JVGEyRnljR1Z1ZEdWeUxtdGhjbkJsYm5SbGNvSVhhMkZ5CmNHVnVkR1Z5TG10aGNuQmxiblJsY2k1emRtT0NKV3RoY25CbGJuUmxjaTVyWVhKd1pXNTBaWEl1YzNaakxtTnMKZFhOMFpYSXViRzlqWVd3d0NnWUlLb1pJemowRUF3SURTQUF3UlFJaEFOeXZGdUE5N1ZPTldvT1RrZjVwR1gzaApzZERJVVRqZ1RuZmhvWUluRGpUQUFpQnQ1Z3htSnB3ZjJ0SCtSK0ZJN1Z1WUhqS0xlUG0rUXVWMnZhd3NMSTg4CjN3PT0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
      service:
        name: karpenter
        namespace: karpenter
        path: /validate/karpenter.sh
        port: 443
    failurePolicy: Fail
    matchPolicy: Equivalent
    name: validation.webhook.karpenter.sh
    namespaceSelector:
      matchExpressions:
      - key: webhooks.knative.dev/exclude
        operator: DoesNotExist
    objectSelector: {}
    rules:
    - apiGroups:
      - karpenter.sh
      apiVersions:
      - v1alpha5
      operations:
      - CREATE
      - UPDATE
      - DELETE
      resources:
-     - machines
-     - machines/status
-     scope: '*'
-   - apiGroups:
-     - karpenter.sh
-     apiVersions:
-     - v1alpha5
-     operations:
-     - CREATE
-     - UPDATE
-     - DELETE
-     resources:
      - provisioners
      - provisioners/status
      scope: '*'
    sideEffects: None
    timeoutSeconds: 10
```
### After 
```
make apply
make diff
helm diff upgrade karpenter charts/karpenter --namespace karpenter --reuse-values --three-way-merge
```



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
