### PR TITLE
chore: `DeepCopy()` the machine in Create call

### DIFF
--- a/pkg/controllers/provisioning/scheduling/machinetemplate.go
+++ b/pkg/controllers/provisioning/scheduling/machinetemplate.go
@@ -15,6 +15,8 @@ limitations under the License.
 package scheduling
 
 import (
+	"fmt"
+
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -80,7 +82,7 @@ func (i *MachineTemplate) ToMachine(owner *v1alpha5.Provisioner) *v1alpha5.Machi
 	})...))
 	m := &v1alpha5.Machine{
 		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: i.ProvisionerName,
+			GenerateName: fmt.Sprintf("%s-", i.ProvisionerName),
 			Annotations:  lo.Assign(i.Annotations, v1alpha5.ProviderAnnotation(i.Provider)),
 			Labels:       i.Labels,
 		},


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

- Deep-copies the machine in the Create calls

There is a memory impact here, but I'm not sure that the memory impact can be avoided considering that we are going to be getting separate copies of the object from the apiserver when we create them, meaning that the create and the subsequent get from the apiserver/cache are going to be separate copies and also spike memory.

<img width="1472" alt="Screen Shot 2023-01-06 at 2 28 01 PM" src="https://user-images.githubusercontent.com/26334334/211111037-a20d26e8-169d-4c0e-88dc-88bd24acdc44.png">

(300 node scale-up. First large peak is from before the PR. Second large peak is from after the PR)

This is needed to avoid race-conditions with making updates to the Machine directly when injecting data here: https://github.com/aws/karpenter/pull/3129

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
