### PR TITLE
fix: Use stable instance-type label in inflight controllers

### DIFF
--- a/pkg/controllers/inflightchecks/failedinit.go
+++ b/pkg/controllers/inflightchecks/failedinit.go
@@ -61,11 +61,11 @@ func (f FailedInit) Check(ctx context.Context, n *v1.Node, provisioner *v1alpha5
 		return nil, err
 	}
 
-	instanceType, ok := lo.Find(instanceTypes, func(it *cloudprovider.InstanceType) bool { return it.Name == n.Labels[v1.LabelInstanceType] })
+	instanceType, ok := lo.Find(instanceTypes, func(it *cloudprovider.InstanceType) bool { return it.Name == n.Labels[v1.LabelInstanceTypeStable] })
 	if !ok {
 		return []Issue{{
 			node:    n,
-			message: fmt.Sprintf("Instance Type %q not found", n.Labels[v1.LabelInstanceType]),
+			message: fmt.Sprintf("Instance Type %q not found", n.Labels[v1.LabelInstanceTypeStable]),
 		}}, nil
 	}
 

--- a/pkg/controllers/inflightchecks/nodeshape.go
+++ b/pkg/controllers/inflightchecks/nodeshape.go
@@ -52,11 +52,11 @@ func (n *NodeShape) Check(ctx context.Context, node *v1.Node, provisioner *v1alp
 		return nil, err
 	}
 
-	instanceType, ok := lo.Find(instanceTypes, func(it *cloudprovider.InstanceType) bool { return it.Name == node.Labels[v1.LabelInstanceType] })
+	instanceType, ok := lo.Find(instanceTypes, func(it *cloudprovider.InstanceType) bool { return it.Name == node.Labels[v1.LabelInstanceTypeStable] })
 	if !ok {
 		return []Issue{{
 			node:    node,
-			message: fmt.Sprintf("Instance Type %q not found", node.Labels[v1.LabelInstanceType]),
+			message: fmt.Sprintf("Instance Type %q not found", node.Labels[v1.LabelInstanceTypeStable]),
 		}}, nil
 	}
 	var issues []Issue

--- a/pkg/controllers/inflightchecks/suite_test.go
+++ b/pkg/controllers/inflightchecks/suite_test.go
@@ -89,7 +89,7 @@ var _ = Describe("Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
-						v1.LabelInstanceType:             "gpu-vendor-instance-type",
+						v1.LabelInstanceTypeStable:       "gpu-vendor-instance-type",
 					},
 				},
 			})
@@ -113,7 +113,7 @@ var _ = Describe("Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
-						v1.LabelInstanceType:             "default-instance-type",
+						v1.LabelInstanceTypeStable:       "default-instance-type",
 					},
 				},
 			})
@@ -136,7 +136,7 @@ var _ = Describe("Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
-						v1.LabelInstanceType:             "default-instance-type",
+						v1.LabelInstanceTypeStable:       "default-instance-type",
 					},
 				},
 			})
@@ -166,7 +166,7 @@ var _ = Describe("Controller", func() {
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{
 						v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
-						v1.LabelInstanceType:             "arm-instance-type",
+						v1.LabelInstanceTypeStable:       "arm-instance-type",
 						v1alpha5.LabelNodeInitialized:    "true",
 					},
 				},


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes #157 

**Description**
`beta.kubernetes.io/instance-type` label is deprecated.
`node.kubernetes.io/instance-type` should be used instead.


**How was this change tested?**
I've tested it using arm64 macbook
```
make toolchain
make test
```

Result:
```
❯ karpenter-core (issue-157-fix) ✔ make test                                  
go test ./... \
                -race \
                --ginkgo.focus="" \
                -cover -coverprofile=coverage.out -outputdir=. -coverpkg=./...
?       github.com/aws/karpenter-core/pkg/apis  [no test files]
?       github.com/aws/karpenter-core/pkg/apis/config   [no test files]
ok      github.com/aws/karpenter-core/pkg/apis/config/settings  1.037s  coverage: 1.6% of statements in ./...
ok      github.com/aws/karpenter-core/pkg/apis/v1alpha5 2.752s  coverage: 4.0% of statements in ./...
?       github.com/aws/karpenter-core/pkg/cloudprovider [no test files]
?       github.com/aws/karpenter-core/pkg/cloudprovider/fake    [no test files]
?       github.com/aws/karpenter-core/pkg/cloudprovider/metrics [no test files]
?       github.com/aws/karpenter-core/pkg/controllers   [no test files]
?       github.com/aws/karpenter-core/pkg/controllers/counter   [no test files]
ok      github.com/aws/karpenter-core/pkg/controllers/deprovisioning    73.630s coverage: 46.4% of statements in ./...
?       github.com/aws/karpenter-core/pkg/controllers/deprovisioning/events     [no test files]
ok      github.com/aws/karpenter-core/pkg/controllers/inflightchecks    17.816s coverage: 9.6% of statements in ./...
ok      github.com/aws/karpenter-core/pkg/controllers/metrics/pod       15.937s coverage: 4.1% of statements in ./...
ok      github.com/aws/karpenter-core/pkg/controllers/metrics/provisioner       17.824s coverage: 5.2% of statements in ./...
ok      github.com/aws/karpenter-core/pkg/controllers/metrics/state     18.290s coverage: 9.1% of statements in ./...
?       github.com/aws/karpenter-core/pkg/controllers/metrics/state/scraper     [no test files]
ok      github.com/aws/karpenter-core/pkg/controllers/node      18.524s coverage: 10.0% of statements in ./...
ok      github.com/aws/karpenter-core/pkg/controllers/provisioning      22.317s coverage: 39.8% of statements in ./...
ok      github.com/aws/karpenter-core/pkg/controllers/provisioning/scheduling   71.539s coverage: 45.8% of statements in ./...
ok      github.com/aws/karpenter-core/pkg/controllers/state     30.739s coverage: 14.1% of statements in ./...
?       github.com/aws/karpenter-core/pkg/controllers/state/informer    [no test files]
ok      github.com/aws/karpenter-core/pkg/controllers/termination       23.551s coverage: 7.9% of statements in ./...
ok      github.com/aws/karpenter-core/pkg/events        4.180s  coverage: 2.6% of statements in ./...
?       github.com/aws/karpenter-core/pkg/metrics       [no test files]
?       github.com/aws/karpenter-core/pkg/operator      [no test files]
ok      github.com/aws/karpenter-core/pkg/operator/controller   10.472s coverage: 6.5% of statements in ./...
?       github.com/aws/karpenter-core/pkg/operator/injection    [no test files]
?       github.com/aws/karpenter-core/pkg/operator/options      [no test files]
?       github.com/aws/karpenter-core/pkg/operator/scheme       [no test files]
ok      github.com/aws/karpenter-core/pkg/operator/settingsstore        7.963s  coverage: 3.2% of statements in ./...
?       github.com/aws/karpenter-core/pkg/operator/settingsstore/fake   [no test files]
ok      github.com/aws/karpenter-core/pkg/scheduling    1.379s  coverage: 5.3% of statements in ./...
?       github.com/aws/karpenter-core/pkg/test  [no test files]
?       github.com/aws/karpenter-core/pkg/test/expectations     [no test files]
ok      github.com/aws/karpenter-core/pkg/utils/atomic  1.490s  coverage: 1.8% of statements in ./...
?       github.com/aws/karpenter-core/pkg/utils/env     [no test files]
ok      github.com/aws/karpenter-core/pkg/utils/functional      0.766s  coverage: 1.2% of statements in ./...
?       github.com/aws/karpenter-core/pkg/utils/machine [no test files]
?       github.com/aws/karpenter-core/pkg/utils/node    [no test files]
?       github.com/aws/karpenter-core/pkg/utils/pod     [no test files]
?       github.com/aws/karpenter-core/pkg/utils/pretty  [no test files]
?       github.com/aws/karpenter-core/pkg/utils/resources       [no test files]
?       github.com/aws/karpenter-core/pkg/utils/result  [no test files]
?       github.com/aws/karpenter-core/pkg/utils/sets    [no test files]
?       github.com/aws/karpenter-core/pkg/webhooks      [no test files]                                                                                                                              1m:35s
❯ karpenter-core (issue-157-fix) ✔ 
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
