### PR TITLE
chore: Remove auto-patching from typed controllers

### DIFF
--- a/pkg/controllers/node/emptiness.go
+++ b/pkg/controllers/node/emptiness.go
@@ -73,7 +73,8 @@ func (r *Emptiness) Reconcile(ctx context.Context, provisioner *v1alpha5.Provisi
 		logging.FromContext(ctx).Infof("added TTL to empty node")
 	}
 
-	return reconcile.Result{}, nil
+	// Short requeue result so that we requeue to check for emptiness when the node nomination time ends
+	return reconcile.Result{RequeueAfter: time.Minute}, nil
 }
 
 func (r *Emptiness) isEmpty(ctx context.Context, n *v1.Node) (bool, error) {

--- a/pkg/controllers/provisioning/controller.go
+++ b/pkg/controllers/provisioning/controller.go
@@ -53,7 +53,7 @@ func (c *Controller) Name() string {
 }
 
 // Reconcile the resource
-func (c *Controller) Reconcile(ctx context.Context, p *v1.Pod) (reconcile.Result, error) {
+func (c *Controller) Reconcile(_ context.Context, p *v1.Pod) (reconcile.Result, error) {
 	if !pod.IsProvisionable(p) {
 		return reconcile.Result{}, nil
 	}

--- a/pkg/operator/controller/typed.go
+++ b/pkg/operator/controller/typed.go
@@ -20,9 +20,6 @@ import (
 	"strings"
 
 	"github.com/samber/lo"
-	"go.uber.org/multierr"
-	"k8s.io/apimachinery/pkg/api/equality"
-	"k8s.io/apimachinery/pkg/runtime"
 	"knative.dev/pkg/logging"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
@@ -50,10 +47,10 @@ type typedDecorator[T client.Object] struct {
 	typedController TypedController[T]
 }
 
-func Typed[T client.Object](kubeClient client.Client, typedReconciler TypedController[T]) Controller {
+func Typed[T client.Object](kubeClient client.Client, typedController TypedController[T]) Controller {
 	return &typedDecorator[T]{
 		kubeClient:      kubeClient,
-		typedController: typedReconciler,
+		typedController: typedController,
 	}
 }
 
@@ -75,60 +72,13 @@ func (t *typedDecorator[T]) Reconcile(ctx context.Context, req reconcile.Request
 	if err := t.kubeClient.Get(ctx, req.NamespacedName, obj); err != nil {
 		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
-	stored := obj.DeepCopyObject().(client.Object)
-
-	var result reconcile.Result
-	var err error
-
 	finalizingTypedController, ok := t.typedController.(FinalizingTypedController[T])
 	if !obj.GetDeletionTimestamp().IsZero() && ok {
-		result, err = finalizingTypedController.Finalize(ctx, obj)
-	} else {
-		result, err = t.typedController.Reconcile(ctx, obj)
+		return finalizingTypedController.Finalize(ctx, obj)
 	}
-
-	if e := t.patch(ctx, stored, obj); e != nil {
-		return reconcile.Result{}, multierr.Combine(e, err)
-	}
-	return result, err
+	return t.typedController.Reconcile(ctx, obj)
 }
 
 func (t *typedDecorator[T]) Builder(ctx context.Context, m manager.Manager) Builder {
 	return t.typedController.Builder(ctx, m)
-}
-
-func (t *typedDecorator[T]) patch(ctx context.Context, obj, updated client.Object) error {
-	// Patch Body if changed
-	if !bodyEqual(obj, updated) {
-		if err := t.kubeClient.Patch(ctx, updated.DeepCopyObject().(client.Object), client.MergeFrom(obj)); err != nil {
-			return client.IgnoreNotFound(err)
-		}
-	}
-	// Patch Status if changed
-	if !statusEqual(obj, updated) {
-		if err := t.kubeClient.Status().Patch(ctx, updated.DeepCopyObject().(client.Object), client.MergeFrom(obj)); err != nil {
-			return client.IgnoreNotFound(err) // Status subresource may not exist
-		}
-	}
-	return nil
-}
-
-// bodyEqual compares two objects, ignoring their status and determines if they are deeply-equal
-func bodyEqual(a, b client.Object) bool {
-	unstructuredA := lo.Must(runtime.DefaultUnstructuredConverter.ToUnstructured(a))
-	unstructuredB := lo.Must(runtime.DefaultUnstructuredConverter.ToUnstructured(b))
-
-	// Remove the status fields, so we are only left with non-status info
-	delete(unstructuredA, "status")
-	delete(unstructuredB, "status")
-
-	return equality.Semantic.DeepEqual(unstructuredA, unstructuredB)
-}
-
-// statusEqual compares two object statuses and determines if they are deeply-equal
-func statusEqual(a, b client.Object) bool {
-	unstructuredA := lo.Must(runtime.DefaultUnstructuredConverter.ToUnstructured(a))
-	unstructuredB := lo.Must(runtime.DefaultUnstructuredConverter.ToUnstructured(b))
-
-	return equality.Semantic.DeepEqual(unstructuredA["status"], unstructuredB["status"])
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes https://github.com/aws/karpenter/issues/3153
Fixes #153 

**Description**

- Remove auto-patching from typed controllers
- This doesn't add patch helpers for not patching on no change yet since it felt like an unnecessary abstraction given the amount of patching that we are currently doing.

**How was this change tested?**

`make presubmit`
`FOCUS=Scheduling make e2etests`
`FOCUS=Emptiness make e2etests`
`FOCUS=Termination make e2etests`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
