### PR TITLE
chore: Return a machine struct from the cloudprovider create call

### DIFF
--- a/pkg/cloudprovider/metrics/cloudprovider.go
+++ b/pkg/cloudprovider/metrics/cloudprovider.go
@@ -18,7 +18,6 @@ import (
 	"context"
 
 	"github.com/prometheus/client_golang/prometheus"
-	v1 "k8s.io/api/core/v1"
 	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
@@ -67,7 +66,7 @@ func Decorate(cloudProvider cloudprovider.CloudProvider) cloudprovider.CloudProv
 	return &decorator{cloudProvider}
 }
 
-func (d *decorator) Create(ctx context.Context, machine *v1alpha5.Machine) (*v1.Node, error) {
+func (d *decorator) Create(ctx context.Context, machine *v1alpha5.Machine) (*v1alpha5.Machine, error) {
 	defer metrics.Measure(methodDurationHistogramVec.WithLabelValues(injection.GetControllerName(ctx), "Create", d.Name()))()
 	return d.CloudProvider.Create(ctx, machine)
 }
@@ -75,6 +74,11 @@ func (d *decorator) Create(ctx context.Context, machine *v1alpha5.Machine) (*v1.
 func (d *decorator) Delete(ctx context.Context, machine *v1alpha5.Machine) error {
 	defer metrics.Measure(methodDurationHistogramVec.WithLabelValues(injection.GetControllerName(ctx), "Delete", d.Name()))()
 	return d.CloudProvider.Delete(ctx, machine)
+}
+
+func (d *decorator) Get(ctx context.Context, machineName, provisionerName string) (*v1alpha5.Machine, error) {
+	defer metrics.Measure(methodDurationHistogramVec.WithLabelValues(injection.GetControllerName(ctx), "Get", d.Name()))()
+	return d.CloudProvider.Get(ctx, machineName, provisionerName)
 }
 
 func (d *decorator) GetInstanceTypes(ctx context.Context, provisioner *v1alpha5.Provisioner) ([]*cloudprovider.InstanceType, error) {

--- a/pkg/cloudprovider/types.go
+++ b/pkg/cloudprovider/types.go
@@ -48,13 +48,13 @@ type Context struct {
 
 // CloudProvider interface is implemented by cloud providers to support provisioning.
 type CloudProvider interface {
-	// Create a node given constraints and instance type options. This API uses a
-	// callback pattern to enable cloudproviders to batch capacity creation
-	// requests. The callback must be called with a theoretical node object that
-	// is fulfilled by the cloud providers capacity creation request.
-	Create(context.Context, *v1alpha5.Machine) (*v1.Node, error)
-	// Delete node in cloudprovider
+	// Create launches a machine with the given resource requests and requirements and returns a hydrated
+	// machine back with resolved machine labels for the launched machine
+	Create(context.Context, *v1alpha5.Machine) (*v1alpha5.Machine, error)
+	// Delete removes a machine from the cloudprovider by its machine name
 	Delete(context.Context, *v1alpha5.Machine) error
+	// Get retrieves a machine from the cloudprovider by its machine name
+	Get(context.Context, string, string) (*v1alpha5.Machine, error)
 	// GetInstanceTypes returns instance types supported by the cloudprovider.
 	// Availability of types or zone may vary by provisioner or over time.  Regardless of
 	// availability, the GetInstanceTypes method should always return all instance types,

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -319,12 +319,21 @@ func (p *Provisioner) launch(ctx context.Context, machine *scheduler.Node, opts 
 	}
 
 	logging.FromContext(ctx).Infof("launching %s", machine)
-	k8sNode, err := p.cloudProvider.Create(
+	created, err := p.cloudProvider.Create(
 		logging.WithLogger(ctx, logging.FromContext(ctx).Named("cloudprovider")),
 		machine.ToMachine(latest),
 	)
 	if err != nil {
 		return "", fmt.Errorf("creating cloud provider instance, %w", err)
+	}
+	k8sNode := &v1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   created.Name,
+			Labels: created.Labels,
+		},
+		Spec: v1.NodeSpec{
+			ProviderID: created.Status.ProviderID,
+		},
 	}
 	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).With("node", k8sNode.Name))
 

--- a/pkg/utils/functional/functional.go
+++ b/pkg/utils/functional/functional.go
@@ -64,3 +64,13 @@ func Unmarshal[T any](raw []byte) (*T, error) {
 	}
 	return &t, nil
 }
+
+func FilterMap[K comparable, V any](m map[K]V, f func(K, V) bool) map[K]V {
+	ret := map[K]V{}
+	for k, v := range m {
+		if f(k, v) {
+			ret[k] = v
+		}
+	}
+	return ret
+}


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

- Return a `v1alpha5.Machine` struct from the cloudprovider create call
- This change preps for the `machine.Controller` which will use the full response to update the Machine status

**How was this change tested?**

`make test`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
