### PR TITLE
bugAdded LimitRange for both Pods and Containers

### DIFF
--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -180,6 +180,7 @@ func ExpectCleanedUp(ctx context.Context, c client.Client) {
 		&v1.Pod{},
 		&v1.Node{},
 		&appsv1.DaemonSet{},
+		&v1.LimitRange{},
 		&policyv1.PodDisruptionBudget{},
 		&v1.PersistentVolumeClaim{},
 		&v1.PersistentVolume{},


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes #https://github.com/aws/karpenter/issues/3199

**Description**

Added LimitRange configuration for when simulating the creation of a pods from a given daemonSet 

**How was this change tested?**

Tested using unit tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
