### PR TITLE
chore: simplify deprovisioning controller and remove dead code

### DIFF
--- a/pkg/controllers/deprovisioning/consolidation.go
+++ b/pkg/controllers/deprovisioning/consolidation.go
@@ -68,18 +68,6 @@ func (c *consolidation) String() string {
 	return metrics.ConsolidationReason
 }
 
-// RecordLastState is used to record the last state that the consolidation implementation failed to work in to allow
-// skipping future consolidation attempts until the state changes.
-func (c *consolidation) RecordLastState(currentState int64) {
-	c.lastConsolidationState = currentState
-}
-
-func (c *consolidation) ShouldAttemptConsolidation() bool {
-	// the last cluster consolidation wasn't able to improve things and nothing has changed regarding
-	// the cluster that makes us think we would be successful now
-	return c.lastConsolidationState != c.cluster.ClusterConsolidationState()
-}
-
 // sortAndFilterCandidates orders deprovisionable nodes by the disruptionCost, removing any that we already know won't
 // be viable consolidation options.
 func (c *consolidation) sortAndFilterCandidates(ctx context.Context, nodes []CandidateNode) ([]CandidateNode, error) {

--- a/pkg/controllers/deprovisioning/emptiness.go
+++ b/pkg/controllers/deprovisioning/emptiness.go
@@ -23,7 +23,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/ptr"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/samber/lo"
 
@@ -35,16 +34,12 @@ import (
 // Emptiness is a subreconciler that deletes empty nodes.
 // Emptiness will respect TTLSecondsAfterEmpty
 type Emptiness struct {
-	clock      clock.Clock
-	kubeClient client.Client
-	cluster    *state.Cluster
+	clock clock.Clock
 }
 
-func NewEmptiness(clk clock.Clock, kubeClient client.Client, cluster *state.Cluster) *Emptiness {
+func NewEmptiness(clk clock.Clock) *Emptiness {
 	return &Emptiness{
-		clock:      clk,
-		kubeClient: kubeClient,
-		cluster:    cluster,
+		clock: clk,
 	}
 }
 

--- a/pkg/controllers/deprovisioning/emptynodeconsolidation.go
+++ b/pkg/controllers/deprovisioning/emptynodeconsolidation.go
@@ -42,7 +42,7 @@ func NewEmptyNodeConsolidation(clk clock.Clock, cluster *state.Cluster, kubeClie
 
 // ComputeCommand generates a deprovisioning command given deprovisionable nodes
 func (c *EmptyNodeConsolidation) ComputeCommand(ctx context.Context, candidates ...CandidateNode) (Command, error) {
-	if !c.ShouldAttemptConsolidation() {
+	if c.cluster.Consolidated() {
 		return Command{action: actionDoNothing}, nil
 	}
 	candidates, err := c.sortAndFilterCandidates(ctx, candidates)

--- a/pkg/controllers/deprovisioning/helpers.go
+++ b/pkg/controllers/deprovisioning/helpers.go
@@ -42,9 +42,9 @@ func simulateScheduling(ctx context.Context, kubeClient client.Client, cluster *
 	candidateNodes ...CandidateNode) (newNodes []*pscheduling.Node, allPodsScheduled bool, err error) {
 
 	candidateNodeNames := sets.NewString(lo.Map(candidateNodes, func(t CandidateNode, i int) string { return t.Name })...)
-	allNodes := cluster.Nodes()
-	deletingNodes := allNodes.DeletingNodes()
-	stateNodes := lo.Filter(allNodes, func(n *state.Node, _ int) bool {
+	nodes := cluster.Nodes()
+	deletingNodes := nodes.Deleting()
+	stateNodes := lo.Filter(nodes.Active(), func(n *state.Node, _ int) bool {
 		return !candidateNodeNames.Has(n.Name())
 	})
 

--- a/pkg/controllers/deprovisioning/multinodeconsolidation.go
+++ b/pkg/controllers/deprovisioning/multinodeconsolidation.go
@@ -39,7 +39,7 @@ func NewMultiNodeConsolidation(clk clock.Clock, cluster *state.Cluster, kubeClie
 }
 
 func (m *MultiNodeConsolidation) ComputeCommand(ctx context.Context, candidates ...CandidateNode) (Command, error) {
-	if !m.ShouldAttemptConsolidation() {
+	if m.cluster.Consolidated() {
 		return Command{action: actionDoNothing}, nil
 	}
 	candidates, err := m.sortAndFilterCandidates(ctx, candidates)

--- a/pkg/controllers/deprovisioning/singlenodeconsolidation.go
+++ b/pkg/controllers/deprovisioning/singlenodeconsolidation.go
@@ -41,7 +41,7 @@ func NewSingleNodeConsolidation(clk clock.Clock, cluster *state.Cluster, kubeCli
 //
 //nolint:gocyclo
 func (c *SingleNodeConsolidation) ComputeCommand(ctx context.Context, candidates ...CandidateNode) (Command, error) {
-	if !c.ShouldAttemptConsolidation() {
+	if c.cluster.Consolidated() {
 		return Command{action: actionDoNothing}, nil
 	}
 	candidates, err := c.sortAndFilterCandidates(ctx, candidates)
@@ -58,7 +58,7 @@ func (c *SingleNodeConsolidation) ComputeCommand(ctx context.Context, candidates
 			logging.FromContext(ctx).Errorf("computing consolidation %s", err)
 			continue
 		}
-		if cmd.action == actionDoNothing || cmd.action == actionRetry || cmd.action == actionFailed {
+		if cmd.action == actionDoNothing || cmd.action == actionRetry {
 			continue
 		}
 

--- a/pkg/controllers/deprovisioning/suite_test.go
+++ b/pkg/controllers/deprovisioning/suite_test.go
@@ -36,6 +36,7 @@ import (
 	. "knative.dev/pkg/logging/testing"
 	"knative.dev/pkg/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/aws/karpenter-core/pkg/apis"
 	"github.com/aws/karpenter-core/pkg/apis/settings"
@@ -173,7 +174,7 @@ var _ = Describe("Drift", func() {
 		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node))
 		fakeClock.Step(10 * time.Minute)
 		go triggerVerifyAction()
-		_, err := deprovisioningController.ProcessCluster(ctx)
+		_, err := deprovisioningController.Reconcile(ctx, reconcile.Request{})
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(cloudProvider.CreateCalls).To(HaveLen(0))
@@ -205,7 +206,7 @@ var _ = Describe("Drift", func() {
 		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node))
 		fakeClock.Step(10 * time.Minute)
 		go triggerVerifyAction()
-		_, err := deprovisioningController.ProcessCluster(ctx)
+		_, err := deprovisioningController.Reconcile(ctx, reconcile.Request{})
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(cloudProvider.CreateCalls).To(HaveLen(0))
@@ -232,7 +233,7 @@ var _ = Describe("Drift", func() {
 		// inform cluster state about the nodes
 		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node))
 		fakeClock.Step(10 * time.Minute)
-		_, err := deprovisioningController.ProcessCluster(ctx)
+		_, err := deprovisioningController.Reconcile(ctx, reconcile.Request{})
 		Expect(err).ToNot(HaveOccurred())
 
 		// we don't need a new node
@@ -266,7 +267,7 @@ var _ = Describe("Drift", func() {
 		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node))
 		fakeClock.Step(10 * time.Minute)
 		go triggerVerifyAction()
-		_, err := deprovisioningController.ProcessCluster(ctx)
+		_, err := deprovisioningController.Reconcile(ctx, reconcile.Request{})
 		Expect(err).ToNot(HaveOccurred())
 
 		// we don't need a new node, but we should evict everything off one of node2 which only has a single pod
@@ -321,7 +322,7 @@ var _ = Describe("Drift", func() {
 		wg := ExpectMakeNewNodesReady(ctx, env.Client, 1, node)
 		fakeClock.Step(10 * time.Minute)
 		go triggerVerifyAction()
-		_, err := deprovisioningController.ProcessCluster(ctx)
+		_, err := deprovisioningController.Reconcile(ctx, reconcile.Request{})
 		Expect(err).ToNot(HaveOccurred())
 		wg.Wait()
 
@@ -413,7 +414,7 @@ var _ = Describe("Drift", func() {
 		wg := ExpectMakeNewNodesReady(ctx, env.Client, 3, node)
 		fakeClock.Step(10 * time.Minute)
 		go triggerVerifyAction()
-		_, err := deprovisioningController.ProcessCluster(ctx)
+		_, err := deprovisioningController.Reconcile(ctx, reconcile.Request{})
 		Expect(err).ToNot(HaveOccurred())
 		wg.Wait()
 
@@ -457,7 +458,7 @@ var _ = Describe("Drift", func() {
 		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node2))
 		fakeClock.Step(10 * time.Minute)
 		go triggerVerifyAction()
-		_, err := deprovisioningController.ProcessCluster(ctx)
+		_, err := deprovisioningController.Reconcile(ctx, reconcile.Request{})
 		Expect(err).ToNot(HaveOccurred())
 
 		// we don't need a new node, but we should evict everything off one of node2 which only has a single pod
@@ -492,7 +493,7 @@ var _ = Describe("Expiration", func() {
 		// inform cluster state about the nodes
 		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node))
 		fakeClock.Step(10 * time.Minute)
-		_, err := deprovisioningController.ProcessCluster(ctx)
+		_, err := deprovisioningController.Reconcile(ctx, reconcile.Request{})
 		Expect(err).ToNot(HaveOccurred())
 
 		// we don't need a new node
@@ -525,7 +526,7 @@ var _ = Describe("Expiration", func() {
 		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node))
 		fakeClock.Step(10 * time.Minute)
 		go triggerVerifyAction()
-		_, err := deprovisioningController.ProcessCluster(ctx)
+		_, err := deprovisioningController.Reconcile(ctx, reconcile.Request{})
 		Expect(err).ToNot(HaveOccurred())
 
 		// we don't need a new node, but we should evict everything off one of node2 which only has a single pod
@@ -569,7 +570,7 @@ var _ = Describe("Expiration", func() {
 		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(nodeNotExpire))
 		fakeClock.Step(10 * time.Minute)
 		go triggerVerifyAction()
-		_, err := deprovisioningController.ProcessCluster(ctx)
+		_, err := deprovisioningController.Reconcile(ctx, reconcile.Request{})
 		Expect(err).ToNot(HaveOccurred())
 
 		// we don't need a new node, but we should evict everything off one of node2 which only has a single pod
@@ -623,7 +624,7 @@ var _ = Describe("Expiration", func() {
 		wg := ExpectMakeNewNodesReady(ctx, env.Client, 1, node)
 		fakeClock.Step(10 * time.Minute)
 		go triggerVerifyAction()
-		_, err := deprovisioningController.ProcessCluster(ctx)
+		_, err := deprovisioningController.Reconcile(ctx, reconcile.Request{})
 		Expect(err).ToNot(HaveOccurred())
 		wg.Wait()
 
@@ -713,7 +714,7 @@ var _ = Describe("Expiration", func() {
 
 		fakeClock.Step(10 * time.Minute)
 		go triggerVerifyAction()
-		_, err := deprovisioningController.ProcessCluster(ctx)
+		_, err := deprovisioningController.Reconcile(ctx, reconcile.Request{})
 		Expect(err).To(HaveOccurred())
 
 		// Expiration should try to make 3 calls but fail for the third.
@@ -805,7 +806,7 @@ var _ = Describe("Expiration", func() {
 		wg := ExpectMakeNewNodesReady(ctx, env.Client, 3, node)
 		fakeClock.Step(10 * time.Minute)
 		go triggerVerifyAction()
-		_, err := deprovisioningController.ProcessCluster(ctx)
+		_, err := deprovisioningController.Reconcile(ctx, reconcile.Request{})
 		Expect(err).ToNot(HaveOccurred())
 		wg.Wait()
 
@@ -918,7 +919,7 @@ var _ = Describe("Replace Nodes", func() {
 		wg := ExpectMakeNewNodesReady(ctx, env.Client, 1, node)
 		fakeClock.Step(10 * time.Minute)
 		go triggerVerifyAction()
-		_, err := deprovisioningController.ProcessCluster(ctx)
+		_, err := deprovisioningController.Reconcile(ctx, reconcile.Request{})
 		Expect(err).ToNot(HaveOccurred())
 		wg.Wait()
 
@@ -993,7 +994,7 @@ var _ = Describe("Replace Nodes", func() {
 		// inform cluster state about the nodes
 		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node1))
 		fakeClock.Step(10 * time.Minute)
-		_, err := deprovisioningController.ProcessCluster(ctx)
+		_, err := deprovisioningController.Reconcile(ctx, reconcile.Request{})
 		Expect(err).ToNot(HaveOccurred())
 
 		// we don't need a new node
@@ -1063,7 +1064,7 @@ var _ = Describe("Replace Nodes", func() {
 		wg := ExpectMakeNewNodesReady(ctx, env.Client, 1, node)
 		fakeClock.Step(10 * time.Minute)
 		go triggerVerifyAction()
-		_, err := deprovisioningController.ProcessCluster(ctx)
+		_, err := deprovisioningController.Reconcile(ctx, reconcile.Request{})
 		Expect(err).ToNot(HaveOccurred())
 		wg.Wait()
 
@@ -1145,7 +1146,7 @@ var _ = Describe("Replace Nodes", func() {
 		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(annotatedNode))
 		fakeClock.Step(10 * time.Minute)
 		go triggerVerifyAction()
-		_, err := deprovisioningController.ProcessCluster(ctx)
+		_, err := deprovisioningController.Reconcile(ctx, reconcile.Request{})
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(cloudProvider.CreateCalls).To(HaveLen(0))
@@ -1235,7 +1236,7 @@ var _ = Describe("Replace Nodes", func() {
 
 		fakeClock.Step(10 * time.Minute)
 		go triggerVerifyAction()
-		_, err := deprovisioningController.ProcessCluster(ctx)
+		_, err := deprovisioningController.Reconcile(ctx, reconcile.Request{})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(cloudProvider.CreateCalls).To(HaveLen(0))
 		ExpectNodeExists(ctx, env.Client, node.Name)
@@ -1338,7 +1339,7 @@ var _ = Describe("Replace Nodes", func() {
 
 		fakeClock.Step(10 * time.Minute)
 		go triggerVerifyAction()
-		_, err := deprovisioningController.ProcessCluster(ctx)
+		_, err := deprovisioningController.Reconcile(ctx, reconcile.Request{})
 		Expect(err).ToNot(HaveOccurred())
 		Expect(cloudProvider.CreateCalls).To(HaveLen(0))
 		ExpectNodeExists(ctx, env.Client, node.Name)
@@ -1393,7 +1394,7 @@ var _ = Describe("Replace Nodes", func() {
 		var consolidationFinished atomic.Bool
 		go triggerVerifyAction()
 		go func() {
-			_, err := deprovisioningController.ProcessCluster(ctx)
+			_, err := deprovisioningController.Reconcile(ctx, reconcile.Request{})
 			Expect(err).ToNot(HaveOccurred())
 			consolidationFinished.Store(true)
 		}()
@@ -1486,7 +1487,7 @@ var _ = Describe("Delete Node", func() {
 		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node2))
 		fakeClock.Step(10 * time.Minute)
 		go triggerVerifyAction()
-		_, err := deprovisioningController.ProcessCluster(ctx)
+		_, err := deprovisioningController.Reconcile(ctx, reconcile.Request{})
 		Expect(err).ToNot(HaveOccurred())
 
 		// we don't need a new node, but we should evict everything off one of node2 which only has a single pod
@@ -1578,7 +1579,7 @@ var _ = Describe("Delete Node", func() {
 		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node2))
 		fakeClock.Step(10 * time.Minute)
 		go triggerVerifyAction()
-		_, err := deprovisioningController.ProcessCluster(ctx)
+		_, err := deprovisioningController.Reconcile(ctx, reconcile.Request{})
 		Expect(err).ToNot(HaveOccurred())
 
 		// we don't need a new node
@@ -1656,7 +1657,7 @@ var _ = Describe("Delete Node", func() {
 		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node2))
 		fakeClock.Step(10 * time.Minute)
 		go triggerVerifyAction()
-		_, err := deprovisioningController.ProcessCluster(ctx)
+		_, err := deprovisioningController.Reconcile(ctx, reconcile.Request{})
 		Expect(err).ToNot(HaveOccurred())
 
 		// we don't need a new node
@@ -1731,7 +1732,7 @@ var _ = Describe("Delete Node", func() {
 		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node2))
 		fakeClock.Step(10 * time.Minute)
 		go triggerVerifyAction()
-		_, err := deprovisioningController.ProcessCluster(ctx)
+		_, err := deprovisioningController.Reconcile(ctx, reconcile.Request{})
 		Expect(err).ToNot(HaveOccurred())
 
 		// we don't need a new node
@@ -1814,7 +1815,7 @@ var _ = Describe("Node Lifetime Consideration", func() {
 		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node2))
 		fakeClock.SetTime(time.Now())
 		go triggerVerifyAction()
-		_, err := deprovisioningController.ProcessCluster(ctx)
+		_, err := deprovisioningController.Reconcile(ctx, reconcile.Request{})
 		Expect(err).ToNot(HaveOccurred())
 
 		// the second node has more pods so it would normally not be picked for consolidation, except it very little
@@ -1912,7 +1913,7 @@ var _ = Describe("Topology Consideration", func() {
 		wg := ExpectMakeNewNodesReady(ctx, env.Client, 1, zone1Node, zone2Node, zone3Node)
 		fakeClock.Step(10 * time.Minute)
 		go triggerVerifyAction()
-		_, err := deprovisioningController.ProcessCluster(ctx)
+		_, err := deprovisioningController.Reconcile(ctx, reconcile.Request{})
 		Expect(err).ToNot(HaveOccurred())
 		wg.Wait()
 
@@ -2014,7 +2015,7 @@ var _ = Describe("Topology Consideration", func() {
 		wg := ExpectMakeNewNodesReady(ctx, env.Client, 1, zone1Node, zone2Node, zone3Node)
 		fakeClock.Step(10 * time.Minute)
 		go triggerVerifyAction()
-		_, err := deprovisioningController.ProcessCluster(ctx)
+		_, err := deprovisioningController.Reconcile(ctx, reconcile.Request{})
 		Expect(err).ToNot(HaveOccurred())
 		wg.Wait()
 
@@ -2053,7 +2054,7 @@ var _ = Describe("Empty Nodes", func() {
 		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node1))
 		fakeClock.Step(10 * time.Minute)
 		go triggerVerifyAction()
-		_, err := deprovisioningController.ProcessCluster(ctx)
+		_, err := deprovisioningController.Reconcile(ctx, reconcile.Request{})
 		Expect(err).ToNot(HaveOccurred())
 
 		// we don't need any new nodes
@@ -2097,7 +2098,7 @@ var _ = Describe("Empty Nodes", func() {
 		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node2))
 		fakeClock.Step(10 * time.Minute)
 		go triggerVerifyAction()
-		_, err := deprovisioningController.ProcessCluster(ctx)
+		_, err := deprovisioningController.Reconcile(ctx, reconcile.Request{})
 		Expect(err).ToNot(HaveOccurred())
 
 		// we don't need any new nodes
@@ -2131,7 +2132,7 @@ var _ = Describe("Empty Nodes", func() {
 
 		fakeClock.Step(10 * time.Minute)
 		go triggerVerifyAction()
-		_, err := deprovisioningController.ProcessCluster(ctx)
+		_, err := deprovisioningController.Reconcile(ctx, reconcile.Request{})
 		Expect(err).ToNot(HaveOccurred())
 
 		// we don't need any new nodes
@@ -2180,7 +2181,7 @@ var _ = Describe("Empty Nodes", func() {
 
 		fakeClock.Step(10 * time.Minute)
 		go triggerVerifyAction()
-		_, err := deprovisioningController.ProcessCluster(ctx)
+		_, err := deprovisioningController.Reconcile(ctx, reconcile.Request{})
 		Expect(err).ToNot(HaveOccurred())
 
 		// we don't need any new nodes and consolidation should notice the huge pending pod that needs the large
@@ -2221,7 +2222,7 @@ var _ = Describe("consolidation TTL", func() {
 		go func() {
 			defer wg.Done()
 			defer finished.Store(true)
-			_, err := deprovisioningController.ProcessCluster(ctx)
+			_, err := deprovisioningController.Reconcile(ctx, reconcile.Request{})
 			Expect(err).ToNot(HaveOccurred())
 		}()
 
@@ -2313,7 +2314,7 @@ var _ = Describe("consolidation TTL", func() {
 		go func() {
 			defer wg.Done()
 			defer finished.Store(true)
-			_, err := deprovisioningController.ProcessCluster(ctx)
+			_, err := deprovisioningController.Reconcile(ctx, reconcile.Request{})
 			Expect(err).ToNot(HaveOccurred())
 		}()
 
@@ -2366,7 +2367,7 @@ var _ = Describe("consolidation TTL", func() {
 		go func() {
 			defer wg.Done()
 			defer finished.Store(true)
-			_, err := deprovisioningController.ProcessCluster(ctx)
+			_, err := deprovisioningController.Reconcile(ctx, reconcile.Request{})
 			Expect(err).ToNot(HaveOccurred())
 		}()
 
@@ -2445,7 +2446,7 @@ var _ = Describe("Parallelization", func() {
 		// Run the processing loop in parallel in the background with environment context
 		go triggerVerifyAction()
 		go func() {
-			_, err := deprovisioningController.ProcessCluster(ctx)
+			_, err := deprovisioningController.Reconcile(ctx, reconcile.Request{})
 			Expect(err).ToNot(HaveOccurred())
 		}()
 
@@ -2545,9 +2546,9 @@ var _ = Describe("Parallelization", func() {
 		// Trigger a reconciliation run which should take into account the deleting node
 		// cnsolidation shouldn't trigger additional actions
 		fakeClock.Step(10 * time.Minute)
-		result, err := deprovisioningController.ProcessCluster(ctx)
+		result, err := deprovisioningController.Reconcile(ctx, reconcile.Request{})
 		Expect(err).ToNot(HaveOccurred())
-		Expect(result).To(Equal(deprovisioning.ResultNothingToDo))
+		Expect(result.RequeueAfter).To(BeNumerically(">", 0))
 	})
 })
 
@@ -2630,7 +2631,7 @@ var _ = Describe("Multi-Node Consolidation", func() {
 		fakeClock.Step(10 * time.Minute)
 		wg := ExpectMakeNewNodesReady(ctx, env.Client, 1, node1, node2, node3)
 		go triggerVerifyAction()
-		_, err := deprovisioningController.ProcessCluster(ctx)
+		_, err := deprovisioningController.Reconcile(ctx, reconcile.Request{})
 		Expect(err).ToNot(HaveOccurred())
 		wg.Wait()
 
@@ -2704,7 +2705,7 @@ var _ = Describe("Multi-Node Consolidation", func() {
 		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node2))
 		fakeClock.Step(10 * time.Minute)
 		go triggerVerifyAction()
-		_, err := deprovisioningController.ProcessCluster(ctx)
+		_, err := deprovisioningController.Reconcile(ctx, reconcile.Request{})
 		Expect(err).ToNot(HaveOccurred())
 
 		// We have [cheap-node, cheap-node] which multi-node consolidation could consolidate via
@@ -2789,7 +2790,7 @@ var _ = Describe("Multi-Node Consolidation", func() {
 		go func() {
 			defer wg.Done()
 			defer finished.Store(true)
-			_, err := deprovisioningController.ProcessCluster(ctx)
+			_, err := deprovisioningController.Reconcile(ctx, reconcile.Request{})
 			Expect(err).ToNot(HaveOccurred())
 		}()
 

--- a/pkg/controllers/state/informer/provisioner.go
+++ b/pkg/controllers/state/informer/provisioner.go
@@ -51,7 +51,7 @@ func (c *ProvisionerController) Name() string {
 
 func (c *ProvisionerController) Reconcile(_ context.Context, _ *v1alpha5.Provisioner) (reconcile.Result, error) {
 	// Something changed in the provisioner so we should re-consider consolidation
-	c.cluster.RecordConsolidationChange()
+	c.cluster.SetConsolidated(false)
 	return reconcile.Result{}, nil
 }
 

--- a/pkg/controllers/state/node.go
+++ b/pkg/controllers/state/node.go
@@ -35,15 +35,15 @@ import (
 // Nodes is a typed version of a list of *Node
 type Nodes []*Node
 
-// ActiveNodes filters nodes that are not in a MarkedForDeletion state
-func (n Nodes) ActiveNodes() Nodes {
+// Active filters nodes that are not in a MarkedForDeletion state
+func (n Nodes) Active() Nodes {
 	return lo.Filter(n, func(node *Node, _ int) bool {
 		return !node.MarkedForDeletion()
 	})
 }
 
-// DeletingNodes filters nodes that are in a MarkedForDeletion state
-func (n Nodes) DeletingNodes() Nodes {
+// Deleting filters nodes that are in a MarkedForDeletion state
+func (n Nodes) Deleting() Nodes {
 	return lo.Filter(n, func(node *Node, _ int) bool {
 		return node.MarkedForDeletion()
 	})

--- a/pkg/controllers/state/suite_test.go
+++ b/pkg/controllers/state/suite_test.go
@@ -1217,13 +1217,12 @@ var _ = Describe("Pod Anti-Affinity", func() {
 
 var _ = Describe("Provisioner Spec Updates", func() {
 	It("should cause consolidation state to change when a provisioner is updated", func() {
-		oldConsolidationState := cluster.ClusterConsolidationState()
+		cluster.SetConsolidated(true)
 		fakeClock.Step(time.Minute)
 		provisioner.Spec.Consolidation = &v1alpha5.Consolidation{Enabled: ptr.Bool(true)}
 		ExpectApplied(ctx, env.Client, provisioner)
 		ExpectReconcileSucceeded(ctx, provisionerController, client.ObjectKeyFromObject(provisioner))
-
-		Expect(oldConsolidationState).To(BeNumerically("<", cluster.ClusterConsolidationState()))
+		Expect(cluster.Consolidated()).To(BeFalse())
 	})
 })
 


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes #2021

**Description**

* Nothing was using `ResultRetry`, which just became success/failed, which maps 1:1 with err being nil or not
* Combined `RecordLastState` from individual deprovisioners into cluster state, which enabled the deprovisioning controller to be unaware of any specific subcontroller.

**How was this change tested?**

`make test`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
