### PR TITLE
test: Fix cache syncing causing transient failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,15 @@ test: ## Run tests
 		--ginkgo.focus="${FOCUS}" \
 		-cover -coverprofile=coverage.out -outputdir=. -coverpkg=./...
 
+deflake: ## Run randomized, racing tests until the test fails to catch flakes
+	ginkgo \
+		--race \
+		--focus="${FOCUS}" \
+		--randomize-all \
+		--until-it-fails \
+		-v \
+		./pkg/...
+
 verify: ## Verify code. Includes codegen, dependencies, linting, formatting, etc
 	go mod tidy
 	go generate ./...

--- a/pkg/controllers/machine/suite_test.go
+++ b/pkg/controllers/machine/suite_test.go
@@ -52,7 +52,7 @@ var cloudProvider *fake.CloudProvider
 func TestAPIs(t *testing.T) {
 	ctx = TestContextWithLogger(t)
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Node")
+	RunSpecs(t, "Machine")
 }
 
 var _ = BeforeSuite(func() {

--- a/pkg/test/cachesyncingclient.go
+++ b/pkg/test/cachesyncingclient.go
@@ -149,11 +149,11 @@ func (c *cacheSyncingStatusWriter) Patch(ctx context.Context, obj client.Object,
 }
 
 func objectSynced(ctx context.Context, c client.Client, obj client.Object) error {
-	stored := obj.DeepCopyObject().(client.Object)
-	if err := c.Get(ctx, client.ObjectKeyFromObject(obj), obj); err != nil {
+	temp := obj.DeepCopyObject().(client.Object)
+	if err := c.Get(ctx, client.ObjectKeyFromObject(obj), temp); err != nil {
 		return fmt.Errorf("getting object, %w", err)
 	}
-	if obj.GetResourceVersion() != stored.GetResourceVersion() {
+	if obj.GetResourceVersion() != temp.GetResourceVersion() {
 		return fmt.Errorf("object hasn't updated")
 	}
 	return nil


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

- Fix cache syncing causing transient failures
- Cache syncing was updating the pointer when it would try to re-get the object, so, in reality, the syncing portion of the client would only attempt to get the updated object twice

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
