### PR TITLE
fix: Return an error when receiving no `provider` or `providerRef`

### DIFF
--- a/hack/toolchain.sh
+++ b/hack/toolchain.sh
@@ -16,7 +16,7 @@ tools() {
     go install github.com/mikefarah/yq/v4@v4.24.5
     go install github.com/norwoodj/helm-docs/cmd/helm-docs@v1.8.1
     go install sigs.k8s.io/controller-runtime/tools/setup-envtest@v0.0.0-20220421205612-c162794a9b12
-    go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.8.0
+    go install sigs.k8s.io/controller-tools/cmd/controller-gen@v0.11.2
     go install github.com/sigstore/cosign/cmd/cosign@v1.10.0
     go install github.com/gohugoio/hugo@v0.97.3+extended
     go install golang.org/x/vuln/cmd/govulncheck@v0.0.0-20220902211423-27dd78d2ca39

--- a/pkg/apis/crds/karpenter.sh_machines.yaml
+++ b/pkg/apis/crds/karpenter.sh_machines.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.11.2
   creationTimestamp: null
   name: machines.karpenter.sh
 spec:
@@ -155,6 +155,8 @@ spec:
                   name:
                     description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
                     type: string
+                required:
+                - name
                 type: object
               requirements:
                 description: Requirements are layered with Labels and applied to every
@@ -327,9 +329,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/pkg/apis/crds/karpenter.sh_provisioners.yaml
+++ b/pkg/apis/crds/karpenter.sh_provisioners.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.8.0
+    controller-gen.kubebuilder.io/version: v0.11.2
   creationTimestamp: null
   name: provisioners.karpenter.sh
 spec:
@@ -188,6 +188,8 @@ spec:
                   name:
                     description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
                     type: string
+                required:
+                - name
                 type: object
               requirements:
                 description: Requirements are layered with Labels and applied to every
@@ -370,9 +372,3 @@ spec:
     storage: true
     subresources:
       status: {}
-status:
-  acceptedNames:
-    kind: ""
-    plural: ""
-  conditions: []
-  storedVersions: []

--- a/pkg/apis/v1alpha5/machine.go
+++ b/pkg/apis/v1alpha5/machine.go
@@ -110,7 +110,8 @@ type ProviderRef struct {
 	// Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds"
 	Kind string `json:"kind,omitempty"`
 	// Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names
-	Name string `json:"name,omitempty"`
+	// +required
+	Name string `json:"name"`
 	// API version of the referent
 	// +optional
 	APIVersion string `json:"apiVersion,omitempty"`

--- a/pkg/apis/v1alpha5/provisioner_validation.go
+++ b/pkg/apis/v1alpha5/provisioner_validation.go
@@ -185,9 +185,13 @@ func (s *ProvisionerSpec) validateRequirements() (errs *apis.FieldError) {
 	return errs
 }
 
+// validateProvider checks if exactly one of provider and providerRef are set
 func (s *ProvisionerSpec) validateProvider() *apis.FieldError {
 	if s.Provider != nil && s.ProviderRef != nil {
 		return apis.ErrMultipleOneOf(providerPath, providerRefPath)
+	}
+	if s.Provider == nil && s.ProviderRef == nil {
+		return apis.ErrMissingOneOf(providerPath, providerRefPath)
 	}
 	return nil
 }

--- a/pkg/apis/v1alpha5/suite_test.go
+++ b/pkg/apis/v1alpha5/suite_test.go
@@ -47,7 +47,12 @@ var _ = Describe("Validation", func() {
 	BeforeEach(func() {
 		provisioner = &Provisioner{
 			ObjectMeta: metav1.ObjectMeta{Name: strings.ToLower(randomdata.SillyName())},
-			Spec:       ProvisionerSpec{},
+			Spec: ProvisionerSpec{
+				ProviderRef: &ProviderRef{
+					Kind: "NodeTemplate",
+					Name: "default",
+				},
+			},
 		}
 	})
 
@@ -102,6 +107,10 @@ var _ = Describe("Validation", func() {
 		It("should not allow provider and providerRef", func() {
 			provisioner.Spec.Provider = &Provider{}
 			provisioner.Spec.ProviderRef = &ProviderRef{Name: "providerRef"}
+			Expect(provisioner.Validate(ctx)).ToNot(Succeed())
+		})
+		It("should require at least one of provider and providerRef", func() {
+			provisioner.Spec.ProviderRef = nil
 			Expect(provisioner.Validate(ctx)).ToNot(Succeed())
 		})
 	})


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes https://github.com/aws/karpenter/issues/3343

**Description**

- Return an error when receiving no `provider` or `providerRef`

Tried using `x-kubernetes-validations` but this doesn't work for customers that have not enabled the feature flag and are using older versions of K8s

```console
error: error validating "pkg/apis/crds/karpenter.sh_provisioners.yaml": error validating data: ValidationError(CustomResourceDefinition.spec.versions[0].schema.openAPIV3Schema.properties.spec): unknown field "x-kubernetes-validations" in io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.JSONSchemaProps; if you choose to ignore these errors, turn validation off with --validate=false
```

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
