### PR TITLE
test: Deflake deprovisioning testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ test: ## Run tests
 	go test ./... \
 		-race \
 		--ginkgo.focus="${FOCUS}" \
+		--ginkgo.v \
 		-cover -coverprofile=coverage.out -outputdir=. -coverpkg=./...
 
 deflake: ## Run randomized, racing tests until the test fails to catch flakes

--- a/hack/toolchain.sh
+++ b/hack/toolchain.sh
@@ -20,6 +20,7 @@ tools() {
     go install github.com/sigstore/cosign/cmd/cosign@v1.10.0
     go install github.com/gohugoio/hugo@v0.97.3+extended
     go install golang.org/x/vuln/cmd/govulncheck@v0.0.0-20220902211423-27dd78d2ca39
+    go install github.com/onsi/ginkgo/v2/ginkgo@latest
 
     if ! echo "$PATH" | grep -q "${GOPATH:-undefined}/bin\|$HOME/go/bin"; then
         echo "Go workspace's \"bin\" directory is not in PATH. Run 'export PATH=\"\$PATH:\${GOPATH:-\$HOME/go}/bin\"'."

--- a/pkg/controllers/deprovisioning/suite_test.go
+++ b/pkg/controllers/deprovisioning/suite_test.go
@@ -739,9 +739,9 @@ var _ = Describe("Replace Nodes", func() {
 		Expect(consolidationFinished.Load()).To(BeFalse())
 
 		// fetch the latest node object and remove the finalizer
-		Expect(env.Client.Get(ctx, client.ObjectKeyFromObject(node), node)).To(Succeed())
+		node = ExpectExists(ctx, env.Client, node)
 		node.SetFinalizers([]string{})
-		Expect(env.Client.Update(ctx, node)).To(Succeed())
+		ExpectApplied(ctx, env.Client, node)
 
 		// consolidation should complete now that the finalizer on the node is gone and it can
 		// was actually deleted


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

- `go triggerVerifyAction()` was sometimes running after the test had completed. This meant that subsequent tests would trigger the verify action before they were expected, polluting the test
- This PR adds a tracker to the `sync.WaitGroup` so that we wait for the `triggerVerifyAction` to complete before proceeding to the next test

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
