### PR TITLE
fix: Fix panic in termination flow

### DIFF
--- a/pkg/controllers/machine/terminator/terminator.go
+++ b/pkg/controllers/machine/terminator/terminator.go
@@ -111,7 +111,8 @@ func (t *Terminator) TerminateNode(ctx context.Context, node *v1.Node) error {
 		if err := t.kubeClient.Patch(ctx, node, client.MergeFrom(stored)); err != nil {
 			return err
 		}
-		terminationSummary.Observe(time.Since(node.DeletionTimestamp.Time).Seconds())
+		// We use stored.DeletionTimestamp since the api-server may give back a node after the patch without a deletionTimestamp
+		terminationSummary.Observe(time.Since(stored.DeletionTimestamp.Time).Seconds())
 	}
 	return nil
 }

--- a/pkg/controllers/termination/controller.go
+++ b/pkg/controllers/termination/controller.go
@@ -66,17 +66,17 @@ func (c *Controller) Finalize(ctx context.Context, node *v1.Node) (reconcile.Res
 		return reconcile.Result{}, nil
 	}
 	if err := c.terminator.Cordon(ctx, node); err != nil {
-		return reconcile.Result{}, fmt.Errorf("cordoning node, %w", err)
+		return reconcile.Result{}, client.IgnoreNotFound(fmt.Errorf("cordoning node, %w", err))
 	}
 	if err := c.terminator.Drain(ctx, node); err != nil {
 		if terminator.IsNodeDrainError(err) {
 			c.recorder.Publish(events.NodeFailedToDrain(node, err))
 			return reconcile.Result{Requeue: true}, nil
 		}
-		return reconcile.Result{}, fmt.Errorf("draining node, %w", err)
+		return reconcile.Result{}, client.IgnoreNotFound(fmt.Errorf("draining node, %w", err))
 	}
 	if err := c.terminator.TerminateNode(ctx, node); err != nil {
-		return reconcile.Result{}, fmt.Errorf("terminating node, %w", err)
+		return reconcile.Result{}, client.IgnoreNotFound(fmt.Errorf("terminating node, %w", err))
 	}
 	return reconcile.Result{}, nil
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

- Termination could panic with the following error when the Patch() update results in the apiserver immediately return back an object that doesn't contain a deletionTimestamp set inside of it (because the object was quickly removed)

```console
2023-02-06T21:35:18.371Z	INFO	controller	Observed a panic in reconciler: runtime error: invalid memory address or nil pointer dereference	{"commit": "afe64e9", "controller": "termination", "controllerGroup": "", "controllerKind": "Node", "Node": {"name":"ip-192-168-112-11.us-east-2.compute.internal"}, "namespace": "", "name": "ip-192-168-112-11.us-east-2.compute.internal", "reconcileID": "4e585e34-4d43-412e-9f77-c5910f911e5f"}
        panic: runtime error: invalid memory address or nil pointer dereference [recovered]
        	panic: runtime error: invalid memory address or nil pointer dereference
        [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1f66d8e]
        
        goroutine 1021 [running]:
        [sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller](http://sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller)).Reconcile.func1()
        	[sigs.k8s.io/controller-runtime@v0.13.0/pkg/internal/controller/controller.go:118](http://sigs.k8s.io/controller-runtime@v0.13.0/pkg/internal/controller/controller.go:118) +0x1f4
        panic({0x2362b80, 0x413de40})
        	runtime/panic.go:884 +0x212
        [github.com/aws/karpenter-core/pkg/controllers/machine/terminator.(*Terminator](http://github.com/aws/karpenter-core/pkg/controllers/machine/terminator.(*Terminator)).TerminateNode(0xc000460c40, {0x2ce8a38, 0xc001d22a80}, 0xc0038b18c0)
        	[github.com/aws/karpenter-core@v0.23.1-0.20230203193516-586061d3d4fa/pkg/controllers/machine/terminator/terminator.go:114](http://github.com/aws/karpenter-core@v0.23.1-0.20230203193516-586061d3d4fa/pkg/controllers/machine/terminator/terminator.go:114) +0x28e
        [github.com/aws/karpenter-core/pkg/controllers/termination.(*Controller](http://github.com/aws/karpenter-core/pkg/controllers/termination.(*Controller)).Finalize(0xc000bfadb0, {0x2ce8a38, 0xc001d22a80}, 0xc0038b18c0)
        	[github.com/aws/karpenter-core@v0.23.1-0.20230203193516-586061d3d4fa/pkg/controllers/termination/controller.go:78](http://github.com/aws/karpenter-core@v0.23.1-0.20230203193516-586061d3d4fa/pkg/controllers/termination/controller.go:78) +0x3d1
        [github.com/aws/karpenter-core/pkg/operator/controller.(*typedDecorator[...]](http://github.com/aws/karpenter-core/pkg/operator/controller.(*typedDecorator[...])).Reconcile(0xc0004d0960, {0x2ce8a38, 0xc001d229f0}, {{{0x0, 0xc005bc0200?}, {0xc006ec93e0?, 0x7fb82d4ebaf0?}}})
        	[github.com/aws/karpenter-core@v0.23.1-0.20230203193516-586061d3d4fa/pkg/operator/controller/typed.go:77](http://github.com/aws/karpenter-core@v0.23.1-0.20230203193516-586061d3d4fa/pkg/operator/controller/typed.go:77) +0x669
        [sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller](http://sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller)).Reconcile(0x2ce8990?, {0x2ce8a38?, 0xc001d229f0?}, {{{0x0?, 0x2670220?}, {0xc006ec93e0?, 0x404cf4?}}})
        	[sigs.k8s.io/controller-runtime@v0.13.0/pkg/internal/controller/controller.go:121](http://sigs.k8s.io/controller-runtime@v0.13.0/pkg/internal/controller/controller.go:121) +0xc8
        [sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller](http://sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller)).reconcileHandler(0xc000f53b80, {0x2ce8990, 0xc000cb6dc0}, {0x2465aa0?, 0xc002db7a60?})
        	[sigs.k8s.io/controller-runtime@v0.13.0/pkg/internal/controller/controller.go:320](http://sigs.k8s.io/controller-runtime@v0.13.0/pkg/internal/controller/controller.go:320) +0x33c
        [sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller](http://sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller)).processNextWorkItem(0xc000f53b80, {0x2ce8990, 0xc000cb6dc0})
        	[sigs.k8s.io/controller-runtime@v0.13.0/pkg/internal/controller/controller.go:273](http://sigs.k8s.io/controller-runtime@v0.13.0/pkg/internal/controller/controller.go:273) +0x1d9
        [sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller](http://sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller)).Start.func2.2()
        	[sigs.k8s.io/controller-runtime@v0.13.0/pkg/internal/controller/controller.go:234](http://sigs.k8s.io/controller-runtime@v0.13.0/pkg/internal/controller/controller.go:234) +0x85
        created by [sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller](http://sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller)).Start.func2
        	[sigs.k8s.io/controller-runtime@v0.13.0/pkg/internal/controller/controller.go:230](http://sigs.k8s.io/controller-runtime@v0.13.0/pkg/internal/controller/controller.go:230) +0x333
```

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
