### PR TITLE
fix: Skip 'hugepages' resources on ceiling

### DIFF
--- a/pkg/utils/resources/resources.go
+++ b/pkg/utils/resources/resources.go
@@ -51,6 +51,9 @@ func Merge(resources ...v1.ResourceList) v1.ResourceList {
 	result := make(v1.ResourceList, len(resources[0]))
 	for _, resourceList := range resources {
 		for resourceName, quantity := range resourceList {
+			if resourceName == "hugepages-2Mi" || resourceName == "hugepages-1Gi" {
+				continue
+			}
 			current := result[resourceName]
 			current.Add(quantity)
 			result[resourceName] = current
@@ -93,6 +96,9 @@ func MaxResources(resources ...v1.ResourceList) v1.ResourceList {
 	resourceList := v1.ResourceList{}
 	for _, resource := range resources {
 		for resourceName, quantity := range resource {
+			if resourceName == "hugepages-2Mi" || resourceName == "hugepages-1Gi" {
+				continue
+			}
 			if value, ok := resourceList[resourceName]; !ok || quantity.Cmp(value) > 0 {
 				resourceList[resourceName] = quantity
 			}


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes https://github.com/aws/karpenter/issues/3315

**Description**
Following the issue above, this fix/feature resolves the above resource incompatibility.
Karpenter manages the nodes/instance types based on the resources keys/values it gets from the cloud provider, hence HW resources (i.e. cpu, memory, gpu, etc.). It can not manage SW resources - as hugepages (https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#resource-types) because they instance based rather than cloud provider based.
Karpenter just doesn't familiar with that resource type (and fails to deal with it when it appears in a workload.yaml), that's why I drop/filter this resource, as it can't be handled anyways via Karpenter.

Please tell if this change is not in the right place or if it might break something.


**How was this change tested?**
Cluster created, Provisioner resource applied, built a karpenter-controller image using my karpenter-core change and helm upgraded my cluster. Afterwards applied the yaml presented in the issue above, and node was allocated!


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
