### PR TITLE
chore: Handle insufficient capacity self-delete

### DIFF
--- a/pkg/cloudprovider/types.go
+++ b/pkg/cloudprovider/types.go
@@ -146,17 +146,17 @@ func (ofs Offerings) Cheapest() Offering {
 
 // MachineNotFoundError is an error type returned by CloudProviders when the reason for failure is NotFound
 type MachineNotFoundError struct {
-	Err error
+	error
 }
 
 func NewMachineNotFoundError(err error) *MachineNotFoundError {
 	return &MachineNotFoundError{
-		Err: err,
+		error: err,
 	}
 }
 
 func (e *MachineNotFoundError) Error() string {
-	return fmt.Sprintf("machine not found, %s", e.Err)
+	return fmt.Sprintf("machine not found, %s", e.error)
 }
 
 func IsMachineNotFoundError(err error) bool {
@@ -169,6 +169,36 @@ func IsMachineNotFoundError(err error) bool {
 
 func IgnoreMachineNotFoundError(err error) error {
 	if IsMachineNotFoundError(err) {
+		return nil
+	}
+	return err
+}
+
+// InsufficientCapacityError is an error type returned by CloudProviders when a launch fails due to a lack of capacity from machine requirements
+type InsufficientCapacityError struct {
+	error
+}
+
+func NewInsufficientCapacityError(err error) *InsufficientCapacityError {
+	return &InsufficientCapacityError{
+		error: err,
+	}
+}
+
+func (e *InsufficientCapacityError) Error() string {
+	return fmt.Sprintf("insufficient capacity, %s", e.error)
+}
+
+func IsInsufficientCapacityError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var icErr *InsufficientCapacityError
+	return errors.As(err, &icErr)
+}
+
+func IgnoreInsufficientCapacityError(err error) error {
+	if IsInsufficientCapacityError(err) {
 		return nil
 	}
 	return err

--- a/pkg/controllers/machine/launch.go
+++ b/pkg/controllers/machine/launch.go
@@ -42,6 +42,10 @@ func (l *Launch) Reconcile(ctx context.Context, machine *v1alpha5.Machine) (reco
 			logging.FromContext(ctx).Debugf("creating machine")
 			retrieved, err = l.cloudProvider.Create(ctx, machine)
 			if err != nil {
+				if cloudprovider.IsInsufficientCapacityError(err) {
+					logging.FromContext(ctx).Error(err)
+					return reconcile.Result{}, client.IgnoreNotFound(l.kubeClient.Delete(ctx, machine))
+				}
 				return reconcile.Result{}, fmt.Errorf("creating machine, %w", err)
 			}
 		} else {


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

- Make an Insufficient Capacity Error a cloudprovider-neutral concept as well as ensure that if this error is returned during machine launch that we self-delete so we will go to re-launch

**How was this change tested?**

`make presubmit`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
