### PR TITLE
fix: Remove deletion webhooks

### DIFF
--- a/charts/karpenter-core/templates/webhooks.yaml
+++ b/charts/karpenter-core/templates/webhooks.yaml
@@ -55,7 +55,6 @@ webhooks:
         operations:
           - CREATE
           - UPDATE
-          - DELETE
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/pkg/apis/v1alpha5/provisioner_validation.go
+++ b/pkg/apis/v1alpha5/provisioner_validation.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/samber/lo"
 	"go.uber.org/multierr"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/sets"
@@ -61,6 +62,13 @@ const (
 	providerPath    = "provider"
 	providerRefPath = "providerRef"
 )
+
+func (p *Provisioner) SupportedVerbs() []admissionregistrationv1.OperationType {
+	return []admissionregistrationv1.OperationType{
+		admissionregistrationv1.Create,
+		admissionregistrationv1.Update,
+	}
+}
 
 func (p *Provisioner) Validate(ctx context.Context) (errs *apis.FieldError) {
 	return errs.Also(


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes #https://github.com/aws/karpenter/issues/3409

**Description**

If a bad CRD causes Karpenter to crash, customers can get stuck without the ability to remove CRDs, since deletion validation webhooks are on by default in knative. 

**How was this change tested?**

```
❯ k scale deployment karpenter -n karpenter --replicas 0
deployment.apps/karpenter scaled
 ~/workspaces/go/src/github.com/aws/karpenter │ deletionwh *1 !7 ?1 ───────────────────── dev ⎈ │ 14:58:23
❯ k apply -f test.yaml
Error from server (InternalError): error when creating "test.yaml": Internal error occurred: failed calling webhook "defaulting.webhook.karpenter.k8s.aws": failed to call webhook: Post "https://karpenter.karpenter.svc:443/default/karpenter.k8s.aws?timeout=10s": no endpoints available for service "karpenter"
 ~/workspaces/go/src/github.com/aws/karpenter │ deletionwh *1 !7 ?1 ───────────────────── dev ⎈ │ 14:58:31
❯ k scale deployment karpenter -n karpenter --replicas 1
deployment.apps/karpenter scaled
 ~/workspaces/go/src/github.com/aws/karpenter │ deletionwh *1 !7 ?1 ───────────────────── dev ⎈ │ 14:58:40
❯ k apply -f test.yaml
provisioner.karpenter.sh/test created
 ~/workspaces/go/src/github.com/aws/karpenter │ deletionwh *1 !7 ?1 ───────────────────── dev ⎈ │ 14:58:52
❯ k scale deployment karpenter -n karpenter --replicas 0
deployment.apps/karpenter scaled
 ~/workspaces/go/src/github.com/aws/karpenter │ deletionwh *1 !7 ?1 ───────────────────── dev ⎈ │ 14:59:00
❯ k delete -f test.yaml
Error from server (InternalError): error when deleting "test.yaml": Internal error occurred: failed calling webhook "validation.webhook.karpenter.k8s.aws": failed to call webhook: Post "https://karpenter.karpenter.svc:443/validate/karpenter.k8s.aws?timeout=10s": no endpoints available for service "karpenter"
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
