### PR TITLE
fix: remove multierr, upgrade go to 1.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,6 @@ require (
 	github.com/prometheus/client_golang v1.14.0
 	github.com/prometheus/client_model v0.3.0
 	github.com/samber/lo v1.37.0
-	go.uber.org/multierr v1.9.0
 	go.uber.org/zap v1.24.0
 	golang.org/x/time v0.0.0-20220609170525-579cf78fd858
 	k8s.io/api v0.25.4
@@ -74,6 +73,7 @@ require (
 	go.opencensus.io v0.23.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
 	go.uber.org/automaxprocs v1.4.0 // indirect
+	go.uber.org/multierr v1.9.0 // indirect
 	golang.org/x/exp v0.0.0-20220303212507-bbda1eaf7a17 // indirect
 	golang.org/x/net v0.5.0 // indirect
 	golang.org/x/oauth2 v0.0.0-20220223155221-ee480838109b // indirect

--- a/pkg/apis/settings/settings.go
+++ b/pkg/apis/settings/settings.go
@@ -16,10 +16,10 @@ package settings
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
-	"go.uber.org/multierr"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/configmap"
@@ -69,17 +69,17 @@ func (*Settings) Inject(ctx context.Context, cm *v1.ConfigMap) (context.Context,
 
 func (in *Settings) Validate() (err error) {
 	if in.BatchMaxDuration == nil {
-		err = multierr.Append(err, fmt.Errorf("batchMaxDuration is required"))
+		err = errors.Join(err, fmt.Errorf("batchMaxDuration is required"))
 	} else if in.BatchMaxDuration.Duration <= 0 {
-		err = multierr.Append(err, fmt.Errorf("batchMaxDuration cannot be negative"))
+		err = errors.Join(err, fmt.Errorf("batchMaxDuration cannot be negative"))
 	}
 	if in.BatchIdleDuration == nil {
-		err = multierr.Append(err, fmt.Errorf("batchIdleDuration is required"))
+		err = errors.Join(err, fmt.Errorf("batchIdleDuration is required"))
 	} else if in.BatchIdleDuration.Duration <= 0 {
-		err = multierr.Append(err, fmt.Errorf("batchIdleDuration cannot be negative"))
+		err = errors.Join(err, fmt.Errorf("batchIdleDuration cannot be negative"))
 	}
 	if in.TTLAfterNotRegistered != nil && in.TTLAfterNotRegistered.Duration <= 0 {
-		err = multierr.Append(err, fmt.Errorf("ttlAfterNotRegistered cannot be negative"))
+		err = errors.Join(err, fmt.Errorf("ttlAfterNotRegistered cannot be negative"))
 	}
 	return err
 }

--- a/pkg/controllers/node/controller.go
+++ b/pkg/controllers/node/controller.go
@@ -16,8 +16,8 @@ package node
 
 import (
 	"context"
+	"errors"
 
-	"go.uber.org/multierr"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/types"
@@ -101,7 +101,7 @@ func (c *Controller) Reconcile(ctx context.Context, node *v1.Node) (reconcile.Re
 	}
 	for _, reconciler := range reconcilers {
 		res, err := reconciler.Reconcile(ctx, provisioner, node)
-		errs = multierr.Append(errs, err)
+		errs = errors.Join(errs, err)
 		results = append(results, res)
 	}
 	if !equality.Semantic.DeepEqual(stored, node) {

--- a/pkg/controllers/provisioning/scheduling/topology.go
+++ b/pkg/controllers/provisioning/scheduling/topology.go
@@ -16,13 +16,13 @@ package scheduling
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"math"
 
 	"github.com/aws/karpenter-core/pkg/controllers/state"
 	"github.com/aws/karpenter-core/pkg/scheduling"
 
-	"go.uber.org/multierr"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
@@ -71,7 +71,7 @@ func NewTopology(ctx context.Context, kubeClient client.Client, cluster *state.C
 
 	errs := t.updateInverseAffinities(ctx)
 	for i := range pods {
-		errs = multierr.Append(errs, t.Update(ctx, pods[i]))
+		errs = errors.Join(errs, t.Update(ctx, pods[i]))
 	}
 	if errs != nil {
 		return nil, errs
@@ -190,7 +190,7 @@ func (t *Topology) updateInverseAffinities(ctx context.Context) error {
 			return true
 		}
 		if err := t.updateInverseAntiAffinity(ctx, pod, node.Labels); err != nil {
-			errs = multierr.Append(errs, fmt.Errorf("tracking existing pod anti-affinity, %w", err))
+			errs = errors.Join(errs, fmt.Errorf("tracking existing pod anti-affinity, %w", err))
 		}
 		return true
 	})

--- a/pkg/scheduling/requirements.go
+++ b/pkg/scheduling/requirements.go
@@ -15,12 +15,12 @@ limitations under the License.
 package scheduling
 
 import (
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
 
 	"github.com/samber/lo"
-	"go.uber.org/multierr"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -126,10 +126,10 @@ func (r Requirements) Compatible(requirements Requirements) (errs error) {
 		if operator := requirements.Get(key).Operator(); r.Has(key) || operator == v1.NodeSelectorOpNotIn || operator == v1.NodeSelectorOpDoesNotExist {
 			continue
 		}
-		errs = multierr.Append(errs, fmt.Errorf("label %q does not have known values%s", key, labelHint(r, key)))
+		errs = errors.Join(errs, fmt.Errorf("label %q does not have known values%s", key, labelHint(r, key)))
 	}
 	// Well Known Labels must intersect, but if not defined, are allowed.
-	return multierr.Append(errs, r.Intersects(requirements))
+	return errors.Join(errs, r.Intersects(requirements))
 }
 
 // editDistance is an implementation of edit distance from Algorithms/DPV
@@ -199,7 +199,7 @@ func (r Requirements) Intersects(requirements Requirements) (errs error) {
 					continue
 				}
 			}
-			errs = multierr.Append(errs, fmt.Errorf("key %s, %s not in %s", key, incoming, existing))
+			errs = errors.Join(errs, fmt.Errorf("key %s, %s not in %s", key, incoming, existing))
 		}
 	}
 	return errs

--- a/pkg/scheduling/taints.go
+++ b/pkg/scheduling/taints.go
@@ -15,10 +15,10 @@ limitations under the License.
 package scheduling
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/samber/lo"
-	"go.uber.org/multierr"
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -34,7 +34,7 @@ func (ts Taints) Tolerates(pod *v1.Pod) (errs error) {
 			tolerates = tolerates || t.ToleratesTaint(&taint)
 		}
 		if !tolerates {
-			errs = multierr.Append(errs, fmt.Errorf("did not tolerate %s=%s:%s", taint.Key, taint.Value, taint.Effect))
+			errs = errors.Join(errs, fmt.Errorf("did not tolerate %s=%s:%s", taint.Key, taint.Value, taint.Effect))
 		}
 	}
 	return errs


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes #216  <!-- issue number -->

**Description**

Removed `multierr` package and replaced with Go 1.20 `errors.Join`

Upgrades repository Go version to 1.20 to allow for new `errors` library features.

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
