### PR TITLE
fix!: Prevent eviction hanging due to `do-not-evict`

### DIFF
--- a/pkg/controllers/deprovisioning/emptiness.go
+++ b/pkg/controllers/deprovisioning/emptiness.go
@@ -18,9 +18,8 @@ import (
 	"context"
 	"time"
 
-	"k8s.io/utils/clock"
-
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/utils/clock"
 	"knative.dev/pkg/logging"
 	"knative.dev/pkg/ptr"
 
@@ -66,7 +65,11 @@ func (e *Emptiness) ShouldDeprovision(ctx context.Context, n *state.Node, provis
 
 // ComputeCommand generates a deprovisioning command given deprovisionable nodes
 func (e *Emptiness) ComputeCommand(_ context.Context, nodes ...CandidateNode) (Command, error) {
-	emptyNodes := lo.Filter(nodes, func(n CandidateNode, _ int) bool { return len(n.pods) == 0 })
+	emptyNodes := lo.Filter(nodes, func(n CandidateNode, _ int) bool {
+		_, canTerminate := canBeTerminated(n, nil)
+		return len(n.pods) == 0 && canTerminate
+	})
+
 	if len(emptyNodes) == 0 {
 		return Command{action: actionDoNothing}, nil
 	}

--- a/pkg/controllers/deprovisioning/suite_test.go
+++ b/pkg/controllers/deprovisioning/suite_test.go
@@ -932,7 +932,7 @@ var _ = Describe("Delete Node", func() {
 		ExpectNotFound(ctx, env.Client, node1)
 	})
 	It("can delete nodes, considers do-not-evict", func() {
-		// create our RS so we can link a pod to it
+		// create our RS, so we can link a pod to it
 		rs := test.ReplicaSet()
 		ExpectApplied(ctx, env.Client, rs)
 		Expect(env.Client.Get(ctx, client.ObjectKeyFromObject(rs), rs)).To(Succeed())
@@ -1000,6 +1000,7 @@ var _ = Describe("Delete Node", func() {
 		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node2))
 
 		fakeClock.Step(10 * time.Minute)
+
 		var wg sync.WaitGroup
 		ExpectTriggerVerifyAction(&wg)
 		_, err := deprovisioningController.Reconcile(ctx, reconcile.Request{})

--- a/pkg/controllers/inflightchecks/termination.go
+++ b/pkg/controllers/inflightchecks/termination.go
@@ -42,7 +42,6 @@ func (t *Termination) Check(ctx context.Context, node *v1.Node, provisioner *v1a
 	if node.DeletionTimestamp.IsZero() {
 		return nil, nil
 	}
-
 	pods, err := nodeutils.GetNodePods(ctx, t.kubeClient, node)
 	if err != nil {
 		return nil, err
@@ -54,13 +53,5 @@ func (t *Termination) Check(ctx context.Context, node *v1.Node, provisioner *v1a
 			message: fmt.Sprintf("Can't drain node, PDB %s is blocking evictions", pdb),
 		})
 	}
-
-	if reason, ok := deprovisioning.PodsPreventEviction(pods); ok {
-		issues = append(issues, Issue{
-			node:    node,
-			message: fmt.Sprintf("Can't drain node, %s", reason),
-		})
-	}
-
 	return issues, nil
 }

--- a/pkg/controllers/machine/terminator/terminator.go
+++ b/pkg/controllers/machine/terminator/terminator.go
@@ -76,9 +76,6 @@ func (t *Terminator) Drain(ctx context.Context, node *v1.Node) error {
 	var podsToEvict []*v1.Pod
 	// Skip node due to pods that are not able to be evicted
 	for _, p := range pods {
-		if podutil.HasDoNotEvict(p) {
-			return NewNodeDrainError(fmt.Errorf("pod %s/%s has do-not-evict annotation", p.Namespace, p.Name))
-		}
 		// Ignore if unschedulable is tolerated, since they will reschedule
 		if podutil.ToleratesUnschedulableTaint(p) {
 			continue


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes https://github.com/aws/karpenter/issues/3383

**Description**

Remove `do-not-evict` preventing eviction when the Node is forcefully deleted through `kubectl delete node` or some other forceful deletion mechanism (like AWS interruption). `do-not-evict` should only be considered for Karpenter's voluntary disruption mechanisms (like emptiness/underutilization/consolidation, expiration, drift, etc.)

__BREAKING CHANGE: Customers who are currently deleting nodes with pods that have `do-not-evict` annotations will no longer have nodes hang on draining for this, meaning that they can't use `do-not-evict` as a stop-gap__

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
