### PR TITLE
perf: Make list calls more consistent

### DIFF
--- a/pkg/controllers/machine/terminator/terminator.go
+++ b/pkg/controllers/machine/terminator/terminator.go
@@ -96,8 +96,8 @@ func (t *Terminator) Drain(ctx context.Context, node *v1.Node) error {
 
 // getPods returns a list of evictable pods for the node
 func (t *Terminator) getPods(ctx context.Context, node *v1.Node) ([]*v1.Pod, error) {
-	podList := &v1.PodList{}
-	if err := t.kubeClient.List(ctx, podList, client.MatchingFields{"spec.nodeName": node.Name}); err != nil {
+	podList := v1.PodList{}
+	if err := t.kubeClient.List(ctx, &podList, client.MatchingFields{"spec.nodeName": node.Name}); err != nil {
 		return nil, fmt.Errorf("listing pods on node, %w", err)
 	}
 	var pods []*v1.Pod

--- a/pkg/controllers/node/controller.go
+++ b/pkg/controllers/node/controller.go
@@ -118,8 +118,8 @@ func (c *Controller) Builder(ctx context.Context, m manager.Manager) corecontrol
 			// Reconcile all nodes related to a provisioner when it changes.
 			&source.Kind{Type: &v1alpha5.Provisioner{}},
 			handler.EnqueueRequestsFromMapFunc(func(o client.Object) (requests []reconcile.Request) {
-				nodes := &v1.NodeList{}
-				if err := c.kubeClient.List(ctx, nodes, client.MatchingLabels(map[string]string{v1alpha5.ProvisionerNameLabelKey: o.GetName()})); err != nil {
+				nodes := v1.NodeList{}
+				if err := c.kubeClient.List(ctx, &nodes, client.MatchingLabels(map[string]string{v1alpha5.ProvisionerNameLabelKey: o.GetName()})); err != nil {
 					logging.FromContext(ctx).Errorf("Failed to list nodes when mapping expiration watch events, %s", err)
 					return requests
 				}

--- a/pkg/controllers/node/emptiness.go
+++ b/pkg/controllers/node/emptiness.go
@@ -73,8 +73,8 @@ func (r *Emptiness) Reconcile(ctx context.Context, provisioner *v1alpha5.Provisi
 }
 
 func (r *Emptiness) isEmpty(ctx context.Context, n *v1.Node) (bool, error) {
-	pods := &v1.PodList{}
-	if err := r.kubeClient.List(ctx, pods, client.MatchingFields{"spec.nodeName": n.Name}); err != nil {
+	pods := v1.PodList{}
+	if err := r.kubeClient.List(ctx, &pods, client.MatchingFields{"spec.nodeName": n.Name}); err != nil {
 		return false, fmt.Errorf("listing pods for node, %w", err)
 	}
 	for i := range pods.Items {

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -327,8 +327,8 @@ func (p *Provisioner) Launch(ctx context.Context, m *scheduler.Machine, opts ...
 }
 
 func (p *Provisioner) getDaemonSetPods(ctx context.Context) ([]*v1.Pod, error) {
-	daemonSetList := &appsv1.DaemonSetList{}
-	if err := p.kubeClient.List(ctx, daemonSetList); err != nil {
+	daemonSetList := appsv1.DaemonSetList{}
+	if err := p.kubeClient.List(ctx, &daemonSetList); err != nil {
 		return nil, fmt.Errorf("listing daemonsets, %w", err)
 	}
 

--- a/pkg/controllers/provisioning/scheduling/topology.go
+++ b/pkg/controllers/provisioning/scheduling/topology.go
@@ -229,13 +229,13 @@ func (t *Topology) updateInverseAntiAffinity(ctx context.Context, pod *v1.Pod, d
 // countDomains initializes the topology group by registereding any well known domains and performing pod counts
 // against the cluster for any existing pods.
 func (t *Topology) countDomains(ctx context.Context, tg *TopologyGroup) error {
-	podList := &v1.PodList{}
+	podList := v1.PodList{}
 
 	// collect the pods from all the specified namespaces (don't see a way to query multiple namespaces
 	// simultaneously)
 	var pods []v1.Pod
 	for _, ns := range tg.namespaces.UnsortedList() {
-		if err := t.kubeClient.List(ctx, podList, TopologyListOptions(ns, tg.selector)); err != nil {
+		if err := t.kubeClient.List(ctx, &podList, TopologyListOptions(ns, tg.selector)); err != nil {
 			return fmt.Errorf("listing pods, %w", err)
 		}
 		pods = append(pods, podList.Items...)

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -80,8 +80,8 @@ func NewCluster(clk clock.Clock, client client.Client, cp cloudprovider.CloudPro
 // of the cluster is as close to correct as it can be when we begin to perform operations
 // utilizing the cluster state as our source of truth
 func (c *Cluster) Synced(ctx context.Context) bool {
-	machineList := &v1alpha5.MachineList{}
-	if err := c.kubeClient.List(ctx, machineList); err != nil {
+	machineList := v1alpha5.MachineList{}
+	if err := c.kubeClient.List(ctx, &machineList); err != nil {
 		logging.FromContext(ctx).Errorf("checking cluster state sync, %v", err)
 		return false
 	}
@@ -310,8 +310,8 @@ func (c *Cluster) GetDaemonSetPod(daemonset *appsv1.DaemonSet) *v1.Pod {
 }
 
 func (c *Cluster) UpdateDaemonSet(ctx context.Context, daemonset *appsv1.DaemonSet) error {
-	pods := &v1.PodList{}
-	err := c.kubeClient.List(ctx, pods, client.InNamespace(daemonset.Namespace))
+	pods := v1.PodList{}
+	err := c.kubeClient.List(ctx, &pods, client.InNamespace(daemonset.Namespace))
 	if err != nil {
 		return err
 	}

--- a/pkg/controllers/termination/controller.go
+++ b/pkg/controllers/termination/controller.go
@@ -113,8 +113,8 @@ func (c *Controller) Finalize(ctx context.Context, node *v1.Node) (reconcile.Res
 }
 
 func (c *Controller) ensureMachinesRemoved(ctx context.Context, n *v1.Node) (allRemoved bool, err error) {
-	machineList := &v1alpha5.MachineList{}
-	if err = c.kubeClient.List(ctx, machineList, client.MatchingFields{"status.providerID": n.Spec.ProviderID}); err != nil {
+	machineList := v1alpha5.MachineList{}
+	if err = c.kubeClient.List(ctx, &machineList, client.MatchingFields{"status.providerID": n.Spec.ProviderID}); err != nil {
 		return false, err
 	}
 	if len(machineList.Items) == 0 {


### PR DESCRIPTION
This has the added benefit that the list object
is created on the stack and not on the heap

<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

In support of https://github.com/aws/karpenter/issues/3565

**Description**

I made no pointers to list objects were created before calling the kubeclient list call.

**How was this change tested?**
Unit tests, also deployed on a live environment to test out the performance.

This change reduces times spent in the `UpdateDaemonSet` function significantly. It went from 8s spent to not being in the tree anymore.
To create these images I took CPU profiles for 120s

Before:
![daemonset-before](https://user-images.githubusercontent.com/5019818/224707673-ba3f9f71-7394-4efd-913f-4ce75c6b6307.png)

After:
![daemonset-after](https://user-images.githubusercontent.com/5019818/224707697-b1e74506-2baa-41ae-b44d-4b844a439dab.png)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
