### PR TITLE
test: add benchmarking into deprovisioning suite tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,22 @@ test: ## Run tests
 	go test ./... \
 		-race \
 		--ginkgo.focus="${FOCUS}" \
+		--ginkgo.skip="benchmark"
 		--ginkgo.v \
 		-cover -coverprofile=coverage.out -outputdir=. -coverpkg=./...
+
+ci-benchmark: ## Run Benchmarks
+	ginkgo ./pkg/... \
+		-race \
+		--dry-run \
+		--label-filter="benchmark" \
+		-cover -coverprofile=coverage.out -output-dir=. -coverpkg=./...
 
 deflake: ## Run randomized, racing tests until the test fails to catch flakes
 	ginkgo \
 		--race \
 		--focus="${FOCUS}" \
+		--skip="benchmark"
 		--randomize-all \
 		--until-it-fails \
 		-v \

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ test: ## Run tests
 	go test ./... \
 		-race \
 		--ginkgo.focus="${FOCUS}" \
-		--ginkgo.skip="benchmark"
+		--ginkgo.skip="benchmark" \
 		--ginkgo.v \
 		-cover -coverprofile=coverage.out -outputdir=. -coverpkg=./...
 
@@ -24,7 +24,7 @@ deflake: ## Run randomized, racing tests until the test fails to catch flakes
 	ginkgo \
 		--race \
 		--focus="${FOCUS}" \
-		--skip="benchmark"
+		--skip="benchmark" \
 		--randomize-all \
 		--until-it-fails \
 		-v \

--- a/pkg/controllers/deprovisioning/suite_test.go
+++ b/pkg/controllers/deprovisioning/suite_test.go
@@ -81,7 +81,7 @@ func TestAPIs(t *testing.T) {
 	RunSpecs(t, "Deprovisioning")
 }
 
-var sampleSizeFlag = 20
+var benchmarkSampleSize = 20
 var experiment = gmeasure.NewExperiment("deprovisioning benchmarks")
 
 var _ = BeforeSuite(func() {
@@ -288,7 +288,7 @@ var _ = Describe("Replace Nodes", func() {
 			experiment.MeasureDuration("replacing nodes", basicReplacementFunc)
 			ExpectCleanedUp(ctx, env.Client)
 			cluster.Reset()
-		}, gmeasure.SamplingConfig{N: sampleSizeFlag, Duration: 1 * time.Minute})
+		}, gmeasure.SamplingConfig{N: benchmarkSampleSize, Duration: 1 * time.Minute})
 	})
 	It("can replace node", basicReplacementFunc)
 	It("can replace nodes, considers PDB", func() {
@@ -924,7 +924,7 @@ var _ = Describe("Delete Node", func() {
 			experiment.MeasureDuration("deleting nodes", basicDeleteFunc)
 			ExpectCleanedUp(ctx, env.Client)
 			cluster.Reset()
-		}, gmeasure.SamplingConfig{N: sampleSizeFlag, Duration: 1 * time.Minute})
+		}, gmeasure.SamplingConfig{N: benchmarkSampleSize, Duration: 1 * time.Minute})
 	})
 
 	It("can delete nodes", basicDeleteFunc)
@@ -1315,7 +1315,7 @@ var _ = Describe("Topology Consideration", func() {
 			experiment.MeasureDuration("replacing with zonal topology spread", basicZonalTopologyReplacementFunc)
 			ExpectCleanedUp(ctx, env.Client)
 			cluster.Reset()
-		}, gmeasure.SamplingConfig{N: sampleSizeFlag, Duration: 1 * time.Minute})
+		}, gmeasure.SamplingConfig{N: benchmarkSampleSize, Duration: 1 * time.Minute})
 	})
 
 	It("can replace node maintaining zonal topology spread", basicZonalTopologyReplacementFunc)
@@ -1458,7 +1458,7 @@ var _ = Describe("Empty Nodes", func() {
 			experiment.MeasureDuration("deleting empty nodes", basicEmptyDeletionFunc)
 			ExpectCleanedUp(ctx, env.Client)
 			cluster.Reset()
-		}, gmeasure.SamplingConfig{N: sampleSizeFlag, Duration: 1 * time.Minute})
+		}, gmeasure.SamplingConfig{N: benchmarkSampleSize, Duration: 1 * time.Minute})
 	})
 	It("can delete empty nodes with consolidation", basicEmptyDeletionFunc)
 	It("can delete multiple empty nodes with consolidation", func() {
@@ -2112,7 +2112,7 @@ var _ = Describe("Multi-Node Consolidation", func() {
 			experiment.MeasureDuration("merging 3 nodes into 1", multiNodeConsolidationFunc)
 			ExpectCleanedUp(ctx, env.Client)
 			cluster.Reset()
-		}, gmeasure.SamplingConfig{N: sampleSizeFlag, Duration: 1 * time.Minute})
+		}, gmeasure.SamplingConfig{N: benchmarkSampleSize, Duration: 1 * time.Minute})
 	})
 	It("can merge 3 nodes into 1", multiNodeConsolidationFunc)
 	It("won't merge 2 nodes into 1 of the same type", func() {

--- a/pkg/controllers/deprovisioning/suite_test.go
+++ b/pkg/controllers/deprovisioning/suite_test.go
@@ -212,7 +212,7 @@ var _ = Describe("Pod Eviction Cost", func() {
 	})
 })
 
-var basicReplacementFunc = func () {
+var basicReplacementFunc = func() {
 	labels := map[string]string{
 		"app": "test",
 	}
@@ -284,7 +284,7 @@ var basicReplacementFunc = func () {
 var _ = Describe("Replace Nodes", func() {
 	It("measures deprovisioning replacement", Serial, Label("benchmark"), func() {
 		AddReportEntry(experiment.Name, experiment)
-		experiment.Sample(func (idx int) {
+		experiment.Sample(func(idx int) {
 			experiment.MeasureDuration("replacing nodes", basicReplacementFunc)
 			ExpectCleanedUp(ctx, env.Client)
 			cluster.Reset()
@@ -829,7 +829,6 @@ var _ = Describe("Replace Nodes", func() {
 	})
 })
 
-
 var _ = Describe("Delete Node", func() {
 	var prov *v1alpha5.Provisioner
 	var machine1, machine2 *v1alpha5.Machine
@@ -919,7 +918,7 @@ var _ = Describe("Delete Node", func() {
 	}
 	It("measures deprovisioning deletion", Serial, Label("benchmark"), func() {
 		AddReportEntry(experiment.Name, experiment)
-		experiment.Sample(func (idx int) {
+		experiment.Sample(func(idx int) {
 			setupVariables()
 			experiment.MeasureDuration("deleting nodes", basicDeleteFunc)
 			ExpectCleanedUp(ctx, env.Client)
@@ -1310,7 +1309,7 @@ var _ = Describe("Topology Consideration", func() {
 	}
 	It("measures replacement with zonal topology spread", Serial, Label("benchmark"), func() {
 		AddReportEntry(experiment.Name, experiment)
-		experiment.Sample(func (idx int) {
+		experiment.Sample(func(idx int) {
 			setupVariables()
 			experiment.MeasureDuration("replacing with zonal topology spread", basicZonalTopologyReplacementFunc)
 			ExpectCleanedUp(ctx, env.Client)
@@ -1453,7 +1452,7 @@ var _ = Describe("Empty Nodes", func() {
 
 	It("measures empty node deletion", Serial, Label("benchmark"), func() {
 		AddReportEntry(experiment.Name, experiment)
-		experiment.Sample(func (idx int) {
+		experiment.Sample(func(idx int) {
 			setupVariables()
 			experiment.MeasureDuration("deleting empty nodes", basicEmptyDeletionFunc)
 			ExpectCleanedUp(ctx, env.Client)
@@ -1873,7 +1872,7 @@ var _ = Describe("Parallelization", func() {
 		rs := test.ReplicaSet()
 		ExpectApplied(ctx, env.Client, rs)
 
-		prov := test.Provisioner(test.ProvisionerOptions{
+		prov = test.Provisioner(test.ProvisionerOptions{
 			Consolidation: &v1alpha5.Consolidation{Enabled: ptr.Bool(true)},
 		})
 		podOpts := test.PodOptions{
@@ -2107,7 +2106,7 @@ var _ = Describe("Multi-Node Consolidation", func() {
 	}
 	It("measures multi node consolidation", Serial, Label("benchmark"), func() {
 		AddReportEntry(experiment.Name, experiment)
-		experiment.Sample(func (idx int) {
+		experiment.Sample(func(idx int) {
 			setupVariables()
 			experiment.MeasureDuration("merging 3 nodes into 1", multiNodeConsolidationFunc)
 			ExpectCleanedUp(ctx, env.Client)

--- a/pkg/controllers/deprovisioning/suite_test.go
+++ b/pkg/controllers/deprovisioning/suite_test.go
@@ -16,7 +16,6 @@ package deprovisioning_test
 
 import (
 	"context"
-	"flag"
 	"fmt"
 	"math"
 	"sort"
@@ -82,11 +81,7 @@ func TestAPIs(t *testing.T) {
 	RunSpecs(t, "Deprovisioning")
 }
 
-var sampleSizeFlag int
-func init() {
-	flag.IntVar(&sampleSizeFlag, "benchmark-sample-size", 20, "This flag is used purely for ginkgo sample size on benchmarking.")
-}
-
+var sampleSizeFlag = 20
 var experiment = gmeasure.NewExperiment("deprovisioning benchmarks")
 
 var _ = BeforeSuite(func() {


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
This uses the `gmeasure` library from ginkgo to get some deprovisioning stats.

```
  Report Entries >>
  deprovisioning benchmarks - /Volumes/workplace/go/src/github.com/aws/karpenter-core/pkg/controllers/deprovisioning/suite_test.go:926 @ 03/17/23 15:19:26.346
    deprovisioning benchmarks
    Name                                            | N  | Min      | Median   | Mean     | StdDev  | Max
    ==========================================================================================================
    deleting empty nodes [duration]                 | 20 | 295.5ms  | 303.1ms  | 406.7ms  | 441.8ms | 2.332s
    ----------------------------------------------------------------------------------------------------------
    replacing with zonal topology spread [duration] | 20 | 485.3ms  | 2.55s    | 2.0431s  | 891.3ms | 2.5947s
    ----------------------------------------------------------------------------------------------------------
    merging 3 nodes into 1 [duration]               | 20 | 2.4869s  | 2.5589s  | 2.5582s  | 36.7ms  | 2.6508s
    ----------------------------------------------------------------------------------------------------------
    replacing nodes [duration]                      | 20 | 393.8ms  | 2.4499s  | 2.0536s  | 822.5ms | 2.5717s
    ----------------------------------------------------------------------------------------------------------
    deleting nodes [duration]                       | 20 | 368.2ms  | 384.6ms  | 390.7ms  | 23.7ms  | 464ms
  << Report Entries
```

**How was this change tested?**
`make ci-benchmark`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
