### PR TITLE
fix: problem where pods blocking eviction were not respected for cons…

### DIFF
--- a/pkg/controllers/deprovisioning/drift.go
+++ b/pkg/controllers/deprovisioning/drift.go
@@ -57,8 +57,8 @@ func (d *Drift) ShouldDeprovision(ctx context.Context, c *Candidate) bool {
 }
 
 // ComputeCommand generates a deprovisioning command given deprovisionable machines
-func (d *Drift) ComputeCommand(ctx context.Context, candidates ...*Candidate) (Command, error) {
-	candidates, err := filterCandidates(ctx, d.kubeClient, d.recorder, candidates)
+func (d *Drift) ComputeCommand(ctx context.Context, nodes ...*Candidate) (Command, error) {
+	candidates, err := filterCandidates(ctx, d.kubeClient, d.recorder, nodes)
 	if err != nil {
 		return Command{}, fmt.Errorf("filtering candidates, %w", err)
 	}

--- a/pkg/controllers/deprovisioning/helpers.go
+++ b/pkg/controllers/deprovisioning/helpers.go
@@ -48,15 +48,15 @@ func filterCandidates(ctx context.Context, kubeClient client.Client, recorder ev
 	// filter out nodes that can't be terminated
 	nodes = lo.Filter(nodes, func(cn *Candidate, _ int) bool {
 		if !cn.Node.DeletionTimestamp.IsZero() {
-			recorder.Publish(deprovisioningevents.Unconsolidatable(cn.Node, "in the process of deletion")...)
+			recorder.Publish(deprovisioningevents.Blocked(cn.Node, "in the process of deletion")...)
 			return false
 		}
 		if pdb, ok := pdbs.CanEvictPods(cn.pods); !ok {
-			recorder.Publish(deprovisioningevents.Unconsolidatable(cn.Node, fmt.Sprintf("pdb %s prevents pod evictions", pdb))...)
+			recorder.Publish(deprovisioningevents.Blocked(cn.Node, fmt.Sprintf("pdb %s prevents pod evictions", pdb))...)
 			return false
 		}
 		if p, ok := hasDoNotEvictPod(cn); ok {
-			recorder.Publish(deprovisioningevents.Unconsolidatable(cn.Node, fmt.Sprintf("pod %s/%s has do not evict annotation", p.Namespace, p.Name))...)
+			recorder.Publish(deprovisioningevents.Blocked(cn.Node, fmt.Sprintf("pod %s/%s has do not evict annotation", p.Namespace, p.Name))...)
 			return false
 		}
 		return true

--- a/pkg/controllers/deprovisioning/multimachineconsolidation.go
+++ b/pkg/controllers/deprovisioning/multimachineconsolidation.go
@@ -58,7 +58,7 @@ func (m *MultiMachineConsolidation) ComputeCommand(ctx context.Context, candidat
 		return cmd, nil
 	}
 
-	v := NewValidation(consolidationTTL, m.clock, m.cluster, m.kubeClient, m.provisioner, m.cloudProvider)
+	v := NewValidation(consolidationTTL, m.clock, m.cluster, m.kubeClient, m.provisioner, m.cloudProvider, m.recorder)
 	isValid, err := v.IsValid(ctx, cmd)
 	if err != nil {
 		return Command{}, fmt.Errorf("validating, %w", err)

--- a/pkg/controllers/deprovisioning/singlemachineconsolidation.go
+++ b/pkg/controllers/deprovisioning/singlemachineconsolidation.go
@@ -49,7 +49,7 @@ func (c *SingleMachineConsolidation) ComputeCommand(ctx context.Context, candida
 		return Command{}, fmt.Errorf("sorting candidates, %w", err)
 	}
 
-	v := NewValidation(consolidationTTL, c.clock, c.cluster, c.kubeClient, c.provisioner, c.cloudProvider)
+	v := NewValidation(consolidationTTL, c.clock, c.cluster, c.kubeClient, c.provisioner, c.cloudProvider, c.recorder)
 	var failedValidation bool
 	for _, candidate := range candidates {
 		// compute a possible consolidation option

--- a/pkg/controllers/deprovisioning/validation.go
+++ b/pkg/controllers/deprovisioning/validation.go
@@ -83,13 +83,12 @@ func (v *Validation) IsValid(ctx context.Context, cmd Command) (bool, error) {
 			return false, fmt.Errorf("constructing validation candidates, %w", err)
 		}
 	}
-	// Compute PDBs and check if all the nodes are still deprovisionable.
-	pdbs, err := NewPDBLimits(ctx, v.kubeClient)
+	nodes, err := filterCandidates(ctx, v.kubeClient, v.recorder, cmd.candidates)
 	if err != nil {
-		return false, fmt.Errorf("tracking PodDisruptionBudgets, %w", err)
+		return false, fmt.Errorf("filtering candidates, %w", err)
 	}
-
-	if valid := v.validateCandidates(cmd, pdbs); !valid {
+	// If we filtered out any candidates, return false as some nodes in the consolidation decision have changed.
+	if len(nodes) != len(cmd.candidates) {
 		return false, nil
 	}
 

--- a/pkg/controllers/deprovisioning/validation.go
+++ b/pkg/controllers/deprovisioning/validation.go
@@ -90,6 +90,13 @@ func (v *Validation) IsValid(ctx context.Context, cmd Command) (bool, error) {
 	if len(nodes) != len(cmd.candidates) {
 		return false, nil
 	}
+	// a candidate we are about to delete is a target of a currently pending pod, wait for that to settle
+	// before continuing consolidation
+	for _, n := range cmd.candidates {
+		if v.cluster.IsNodeNominated(n.Name()) {
+			return false, nil
+		}
+	}
 
 	isValid, err := v.ValidateCommand(ctx, cmd, v.validationCandidates)
 	if err != nil {

--- a/pkg/controllers/deprovisioning/validation.go
+++ b/pkg/controllers/deprovisioning/validation.go
@@ -102,7 +102,7 @@ func (v *Validation) IsValid(ctx context.Context, cmd Command) (bool, error) {
 }
 
 // Returns if the candidates chosen can still be terminated after the TTL
-func (v *Validation) validateCandidates(ctx context.Context, cmd Command, pdbs *PDBLimits) bool {
+func (v *Validation) validateCandidates(cmd Command, pdbs *PDBLimits) bool {
 	for _, n := range cmd.candidates {
 		if !n.Node.DeletionTimestamp.IsZero() {
 			v.recorder.Publish(deprovisioningevents.Unconsolidatable(n.Node, "in the process of deletion")...)


### PR DESCRIPTION
…olidation

<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes https://github.com/aws/karpenter/issues/3594

**Description**
Adds an additional check in Consolidation validation to make sure that no new pods that block eviction were scheduled during the 15 Seconds Consolidation TTL. 

Also pulls out the common filter code. 

**How was this change tested?**
- Added unit tests and `make presubmit`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
