### PR TITLE
chore: Create a separate launch controller to quickly react to machine launch

### DIFF
--- a/pkg/controllers/machine/initialization_test.go
+++ b/pkg/controllers/machine/initialization_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Initialization", func() {
 			},
 		})
 		ExpectApplied(ctx, env.Client, provisioner, machine)
-		ExpectReconcileSucceeded(ctx, machineController, client.ObjectKeyFromObject(machine))
+		ExpectReconcileSucceeded(ctx, launchController, client.ObjectKeyFromObject(machine))
 		machine = ExpectExists(ctx, env.Client, machine)
 
 		node := test.Node(test.NodeOptions{
@@ -103,7 +103,7 @@ var _ = Describe("Initialization", func() {
 			},
 		})
 		ExpectApplied(ctx, env.Client, provisioner, machine)
-		ExpectReconcileSucceeded(ctx, machineController, client.ObjectKeyFromObject(machine))
+		ExpectReconcileSucceeded(ctx, launchController, client.ObjectKeyFromObject(machine))
 		machine = ExpectExists(ctx, env.Client, machine)
 
 		node := test.Node(test.NodeOptions{
@@ -143,7 +143,7 @@ var _ = Describe("Initialization", func() {
 			},
 		})
 		ExpectApplied(ctx, env.Client, provisioner, machine)
-		ExpectReconcileSucceeded(ctx, machineController, client.ObjectKeyFromObject(machine))
+		ExpectReconcileSucceeded(ctx, launchController, client.ObjectKeyFromObject(machine))
 		machine = ExpectExists(ctx, env.Client, machine)
 
 		node := test.Node(test.NodeOptions{
@@ -186,7 +186,7 @@ var _ = Describe("Initialization", func() {
 			},
 		})
 		ExpectApplied(ctx, env.Client, provisioner, machine)
-		ExpectReconcileSucceeded(ctx, machineController, client.ObjectKeyFromObject(machine))
+		ExpectReconcileSucceeded(ctx, launchController, client.ObjectKeyFromObject(machine))
 		machine = ExpectExists(ctx, env.Client, machine)
 
 		// Update the machine to add mock the instance type having an extended resource
@@ -234,7 +234,7 @@ var _ = Describe("Initialization", func() {
 			},
 		})
 		ExpectApplied(ctx, env.Client, provisioner, machine)
-		ExpectReconcileSucceeded(ctx, machineController, client.ObjectKeyFromObject(machine))
+		ExpectReconcileSucceeded(ctx, launchController, client.ObjectKeyFromObject(machine))
 		machine = ExpectExists(ctx, env.Client, machine)
 
 		// Update the machine to add mock the instance type having an extended resource
@@ -305,7 +305,7 @@ var _ = Describe("Initialization", func() {
 			},
 		})
 		ExpectApplied(ctx, env.Client, provisioner, machine)
-		ExpectReconcileSucceeded(ctx, machineController, client.ObjectKeyFromObject(machine))
+		ExpectReconcileSucceeded(ctx, launchController, client.ObjectKeyFromObject(machine))
 		machine = ExpectExists(ctx, env.Client, machine)
 
 		node := test.Node(test.NodeOptions{
@@ -375,7 +375,7 @@ var _ = Describe("Initialization", func() {
 			},
 		})
 		ExpectApplied(ctx, env.Client, provisioner, machine)
-		ExpectReconcileSucceeded(ctx, machineController, client.ObjectKeyFromObject(machine))
+		ExpectReconcileSucceeded(ctx, launchController, client.ObjectKeyFromObject(machine))
 		machine = ExpectExists(ctx, env.Client, machine)
 
 		node := test.Node(test.NodeOptions{

--- a/pkg/controllers/machine/launch/controller.go
+++ b/pkg/controllers/machine/launch/controller.go
@@ -1,0 +1,145 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package launch
+
+import (
+	"context"
+	"time"
+
+	"github.com/patrickmn/go-cache"
+	"go.uber.org/multierr"
+	"golang.org/x/time/rate"
+	"k8s.io/apimachinery/pkg/api/equality"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/utils/clock"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
+	"github.com/aws/karpenter-core/pkg/cloudprovider"
+	corecontroller "github.com/aws/karpenter-core/pkg/operator/controller"
+	"github.com/aws/karpenter-core/pkg/utils/result"
+)
+
+type machineReconciler interface {
+	Reconcile(context.Context, *v1alpha5.Machine) (reconcile.Result, error)
+}
+
+var _ corecontroller.TypedController[*v1alpha5.Machine] = (*Controller)(nil)
+
+// Controller is a Launch controller which has a high concurrency limit and works to launch and propagate
+// launch data into the Machines as quickly as possible. This launch controller also controls timeouts if the
+// launch doesn't execute and finish within a defined launchTTL
+type Controller struct {
+	kubeClient    client.Client
+	cloudProvider cloudprovider.CloudProvider
+
+	launch  *Launch
+	timeout *Timeout
+}
+
+func NewController(clk clock.Clock, kubeClient client.Client, cloudProvider cloudprovider.CloudProvider) corecontroller.Controller {
+	return corecontroller.Typed[*v1alpha5.Machine](kubeClient, &Controller{
+		kubeClient:    kubeClient,
+		cloudProvider: cloudProvider,
+
+		launch:  &Launch{kubeClient: kubeClient, cloudProvider: cloudProvider, cache: cache.New(time.Minute, time.Second*10)},
+		timeout: &Timeout{clock: clk, kubeClient: kubeClient},
+	})
+}
+
+func (*Controller) Name() string {
+	return "machine_launch"
+}
+
+func (c *Controller) Reconcile(ctx context.Context, machine *v1alpha5.Machine) (reconcile.Result, error) {
+	if !machine.DeletionTimestamp.IsZero() {
+		return reconcile.Result{}, nil
+	}
+	if machine.StatusConditions().GetCondition(v1alpha5.MachineCreated).IsTrue() {
+		return reconcile.Result{}, nil
+	}
+
+	// Add the finalizer immediately since we shouldn't launch if we don't yet have the finalizer.
+	// Otherwise, we could leak resources
+	stored := machine.DeepCopy()
+	controllerutil.AddFinalizer(machine, v1alpha5.TerminationFinalizer)
+	if !equality.Semantic.DeepEqual(machine, stored) {
+		if err := c.kubeClient.Patch(ctx, machine, client.MergeFrom(stored)); err != nil {
+			return reconcile.Result{}, client.IgnoreNotFound(err)
+		}
+	}
+
+	stored = machine.DeepCopy()
+	var results []reconcile.Result
+	var errs error
+	for _, reconciler := range []machineReconciler{
+		c.launch,
+		c.timeout, // we check timeout last, since we don't want to delete the machine, and then still launch
+	} {
+		res, err := reconciler.Reconcile(ctx, machine)
+		errs = multierr.Append(errs, err)
+		results = append(results, res)
+	}
+	if !equality.Semantic.DeepEqual(stored, machine) {
+		statusCopy := machine.DeepCopy()
+		if err := c.kubeClient.Patch(ctx, machine, client.MergeFrom(stored)); err != nil {
+			return reconcile.Result{}, client.IgnoreNotFound(multierr.Append(errs, err))
+		}
+		if err := c.kubeClient.Status().Patch(ctx, statusCopy, client.MergeFrom(stored)); err != nil {
+			return reconcile.Result{}, client.IgnoreNotFound(multierr.Append(errs, err))
+		}
+	}
+	return result.Min(results...), errs
+}
+
+func (c *Controller) Builder(_ context.Context, m manager.Manager) corecontroller.Builder {
+	return corecontroller.Adapt(controllerruntime.
+		NewControllerManagedBy(m).
+		For(&v1alpha5.Machine{}).
+		WithEventFilter(predicate.Funcs{
+			CreateFunc: func(_ event.CreateEvent) bool { return true },
+			UpdateFunc: func(_ event.UpdateEvent) bool { return false },
+			DeleteFunc: func(_ event.DeleteEvent) bool { return false },
+		}).
+		WithOptions(controller.Options{
+			RateLimiter: workqueue.NewMaxOfRateLimiter(
+				workqueue.NewItemExponentialFailureRateLimiter(time.Second, time.Minute),
+				// 10 qps, 100 bucket size
+				&workqueue.BucketRateLimiter{Limiter: rate.NewLimiter(rate.Limit(10), 100)},
+			),
+			// Higher concurrency limit since we want faster reaction to launch
+			// This high of a concurrency limit should be localized to this launch controller since it is trying to
+			// launch machines as quickly and as efficiently as possible
+			MaxConcurrentReconciles: 1000,
+		}))
+}
+
+// removeFinalizerBestEffort attempts to Patch out the Finalizer to be more efficient and save time
+// This isn't necessary but saves us from running through the standard termination loop when we know that the
+// cloudprovider machine doesn't exist (since we haven't launched) so there's no use going through the finalization loop
+// It returns a boolean representing if it was able to successfully remove the finalizer
+func removeFinalizerBestEffort(ctx context.Context, c client.Client, machine *v1alpha5.Machine) bool {
+	stored := machine.DeepCopy()
+	controllerutil.RemoveFinalizer(machine, v1alpha5.TerminationFinalizer)
+	err := c.Patch(ctx, machine, client.MergeFrom(stored))
+	return err == nil
+}

--- a/pkg/controllers/machine/launch/launch.go
+++ b/pkg/controllers/machine/launch/launch.go
@@ -12,15 +12,17 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package machine
+package launch
 
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/patrickmn/go-cache"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/samber/lo"
+	v1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/logging"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -31,16 +33,19 @@ import (
 	"github.com/aws/karpenter-core/pkg/scheduling"
 )
 
+// Launch is a sub-reconciler that either launches or links the Machine to a CloudProvider Machine
 type Launch struct {
 	kubeClient    client.Client
 	cloudProvider cloudprovider.CloudProvider
 	cache         *cache.Cache // exists due to eventual consistency on the cache
 }
 
+// nolint:gocyclo
 func (l *Launch) Reconcile(ctx context.Context, machine *v1alpha5.Machine) (reconcile.Result, error) {
-	if machine.Status.ProviderID != "" {
-		return reconcile.Result{}, nil
-	}
+	// Mark the other status conditions as false since these can't be true until the Machine is launched
+	machine.StatusConditions().MarkFalse(v1alpha5.MachineRegistered, "MachineNotLaunched", "Machine has not been launched")
+	machine.StatusConditions().MarkFalse(v1alpha5.MachineInitialized, "MachineNotLaunched", "Machine has not been launched")
+
 	var err error
 	var created *v1alpha5.Machine
 	if ret, ok := l.cache.Get(client.ObjectKeyFromObject(machine).String()); ok {
@@ -49,14 +54,18 @@ func (l *Launch) Reconcile(ctx context.Context, machine *v1alpha5.Machine) (reco
 		created, err = l.cloudProvider.Get(ctx, id)
 		if err != nil {
 			if cloudprovider.IsMachineNotFoundError(err) {
+				removedFinalizer := removeFinalizerBestEffort(ctx, l.kubeClient, machine)
 				if err = l.kubeClient.Delete(ctx, machine); err != nil {
 					return reconcile.Result{}, client.IgnoreNotFound(err)
 				}
 				logging.FromContext(ctx).Debugf("garbage collected machine with no cloudprovider representation")
+				if removedFinalizer {
+					logging.FromContext(ctx).Infof("deleted machine")
+				}
 				metrics.MachinesTerminatedCounter.With(prometheus.Labels{
 					metrics.ReasonLabel:      "garbage_collected",
 					metrics.ProvisionerLabel: machine.Labels[v1alpha5.ProvisionerNameLabelKey],
-				})
+				}).Inc()
 				return reconcile.Result{}, nil
 			}
 			machine.StatusConditions().MarkFalse(v1alpha5.MachineCreated, "LinkFailed", truncateMessage(err.Error()))
@@ -64,11 +73,25 @@ func (l *Launch) Reconcile(ctx context.Context, machine *v1alpha5.Machine) (reco
 		}
 		logging.FromContext(ctx).Debugf("linked machine")
 	} else {
+		instanceTypeRequirement, _ := lo.Find(machine.Spec.Requirements, func(req v1.NodeSelectorRequirement) bool { return req.Key == v1.LabelInstanceTypeStable })
+		logging.FromContext(ctx).With("pods", machine.Spec.Resources.Requests[v1.ResourcePods],
+			"resources", machine.Spec.Resources.Requests, "instance-types", instanceTypeList(instanceTypeRequirement.Values)).Infof("launching machine")
 		created, err = l.cloudProvider.Create(ctx, machine)
 		if err != nil {
 			if cloudprovider.IsInsufficientCapacityError(err) {
 				logging.FromContext(ctx).Error(err)
-				return reconcile.Result{}, client.IgnoreNotFound(l.kubeClient.Delete(ctx, machine))
+				removedFinalizer := removeFinalizerBestEffort(ctx, l.kubeClient, machine)
+				if err = l.kubeClient.Delete(ctx, machine); err != nil {
+					return reconcile.Result{}, client.IgnoreNotFound(err)
+				}
+				if removedFinalizer {
+					logging.FromContext(ctx).Infof("deleted machine")
+				}
+				metrics.MachinesTerminatedCounter.With(prometheus.Labels{
+					metrics.ReasonLabel:      "insufficient_capacity",
+					metrics.ProvisionerLabel: machine.Labels[v1alpha5.ProvisionerNameLabelKey],
+				}).Inc()
+				return reconcile.Result{}, nil
 			}
 			machine.StatusConditions().MarkFalse(v1alpha5.MachineCreated, "LaunchFailed", truncateMessage(err.Error()))
 			return reconcile.Result{}, fmt.Errorf("creating machine, %w", err)
@@ -77,6 +100,10 @@ func (l *Launch) Reconcile(ctx context.Context, machine *v1alpha5.Machine) (reco
 	}
 	l.cache.SetDefault(client.ObjectKeyFromObject(machine).String(), created)
 	PopulateMachineDetails(machine, created)
+
+	// Update the status conditions now that the Machine has been launched
+	machine.StatusConditions().MarkFalse(v1alpha5.MachineRegistered, "NodeNotFound", "Node not registered with cluster")
+	machine.StatusConditions().MarkFalse(v1alpha5.MachineInitialized, "NodeNotFound", "Node not registered with cluster")
 	machine.StatusConditions().MarkTrue(v1alpha5.MachineCreated)
 	return reconcile.Result{}, nil
 }
@@ -94,6 +121,21 @@ func PopulateMachineDetails(machine, retrieved *v1alpha5.Machine) {
 	machine.Status.ProviderID = retrieved.Status.ProviderID
 	machine.Status.Allocatable = retrieved.Status.Allocatable
 	machine.Status.Capacity = retrieved.Status.Capacity
+}
+
+func instanceTypeList(names []string) string {
+	var itSb strings.Builder
+	for i, name := range names {
+		// print the first 5 instance types only (indices 0-4)
+		if i > 4 {
+			lo.Must(fmt.Fprintf(&itSb, " and %d other(s)", len(names)-i))
+			break
+		} else if i > 0 {
+			lo.Must(fmt.Fprint(&itSb, ", "))
+		}
+		lo.Must(fmt.Fprint(&itSb, name))
+	}
+	return itSb.String()
 }
 
 func truncateMessage(msg string) string {

--- a/pkg/controllers/machine/launch/timeout.go
+++ b/pkg/controllers/machine/launch/timeout.go
@@ -1,0 +1,62 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package launch
+
+import (
+	"context"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/utils/clock"
+	"knative.dev/pkg/logging"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
+	"github.com/aws/karpenter-core/pkg/metrics"
+)
+
+// Timeout is a sub-reconciler that checks if the Machine is beyond its launch timeout and deletes it if it is
+type Timeout struct {
+	clock      clock.Clock
+	kubeClient client.Client
+}
+
+// launchTTL is a heuristic time that we expect to succeed with our cloudprovider.Create() call
+// If we don't succeed within this time, then we should delete and try again through some other mechanism
+const launchTTL = time.Minute * 2
+
+func (t *Timeout) Reconcile(ctx context.Context, machine *v1alpha5.Machine) (reconcile.Result, error) {
+	if machine.StatusConditions().GetCondition(v1alpha5.MachineCreated) == nil {
+		return reconcile.Result{Requeue: true}, nil
+	}
+	if t.clock.Since(machine.StatusConditions().GetCondition(v1alpha5.MachineCreated).LastTransitionTime.Inner.Time) < launchTTL {
+		return reconcile.Result{RequeueAfter: launchTTL - t.clock.Since(machine.StatusConditions().GetCondition(v1alpha5.MachineCreated).LastTransitionTime.Inner.Time)}, nil
+	}
+	// Delete the machine if we believe the machine won't create
+	removedFinalizer := removeFinalizerBestEffort(ctx, t.kubeClient, machine)
+	if err := t.kubeClient.Delete(ctx, machine); err != nil {
+		return reconcile.Result{}, client.IgnoreNotFound(err)
+	}
+	logging.FromContext(ctx).With("ttl", launchTTL).Debugf("deleting machine since node hasn't created within creation ttl")
+	if removedFinalizer {
+		logging.FromContext(ctx).Infof("deleted machine")
+	}
+	metrics.MachinesTerminatedCounter.With(prometheus.Labels{
+		metrics.ReasonLabel:      "launch_timeout",
+		metrics.ProvisionerLabel: machine.Labels[v1alpha5.ProvisionerNameLabelKey],
+	}).Inc()
+	return reconcile.Result{}, nil
+}

--- a/pkg/controllers/machine/liveness.go
+++ b/pkg/controllers/machine/liveness.go
@@ -19,7 +19,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"go.uber.org/multierr"
 	"k8s.io/utils/clock"
 	"knative.dev/pkg/logging"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -27,7 +26,6 @@ import (
 
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/metrics"
-	"github.com/aws/karpenter-core/pkg/utils/result"
 )
 
 type Liveness struct {
@@ -35,40 +33,11 @@ type Liveness struct {
 	kubeClient client.Client
 }
 
-// launchTTL is a heuristic time that we expect to succeed with our cloudprovider.Create() call
-// If we don't succeed within this time, then we should delete and try again through some other mechanism
-const launchTTL = time.Minute * 2
-
 // registrationTTL is a heuristic time that we expect the node to register within
 // If we don't see the node within this time, then we should delete the machine and try again
 const registrationTTL = time.Minute * 15
 
 func (l *Liveness) Reconcile(ctx context.Context, machine *v1alpha5.Machine) (reconcile.Result, error) {
-	creationRes, creationErr := l.launchTTL(ctx, machine)
-	registrationRes, registrationErr := l.registrationTTL(ctx, machine)
-	return result.Min(creationRes, registrationRes), multierr.Combine(creationErr, registrationErr)
-}
-
-func (l *Liveness) launchTTL(ctx context.Context, machine *v1alpha5.Machine) (reconcile.Result, error) {
-	if machine.StatusConditions().GetCondition(v1alpha5.MachineCreated).IsTrue() {
-		return reconcile.Result{}, nil
-	}
-	if machine.CreationTimestamp.IsZero() || l.clock.Since(machine.CreationTimestamp.Time) < launchTTL {
-		return reconcile.Result{RequeueAfter: launchTTL - l.clock.Since(machine.CreationTimestamp.Time)}, nil
-	}
-	// Delete the machine if we believe the machine won't create
-	if err := l.kubeClient.Delete(ctx, machine); err != nil {
-		return reconcile.Result{}, client.IgnoreNotFound(err)
-	}
-	logging.FromContext(ctx).With("ttl", launchTTL).Debugf("terminating machine since node hasn't created within creation ttl")
-	metrics.MachinesTerminatedCounter.With(prometheus.Labels{
-		metrics.ReasonLabel:      "machine_creation_timeout",
-		metrics.ProvisionerLabel: machine.Labels[v1alpha5.ProvisionerNameLabelKey],
-	})
-	return reconcile.Result{}, nil
-}
-
-func (l *Liveness) registrationTTL(ctx context.Context, machine *v1alpha5.Machine) (reconcile.Result, error) {
 	if machine.StatusConditions().GetCondition(v1alpha5.MachineRegistered).IsTrue() {
 		return reconcile.Result{}, nil
 	}
@@ -81,7 +50,7 @@ func (l *Liveness) registrationTTL(ctx context.Context, machine *v1alpha5.Machin
 	}
 	logging.FromContext(ctx).With("ttl", registrationTTL).Debugf("terminating machine since node hasn't registered within registration ttl")
 	metrics.MachinesTerminatedCounter.With(prometheus.Labels{
-		metrics.ReasonLabel:      "machine_registration_timeout",
+		metrics.ReasonLabel:      "registration_timeout",
 		metrics.ProvisionerLabel: machine.Labels[v1alpha5.ProvisionerNameLabelKey],
 	})
 	return reconcile.Result{}, nil

--- a/pkg/controllers/machine/registration_test.go
+++ b/pkg/controllers/machine/registration_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Registration", func() {
 			},
 		})
 		ExpectApplied(ctx, env.Client, provisioner, machine)
-		ExpectReconcileSucceeded(ctx, machineController, client.ObjectKeyFromObject(machine))
+		ExpectReconcileSucceeded(ctx, launchController, client.ObjectKeyFromObject(machine))
 		machine = ExpectExists(ctx, env.Client, machine)
 
 		node := test.Node(test.NodeOptions{ProviderID: machine.Status.ProviderID})
@@ -61,7 +61,7 @@ var _ = Describe("Registration", func() {
 			},
 		})
 		ExpectApplied(ctx, env.Client, provisioner, machine)
-		ExpectReconcileSucceeded(ctx, machineController, client.ObjectKeyFromObject(machine))
+		ExpectReconcileSucceeded(ctx, launchController, client.ObjectKeyFromObject(machine))
 		machine = ExpectExists(ctx, env.Client, machine)
 
 		node := test.Node(test.NodeOptions{ProviderID: machine.Status.ProviderID})
@@ -82,7 +82,7 @@ var _ = Describe("Registration", func() {
 			},
 		})
 		ExpectApplied(ctx, env.Client, provisioner, machine)
-		ExpectReconcileSucceeded(ctx, machineController, client.ObjectKeyFromObject(machine))
+		ExpectReconcileSucceeded(ctx, launchController, client.ObjectKeyFromObject(machine))
 		machine = ExpectExists(ctx, env.Client, machine)
 		Expect(machine.Labels).To(HaveKeyWithValue("custom-label", "custom-value"))
 		Expect(machine.Labels).To(HaveKeyWithValue("other-custom-label", "other-custom-value"))
@@ -110,7 +110,7 @@ var _ = Describe("Registration", func() {
 			},
 		})
 		ExpectApplied(ctx, env.Client, provisioner, machine)
-		ExpectReconcileSucceeded(ctx, machineController, client.ObjectKeyFromObject(machine))
+		ExpectReconcileSucceeded(ctx, launchController, client.ObjectKeyFromObject(machine))
 		machine = ExpectExists(ctx, env.Client, machine)
 		Expect(machine.Annotations).To(HaveKeyWithValue(v1alpha5.DoNotConsolidateNodeAnnotationKey, "true"))
 		Expect(machine.Annotations).To(HaveKeyWithValue("my-custom-annotation", "my-custom-value"))
@@ -148,7 +148,7 @@ var _ = Describe("Registration", func() {
 			},
 		})
 		ExpectApplied(ctx, env.Client, provisioner, machine)
-		ExpectReconcileSucceeded(ctx, machineController, client.ObjectKeyFromObject(machine))
+		ExpectReconcileSucceeded(ctx, launchController, client.ObjectKeyFromObject(machine))
 		machine = ExpectExists(ctx, env.Client, machine)
 		Expect(machine.Spec.Taints).To(ContainElements(
 			v1.Taint{
@@ -216,7 +216,7 @@ var _ = Describe("Registration", func() {
 			},
 		})
 		ExpectApplied(ctx, env.Client, provisioner, machine)
-		ExpectReconcileSucceeded(ctx, machineController, client.ObjectKeyFromObject(machine))
+		ExpectReconcileSucceeded(ctx, launchController, client.ObjectKeyFromObject(machine))
 		machine = ExpectExists(ctx, env.Client, machine)
 		Expect(machine.Spec.StartupTaints).To(ContainElements(
 			v1.Taint{
@@ -282,7 +282,7 @@ var _ = Describe("Registration", func() {
 			},
 		})
 		ExpectApplied(ctx, env.Client, provisioner, machine)
-		ExpectReconcileSucceeded(ctx, machineController, client.ObjectKeyFromObject(machine))
+		ExpectReconcileSucceeded(ctx, launchController, client.ObjectKeyFromObject(machine))
 		machine = ExpectExists(ctx, env.Client, machine)
 
 		node := test.Node(test.NodeOptions{ProviderID: machine.Status.ProviderID})

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -20,8 +20,9 @@ import (
 )
 
 const (
-	nodeSubsystem    = "nodes"
-	machineSubsystem = "machines"
+	nodeSubsystem                  = "nodes"
+	machineSubsystem               = "machines"
+	cloudProviderMachinesSubsystem = "cloudprovider_machines"
 )
 
 var (
@@ -54,7 +55,7 @@ var (
 			Namespace: Namespace,
 			Subsystem: machineSubsystem,
 			Name:      "created",
-			Help:      "Number of machines created in total by Karpenter. Labeled by reason the machine was terminated and the owning provisioner.",
+			Help:      "Number of machines created in total by Karpenter. Labeled by reason the machine was created and the owning provisioner.",
 		},
 		[]string{
 			ReasonLabel,

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -45,7 +45,7 @@ import (
 
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
-	"github.com/aws/karpenter-core/pkg/controllers/machine"
+	"github.com/aws/karpenter-core/pkg/controllers/machine/launch"
 	"github.com/aws/karpenter-core/pkg/controllers/provisioning"
 	"github.com/aws/karpenter-core/pkg/controllers/provisioning/scheduling"
 	"github.com/aws/karpenter-core/pkg/controllers/state"
@@ -296,7 +296,7 @@ func ExpectMachineDeployedWithOffset(offset int, ctx context.Context, c client.C
 	ExpectWithOffset(offset+1, err).To(Succeed())
 
 	// Make the machine ready in the status conditions
-	machine.PopulateMachineDetails(m, resolved)
+	launch.PopulateMachineDetails(m, resolved)
 	m.StatusConditions().MarkTrue(v1alpha5.MachineCreated)
 	m.StatusConditions().MarkTrue(v1alpha5.MachineRegistered)
 


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

Create a separate launch controller to quickly react to machine launch. This new machine launch controller should have a _much_ higher concurrency limit than the other controllers. The reason for this is so that we can quickly react to Machine create requests to launch as many machines as quickly as we possibly can.

This also prevents bottlenecking due to other things that were coming at the same time when these were all merged into a single controller (i.e. Node events for registration/initialization, termination, liveness, etc.)

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
