### PR TITLE
feat: add in termination check for nodes without machines

### DIFF
--- a/pkg/controllers/machine/garbagecollect/suite_test.go
+++ b/pkg/controllers/machine/garbagecollect/suite_test.go
@@ -105,7 +105,7 @@ var _ = Describe("GarbageCollection", func() {
 		machine = ExpectExists(ctx, env.Client, machine)
 
 		// Step forward to move past the cache eventual consistency timeout
-		fakeClock.Step(time.Second * 20)
+		fakeClock.SetTime(time.Now().Add(time.Second * 20))
 
 		// Delete the machine from the cloudprovider
 		Expect(cloudProvider.Delete(ctx, machine)).To(Succeed())
@@ -132,7 +132,7 @@ var _ = Describe("GarbageCollection", func() {
 		}
 
 		// Step forward to move past the cache eventual consistency timeout
-		fakeClock.Step(time.Second * 20)
+		fakeClock.SetTime(time.Now().Add(time.Second * 20))
 
 		for _, machine := range machines {
 			// Delete the machine from the cloudprovider
@@ -160,7 +160,7 @@ var _ = Describe("GarbageCollection", func() {
 		machine = ExpectExists(ctx, env.Client, machine)
 
 		// Step forward to move past the cache eventual consistency timeout
-		fakeClock.Step(time.Second * 20)
+		fakeClock.SetTime(time.Now().Add(time.Second * 20))
 
 		// Reconcile the Machine. It should not be deleted by this flow since it has never been registered
 		ExpectReconcileSucceeded(ctx, garbageCollectionController, client.ObjectKey{})


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes https://github.com/aws/karpenter/issues/3562 

**Description**
Adds in a termination check to see if the underlying instance is not found. If not found, Karpenter will delete the node and remove the finalizer.

**How was this change tested?**
- `make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
