### PR TITLE
feat: added expiration as node annotation for monitorability

### DIFF
--- a/pkg/apis/v1alpha5/labels.go
+++ b/pkg/apis/v1alpha5/labels.go
@@ -51,6 +51,7 @@ const (
 
 	// Karpenter specific annotation values
 	VoluntaryDisruptionDriftedAnnotationValue = "drifted"
+	VoluntaryDisruptionExpiredAnnotationValue = "expired"
 )
 
 // Karpenter specific finalizers

--- a/pkg/cloudprovider/fake/cloudprovider.go
+++ b/pkg/cloudprovider/fake/cloudprovider.go
@@ -67,6 +67,7 @@ func (c *CloudProvider) Reset() {
 	c.AllowedCreateCalls = math.MaxInt
 	c.NextCreateErr = nil
 	c.DeleteCalls = []*v1alpha5.Machine{}
+	c.Drifted = false
 }
 
 func (c *CloudProvider) Create(ctx context.Context, machine *v1alpha5.Machine) (*v1alpha5.Machine, error) {

--- a/pkg/controllers/deprovisioning/drift_test.go
+++ b/pkg/controllers/deprovisioning/drift_test.go
@@ -45,6 +45,9 @@ var _ = Describe("Drift", func() {
 		prov = test.Provisioner()
 		machine, node = test.MachineAndNode(v1alpha5.Machine{
 			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					v1alpha5.VoluntaryDisruptionAnnotationKey: v1alpha5.VoluntaryDisruptionDriftedAnnotationValue,
+				},
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: prov.Name,
 					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name,
@@ -79,7 +82,7 @@ var _ = Describe("Drift", func() {
 		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
 		ExpectExists(ctx, env.Client, node)
 	})
-	It("should ignore nodes with the drift label, but not the drifted value", func() {
+	It("should ignore nodes with the disrupted annotation key, but not the drifted value", func() {
 		node.Annotations = lo.Assign(node.Annotations, map[string]string{
 			v1alpha5.VoluntaryDisruptionAnnotationKey: "wrong-value",
 		})
@@ -99,7 +102,8 @@ var _ = Describe("Drift", func() {
 		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
 		ExpectExists(ctx, env.Client, node)
 	})
-	It("should ignore nodes without the drift label", func() {
+	It("should ignore nodes without the disrupted annotation key", func() {
+		delete(node.Annotations, v1alpha5.VoluntaryDisruptionAnnotationKey)
 		ExpectApplied(ctx, env.Client, machine, node, prov)
 
 		// inform cluster state about nodes and machines

--- a/pkg/controllers/node/controller.go
+++ b/pkg/controllers/node/controller.go
@@ -31,7 +31,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	"github.com/aws/karpenter-core/pkg/apis/settings"
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	corecontroller "github.com/aws/karpenter-core/pkg/operator/controller"
 
@@ -98,9 +97,7 @@ func (c *Controller) Reconcile(ctx context.Context, node *v1.Node) (reconcile.Re
 		c.emptiness,
 		c.finalizer,
 		c.expiration,
-	}
-	if settings.FromContext(ctx).DriftEnabled {
-		reconcilers = append(reconcilers, c.drift)
+		c.drift,
 	}
 	for _, reconciler := range reconcilers {
 		res, err := reconciler.Reconcile(ctx, provisioner, node)

--- a/pkg/controllers/node/controller.go
+++ b/pkg/controllers/node/controller.go
@@ -55,6 +55,7 @@ type Controller struct {
 	emptiness      *Emptiness
 	finalizer      *Finalizer
 	drift          *Drift
+	expiration     *Expiration
 }
 
 // NewController constructs a nodeController instance
@@ -95,6 +96,7 @@ func (c *Controller) Reconcile(ctx context.Context, node *v1.Node) (reconcile.Re
 		c.initialization,
 		c.emptiness,
 		c.finalizer,
+		c.expiration,
 	}
 	if settings.FromContext(ctx).DriftEnabled {
 		reconcilers = append(reconcilers, c.drift)

--- a/pkg/controllers/node/controller.go
+++ b/pkg/controllers/node/controller.go
@@ -66,6 +66,7 @@ func NewController(clk clock.Clock, kubeClient client.Client, cloudProvider clou
 		initialization: &Initialization{kubeClient: kubeClient, cloudProvider: cloudProvider},
 		emptiness:      &Emptiness{kubeClient: kubeClient, clock: clk, cluster: cluster},
 		drift:          &Drift{kubeClient: kubeClient, cloudProvider: cloudProvider},
+		expiration:     &Expiration{clock: clk},
 	})
 }
 

--- a/pkg/controllers/node/drift.go
+++ b/pkg/controllers/node/drift.go
@@ -20,11 +20,13 @@ import (
 	"time"
 
 	v1 "k8s.io/api/core/v1"
+	"knative.dev/pkg/logging"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/samber/lo"
 
+	"github.com/aws/karpenter-core/pkg/apis/settings"
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
 	"github.com/aws/karpenter-core/pkg/utils/machine"
@@ -36,20 +38,39 @@ type Drift struct {
 }
 
 func (d *Drift) Reconcile(ctx context.Context, provisioner *v1alpha5.Provisioner, node *v1.Node) (reconcile.Result, error) {
-	if _, ok := node.Annotations[v1alpha5.VoluntaryDisruptionAnnotationKey]; ok {
+	// If the node is marked as voluntarily disrupted by another controller, do nothing.
+	val, hasAnnotation := node.Annotations[v1alpha5.VoluntaryDisruptionAnnotationKey]
+	if hasAnnotation && val != v1alpha5.VoluntaryDisruptionDriftedAnnotationValue {
 		return reconcile.Result{}, nil
 	}
 
-	// TODO: Add Provisioner Drift
+	// From here there are three scenarios to handle:
+	// 1. If drift is not enabled but the node is drifted, remove the annotation
+	//    so another disruption controller can annotate the node.
+	if !settings.FromContext(ctx).DriftEnabled {
+		if val == v1alpha5.VoluntaryDisruptionDriftedAnnotationValue {
+			delete(node.Annotations, v1alpha5.VoluntaryDisruptionAnnotationKey)
+			logging.FromContext(ctx).Infof("removing drift annotation from node as drift has been disabled")
+		}
+		return reconcile.Result{}, nil
+	}
+
 	drifted, err := d.cloudProvider.IsMachineDrifted(ctx, machine.NewFromNode(node))
 	if err != nil {
 		return reconcile.Result{}, fmt.Errorf("getting drift for node, %w", err)
 	}
-	if drifted {
+	// 2. Otherwise, if the node isn't drifted, but has the annotation, remove it.
+	if !drifted && hasAnnotation {
+		delete(node.Annotations, v1alpha5.VoluntaryDisruptionAnnotationKey)
+		logging.FromContext(ctx).Infof("removing drift annotation from node")
+		// 3. Finally, if the node is drifted, but doesn't have the annotation, add it.
+	} else if drifted && !hasAnnotation {
 		node.Annotations = lo.Assign(node.Annotations, map[string]string{
 			v1alpha5.VoluntaryDisruptionAnnotationKey: v1alpha5.VoluntaryDisruptionDriftedAnnotationValue,
 		})
+		logging.FromContext(ctx).Infof("annotating node as drifted")
 	}
+
 	// Requeue after 5 minutes for the cache TTL
 	return reconcile.Result{RequeueAfter: 5 * time.Minute}, nil
 }

--- a/pkg/controllers/node/expiration.go
+++ b/pkg/controllers/node/expiration.go
@@ -1,0 +1,62 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package node
+
+import (
+	"context"
+	"time"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/utils/clock"
+	"knative.dev/pkg/logging"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/samber/lo"
+
+	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
+	utilsnode "github.com/aws/karpenter-core/pkg/utils/node"
+)
+
+// Expiration is a node sub-controller that annotates or de-annotates an expired node based on TTLSecondsUntilExpired
+type Expiration struct {
+	clock clock.Clock
+}
+
+func (e *Expiration) Reconcile(ctx context.Context, provisioner *v1alpha5.Provisioner, node *v1.Node) (reconcile.Result, error) {
+	// Ignore node if not applicable
+	if provisioner.Spec.TTLSecondsUntilExpired == nil {
+		return reconcile.Result{}, nil
+	}
+
+	// If the node is marked as voluntarily disrupted by another controller, do nothing.
+	val, hasAnnotation := node.Annotations[v1alpha5.VoluntaryDisruptionAnnotationKey]
+	if hasAnnotation && val != v1alpha5.VoluntaryDisruptionExpiredAnnotationValue {
+		return reconcile.Result{}, nil
+	}
+
+	expired := utilsnode.IsExpired(node, e.clock, provisioner)
+	if !expired && hasAnnotation {
+		delete(node.Annotations, v1alpha5.EmptinessTimestampAnnotationKey)
+		logging.FromContext(ctx).Infof("removed expiration TTL from node")
+	} else if expired && !hasAnnotation {
+		node.Annotations = lo.Assign(node.Annotations, map[string]string{
+			v1alpha5.VoluntaryDisruptionExpiredAnnotationValue: e.clock.Now().Format(time.RFC3339),
+		})
+		logging.FromContext(ctx).Infof("added TTL to expired node")
+	}
+
+	// If not expired, and doesn't have annotation, requeue at expiration time.
+	return reconcile.Result{RequeueAfter: time.Until(utilsnode.GetExpirationTime(node, provisioner))}, nil
+}

--- a/pkg/controllers/node/expiration.go
+++ b/pkg/controllers/node/expiration.go
@@ -48,11 +48,11 @@ func (e *Expiration) Reconcile(ctx context.Context, provisioner *v1alpha5.Provis
 
 	expired := utilsnode.IsExpired(node, e.clock, provisioner)
 	if !expired && hasAnnotation {
-		delete(node.Annotations, v1alpha5.EmptinessTimestampAnnotationKey)
+		delete(node.Annotations, v1alpha5.VoluntaryDisruptionAnnotationKey)
 		logging.FromContext(ctx).Infof("removed expiration TTL from node")
 	} else if expired && !hasAnnotation {
 		node.Annotations = lo.Assign(node.Annotations, map[string]string{
-			v1alpha5.VoluntaryDisruptionExpiredAnnotationValue: e.clock.Now().Format(time.RFC3339),
+			v1alpha5.VoluntaryDisruptionAnnotationKey: v1alpha5.VoluntaryDisruptionExpiredAnnotationValue,
 		})
 		logging.FromContext(ctx).Infof("added TTL to expired node")
 	}

--- a/pkg/controllers/node/suite_test.go
+++ b/pkg/controllers/node/suite_test.go
@@ -397,7 +397,7 @@ var _ = Describe("Controller", func() {
 			ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(node))
 
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
-			Expect(node.Annotations).To(HaveKeyWithValue(v1alpha5.VoluntaryDisruptionAnnotationKey, v1alpha5.VoluntaryDisruptionDriftedAnnotationValue))
+			Expect(node.Annotations).To(HaveKeyWithValue(v1alpha5.VoluntaryDisruptionAnnotationKey, v1alpha5.VoluntaryDisruptionExpiredAnnotationValue))
 		})
 		It("should remove the annotation from non-empty nodes", func() {
 			provisioner.Spec.TTLSecondsUntilExpired = ptr.Int64(200)
@@ -407,10 +407,11 @@ var _ = Describe("Controller", func() {
 					v1alpha5.VoluntaryDisruptionAnnotationKey: v1alpha5.VoluntaryDisruptionDriftedAnnotationValue,
 				}},
 			})
+			ExpectApplied(ctx, env.Client, provisioner, node)
 			ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(node))
 
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
-			Expect(node.Annotations).ToNot(HaveKeyWithValue(v1alpha5.VoluntaryDisruptionAnnotationKey, v1alpha5.VoluntaryDisruptionDriftedAnnotationValue))
+			Expect(node.Annotations).ToNot(HaveKeyWithValue(v1alpha5.VoluntaryDisruptionAnnotationKey, v1alpha5.VoluntaryDisruptionExpiredAnnotationValue))
 		})
 	})
 	Context("Finalizer", func() {

--- a/pkg/utils/node/node.go
+++ b/pkg/utils/node/node.go
@@ -62,7 +62,7 @@ func GetCondition(n *v1.Node, match v1.NodeConditionType) v1.NodeCondition {
 }
 
 func GetExpirationTime(node *v1.Node, provisioner *v1alpha5.Provisioner) time.Time {
-	if provisioner == nil || provisioner.Spec.TTLSecondsUntilExpired == nil {
+	if provisioner == nil || provisioner.Spec.TTLSecondsUntilExpired == nil || node == nil {
 		// If not defined, return some much larger time.
 		return time.Date(5000, 0, 0, 0, 0, 0, 0, time.UTC)
 	}

--- a/pkg/utils/node/node.go
+++ b/pkg/utils/node/node.go
@@ -17,10 +17,14 @@ package node
 import (
 	"context"
 	"fmt"
+	"time"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/utils/clock"
+	"knative.dev/pkg/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/utils/pod"
 )
 
@@ -55,4 +59,17 @@ func GetCondition(n *v1.Node, match v1.NodeConditionType) v1.NodeCondition {
 		}
 	}
 	return v1.NodeCondition{}
+}
+
+func GetExpirationTime(node *v1.Node, provisioner *v1alpha5.Provisioner) time.Time {
+	if provisioner == nil || provisioner.Spec.TTLSecondsUntilExpired == nil {
+		// If not defined, return some much larger time.
+		return time.Date(5000, 0, 0, 0, 0, 0, 0, time.UTC)
+	}
+	expirationTTL := time.Duration(ptr.Int64Value(provisioner.Spec.TTLSecondsUntilExpired)) * time.Second
+	return node.CreationTimestamp.Add(expirationTTL)
+}
+
+func IsExpired(n *v1.Node, clock clock.Clock, provisioner *v1alpha5.Provisioner) bool {
+	return clock.Now().After(GetExpirationTime(n, provisioner))
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
This changes expiration to annotate the node so that users can be aware of when an expired node is queued up for deprovisioning.

**How was this change tested?**
`make presubmit`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
