### PR TITLE
test: Add CacheSyncClient Handling for patching Finalizer and Fix Flake

### DIFF
--- a/pkg/controllers/machine/termination/suite_test.go
+++ b/pkg/controllers/machine/termination/suite_test.go
@@ -118,6 +118,8 @@ var _ = Describe("Termination", func() {
 		Expect(env.Client.Delete(ctx, machine)).To(Succeed())
 		ExpectReconcileSucceeded(ctx, terminationController, client.ObjectKeyFromObject(machine)) // triggers the node deletion
 		ExpectFinalizersRemoved(ctx, env.Client, node)
+		ExpectNotFound(ctx, env.Client, node)
+		
 		ExpectReconcileSucceeded(ctx, terminationController, client.ObjectKeyFromObject(machine)) // now all nodes are gone so machine deletion continues
 		ExpectNotFound(ctx, env.Client, machine, node)
 
@@ -142,6 +144,8 @@ var _ = Describe("Termination", func() {
 		Expect(env.Client.Delete(ctx, machine)).To(Succeed())
 		ExpectReconcileSucceeded(ctx, terminationController, client.ObjectKeyFromObject(machine)) // triggers the node deletion
 		ExpectFinalizersRemoved(ctx, env.Client, node1, node2, node3)
+		ExpectNotFound(ctx, env.Client, node1, node2, node3)
+
 		ExpectReconcileSucceeded(ctx, terminationController, client.ObjectKeyFromObject(machine)) // now all nodes are gone so machine deletion continues
 		ExpectNotFound(ctx, env.Client, machine, node1, node2, node3)
 
@@ -168,9 +172,10 @@ var _ = Describe("Termination", func() {
 		ExpectExists(ctx, env.Client, node)
 
 		ExpectFinalizersRemoved(ctx, env.Client, node)
+		ExpectNotFound(ctx, env.Client, node)
 		ExpectReconcileSucceeded(ctx, terminationController, client.ObjectKeyFromObject(machine)) // now the machine should be gone
 
-		ExpectNotFound(ctx, env.Client, machine, node)
+		ExpectNotFound(ctx, env.Client, machine)
 	})
 	It("should not call Delete() on the CloudProvider if the machine hasn't been launched yet", func() {
 		ExpectApplied(ctx, env.Client, provisioner, machine)

--- a/pkg/test/cachesyncingclient.go
+++ b/pkg/test/cachesyncingclient.go
@@ -154,7 +154,9 @@ func (c *cacheSyncingStatusWriter) Patch(ctx context.Context, obj client.Object,
 func objectSynced(ctx context.Context, c client.Client, obj client.Object) error {
 	temp := obj.DeepCopyObject().(client.Object)
 	if err := c.Get(ctx, client.ObjectKeyFromObject(obj), temp); err != nil {
-		return fmt.Errorf("getting object, %w", err)
+		// If the object isn't found, we assume that the cache was synced since the Update operation must have caused
+		// the object to get completely removed (like a finalizer update)
+		return client.IgnoreNotFound(fmt.Errorf("getting object, %w", err))
 	}
 	if obj.GetResourceVersion() != temp.GetResourceVersion() {
 		return fmt.Errorf("object hasn't updated")

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -39,6 +39,7 @@ import (
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -50,6 +51,7 @@ import (
 	"github.com/aws/karpenter-core/pkg/controllers/provisioning/scheduling"
 	"github.com/aws/karpenter-core/pkg/controllers/state"
 	"github.com/aws/karpenter-core/pkg/metrics"
+	"github.com/aws/karpenter-core/pkg/operator/scheme"
 	"github.com/aws/karpenter-core/pkg/test"
 )
 
@@ -109,7 +111,7 @@ func ExpectNotFoundWithOffset(offset int, ctx context.Context, c client.Client, 
 		EventuallyWithOffset(offset+1, func() bool {
 			return errors.IsNotFound(c.Get(ctx, types.NamespacedName{Name: object.GetName(), Namespace: object.GetNamespace()}, object))
 		}, ReconcilerPropagationTime, RequestInterval).Should(BeTrue(), func() string {
-			return fmt.Sprintf("expected %s to be deleted, but it still exists", client.ObjectKeyFromObject(object))
+			return fmt.Sprintf("expected %s/%s to be deleted, but it still exists", lo.Must(apiutil.GVKForObject(object, scheme.Scheme)), client.ObjectKeyFromObject(object))
 		})
 	}
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

- Add CacheSyncClient Handling for patching out finalizer
- Wait for the Node to be Gone in the termination flow before calling Machine termination controller

**How was this change tested?**

`make presubmit`

Viewed a drop in the time that it took to complete finalization removal and the Patching out of a finalizer from the Node

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
