### PR TITLE
feat: Added metrics for consistency checks

### DIFF
--- a/pkg/controllers/consistency/events.go
+++ b/pkg/controllers/consistency/events.go
@@ -12,7 +12,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package events
+package consistency
 
 import (
 	v1 "k8s.io/api/core/v1"
@@ -20,12 +20,12 @@ import (
 	"github.com/aws/karpenter-core/pkg/events"
 )
 
-func InflightCheck(node *v1.Node, message string) []events.Event {
+func CheckEvent(node *v1.Node, message string) []events.Event {
 	return []events.Event{
 		{
 			InvolvedObject: node,
 			Type:           v1.EventTypeWarning,
-			Reason:         "FailedInflightCheck",
+			Reason:         "FailedConsistencyCheck",
 			Message:        message,
 			DedupeValues:   []string{node.Name, message},
 		},

--- a/pkg/controllers/consistency/failedinit.go
+++ b/pkg/controllers/consistency/failedinit.go
@@ -12,7 +12,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package inflightchecks
+package consistency
 
 import (
 	"context"
@@ -68,18 +68,18 @@ func (f FailedInit) Check(ctx context.Context, n *v1.Node) ([]Issue, error) {
 	}
 	instanceType, ok := lo.Find(instanceTypes, func(it *cloudprovider.InstanceType) bool { return it.Name == n.Labels[v1.LabelInstanceTypeStable] })
 	if !ok {
-		return []Issue{Issue(fmt.Sprintf("Instance Type %q not found", n.Labels[v1.LabelInstanceTypeStable]))}, nil
+		return []Issue{Issue(fmt.Sprintf("instance type %q not found", n.Labels[v1.LabelInstanceTypeStable]))}, nil
 	}
 
 	// detect startup taints which should be removed
 	var result []Issue
 	if taint, ok := node.IsStartupTaintRemoved(n, provisioner); !ok {
-		result = append(result, Issue(fmt.Sprintf("Startup taint %q is still on the node", formatTaint(taint))))
+		result = append(result, Issue(fmt.Sprintf("startup taint %q is still on the node", formatTaint(taint))))
 	}
 
 	// and extended resources which never registered
 	if resource, ok := node.IsExtendedResourceRegistered(n, instanceType); !ok {
-		result = append(result, Issue(fmt.Sprintf("Expected resource %q didn't register on the node", resource)))
+		result = append(result, Issue(fmt.Sprintf("expected resource %q didn't register on the node", resource)))
 	}
 
 	return result, nil

--- a/pkg/controllers/consistency/metrics.go
+++ b/pkg/controllers/consistency/metrics.go
@@ -1,0 +1,41 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package consistency
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	"github.com/aws/karpenter-core/pkg/metrics"
+)
+
+func init() {
+	crmetrics.Registry.MustRegister(consistencyErrors)
+}
+
+const (
+	checkLabel = "check"
+	subsystem  = "consistency"
+)
+
+var consistencyErrors = prometheus.NewCounterVec(
+	prometheus.CounterOpts{
+		Namespace: metrics.Namespace,
+		Subsystem: subsystem,
+		Name:      "errors",
+		Help:      "Number of consistency checks that have failed.",
+	},
+	[]string{checkLabel},
+)

--- a/pkg/controllers/consistency/nodeshape.go
+++ b/pkg/controllers/consistency/nodeshape.go
@@ -12,7 +12,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package inflightchecks
+package consistency
 
 import (
 	"context"
@@ -60,19 +60,19 @@ func (n *NodeShape) Check(ctx context.Context, node *v1.Node) ([]Issue, error) {
 	}
 	instanceType, ok := lo.Find(instanceTypes, func(it *cloudprovider.InstanceType) bool { return it.Name == node.Labels[v1.LabelInstanceTypeStable] })
 	if !ok {
-		return []Issue{Issue(fmt.Sprintf("Instance Type %q not found", node.Labels[v1.LabelInstanceTypeStable]))}, nil
+		return []Issue{Issue(fmt.Sprintf("instance type %q not found", node.Labels[v1.LabelInstanceTypeStable]))}, nil
 	}
 	var issues []Issue
 	for resourceName, expectedQuantity := range instanceType.Capacity {
 		nodeQuantity, ok := node.Status.Capacity[resourceName]
 		if !ok && !expectedQuantity.IsZero() {
-			issues = append(issues, Issue(fmt.Sprintf("Expected resource %s not found", resourceName)))
+			issues = append(issues, Issue(fmt.Sprintf("expected resource %s not found", resourceName)))
 			continue
 		}
 
 		pct := nodeQuantity.AsApproximateFloat64() / expectedQuantity.AsApproximateFloat64()
 		if pct < 0.90 {
-			issues = append(issues, Issue(fmt.Sprintf("Expected %s of resource %s, but found %s (%0.1f%% of expected)", expectedQuantity.String(),
+			issues = append(issues, Issue(fmt.Sprintf("expected %s of resource %s, but found %s (%0.1f%% of expected)", expectedQuantity.String(),
 				resourceName, nodeQuantity.String(), pct*100)))
 		}
 	}

--- a/pkg/controllers/consistency/termination.go
+++ b/pkg/controllers/consistency/termination.go
@@ -12,7 +12,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package inflightchecks
+package consistency
 
 import (
 	"context"
@@ -51,7 +51,7 @@ func (t *Termination) Check(ctx context.Context, node *v1.Node) ([]Issue, error)
 	}
 	var issues []Issue
 	if pdb, ok := pdbs.CanEvictPods(pods); !ok {
-		issues = append(issues, Issue(fmt.Sprintf("Can't drain node, PDB %s is blocking evictions", pdb)))
+		issues = append(issues, Issue(fmt.Sprintf("can't drain node, PDB %s is blocking evictions", pdb)))
 	}
 	return issues, nil
 }

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -22,9 +22,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
+	"github.com/aws/karpenter-core/pkg/controllers/consistency"
 	"github.com/aws/karpenter-core/pkg/controllers/counter"
 	"github.com/aws/karpenter-core/pkg/controllers/deprovisioning"
-	"github.com/aws/karpenter-core/pkg/controllers/inflightchecks"
 	metricspod "github.com/aws/karpenter-core/pkg/controllers/metrics/pod"
 	metricsprovisioner "github.com/aws/karpenter-core/pkg/controllers/metrics/provisioner"
 	metricsstate "github.com/aws/karpenter-core/pkg/controllers/metrics/state"
@@ -69,6 +69,6 @@ func NewControllers(
 		metricspod.NewController(kubeClient),
 		metricsprovisioner.NewController(kubeClient),
 		counter.NewController(kubeClient, cluster),
-		inflightchecks.NewController(clock, kubeClient, recorder, cloudProvider),
+		consistency.NewController(clock, kubeClient, recorder, cloudProvider),
 	}
 }


### PR DESCRIPTION
Fixes #3696

**Description**

Added metrics for consistency checks.

**How was this change tested?**

```
karpenter-96d576577-djtgc controller 2023-04-07T17:48:25.908Z	ERROR	controller.consistency	check failed, expected 688 of resource pods, but found 345 (50.1% of expected)	{"commit": "0bcd446-dirty", "node": "ip-192-168-98-227.us-west-2.compute.internal"}
```

```
curl localhost:8080/metrics | grep karpenter_consistency_errors
karpenter_consistency_errors{check="NodeShape"} 1
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
