### PR TITLE
feat: visibility improvements for deprovisioning

### DIFF
--- a/pkg/controllers/deprovisioning/controller.go
+++ b/pkg/controllers/deprovisioning/controller.go
@@ -117,6 +117,7 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	isConsolidated := c.cluster.Consolidated()
 	for _, d := range c.deprovisioners {
 		ctx = context.WithValue(ctx, "deprovisioner", d.String())
+		c.recorder.Publish(deprovisioningevents.Computing(d.String())...)
 		candidates, err := GetCandidates(ctx, c.cluster, c.kubeClient, c.clock, c.cloudProvider, d.ShouldDeprovision)
 		if err != nil {
 			return reconcile.Result{}, fmt.Errorf("determining candidates, %w", err)

--- a/pkg/controllers/deprovisioning/controller.go
+++ b/pkg/controllers/deprovisioning/controller.go
@@ -156,7 +156,7 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 
 func (c *Controller) executeCommand(ctx context.Context, d Deprovisioner, command Command) error {
 	deprovisioningActionsPerformedCounter.With(prometheus.Labels{"action": fmt.Sprintf("%s/%s", d, command.action)}).Add(1)
-	logging.FromContext(ctx).With("deprovisioner", ctx.Value("deprovisioner")).Infof("deprovisioning via %s %s", d, command)
+	logging.FromContext(ctx).Infof("deprovisioning via %s %s", d, command)
 
 	reason := fmt.Sprintf("%s/%s", d, command.action)
 	if command.action == actionReplace {
@@ -277,7 +277,7 @@ func (c *Controller) waitForDeletion(ctx context.Context, node *v1.Node) {
 		return fmt.Errorf("expected node to be not found")
 	}, waitRetryOptions...,
 	); err != nil {
-		logging.FromContext(ctx).With("deprovisioner", ctx.Value("deprovisioner")).Errorf("Waiting on machine deletion, %s", err)
+		logging.FromContext(ctx).Errorf("Waiting on machine deletion, %s", err)
 	}
 }
 

--- a/pkg/controllers/deprovisioning/emptymachineconsolidation.go
+++ b/pkg/controllers/deprovisioning/emptymachineconsolidation.go
@@ -43,6 +43,7 @@ func NewEmptyMachineConsolidation(clk clock.Clock, cluster *state.Cluster, kubeC
 // ComputeCommand generates a deprovisioning command given deprovisionable machines
 func (c *EmptyMachineConsolidation) ComputeCommand(ctx context.Context, candidates ...*Candidate) (Command, error) {
 	if c.cluster.Consolidated() {
+		logging.FromContext(ctx).Debugf("skipping empty node consolidation since cluster is consolidated")
 		return Command{action: actionDoNothing}, nil
 	}
 	candidates, err := c.sortAndFilterCandidates(ctx, candidates)

--- a/pkg/controllers/deprovisioning/events/events.go
+++ b/pkg/controllers/deprovisioning/events/events.go
@@ -47,6 +47,18 @@ func Terminating(node *v1.Node, reason string) []events.Event {
 	}
 }
 
+func Computing(deprovisioner string) []events.Event {
+	return []events.Event{
+		{
+			Type:           v1.EventTypeNormal,
+			Reason:         "ComputingDeprovisioning",
+			Message:        fmt.Sprintf("Computing deprovisioning for %s", deprovisioner),
+			DedupeValues:   []string{deprovisioner},
+			DedupeTimeout:  10 * time.Second,
+		},
+	}
+}
+
 func Launching(node *v1.Node, reason string) events.Event {
 	return events.Event{
 		InvolvedObject: node,

--- a/pkg/controllers/deprovisioning/multimachineconsolidation.go
+++ b/pkg/controllers/deprovisioning/multimachineconsolidation.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/clock"
+	"knative.dev/pkg/logging"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
@@ -41,6 +42,7 @@ func NewMultiMachineConsolidation(clk clock.Clock, cluster *state.Cluster, kubeC
 
 func (m *MultiMachineConsolidation) ComputeCommand(ctx context.Context, candidates ...*Candidate) (Command, error) {
 	if m.cluster.Consolidated() {
+		logging.FromContext(ctx).Debugf("skipping multi node consolidation since cluster is consolidated")
 		return Command{action: actionDoNothing}, nil
 	}
 	candidates, err := m.sortAndFilterCandidates(ctx, candidates)

--- a/pkg/controllers/deprovisioning/singlemachineconsolidation.go
+++ b/pkg/controllers/deprovisioning/singlemachineconsolidation.go
@@ -42,6 +42,7 @@ func NewSingleMachineConsolidation(clk clock.Clock, cluster *state.Cluster, kube
 // nolint:gocyclo
 func (c *SingleMachineConsolidation) ComputeCommand(ctx context.Context, candidates ...*Candidate) (Command, error) {
 	if c.cluster.Consolidated() {
+		logging.FromContext(ctx).Debugf("skipping single node consolidation since cluster is consolidated")
 		return Command{action: actionDoNothing}, nil
 	}
 	candidates, err := c.sortAndFilterCandidates(ctx, candidates)


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
Added log lines for deprovisioning for any deprovisioning that doesn't occur. 

This also adds in a kube-event for when deprovisioning is executed.

This PR is currently for reference. 

**How was this change tested?**

- updated the go.mod and go.sum in aws/karpenter to refer to this and saw the logs.
- For a stable cluster this makes the logs very spammy, getting the following every 10 seconds. 
```
karpenter-79b84777c-tc2lv controller 2023-04-07T18:38:51.027Z	DEBUG	controller.deprovisioning	found no deprovisionable nodes	{"commit": "9604517-dirty", "deprovisioner": "expiration"}
karpenter-79b84777c-tc2lv controller 2023-04-07T18:38:51.030Z	DEBUG	controller.deprovisioning	found no deprovisionable nodes	{"commit": "9604517-dirty", "deprovisioner": "drift"}
karpenter-79b84777c-tc2lv controller 2023-04-07T18:38:51.033Z	DEBUG	controller.deprovisioning	found no deprovisionable nodes	{"commit": "9604517-dirty", "deprovisioner": "emptiness"}
karpenter-79b84777c-tc2lv controller 2023-04-07T18:38:51.036Z	DEBUG	controller.deprovisioning	skipping empty node consolidation since cluster is consolidated	{"commit": "9604517-dirty"}
karpenter-79b84777c-tc2lv controller 2023-04-07T18:38:51.039Z	DEBUG	controller.deprovisioning	skipping multi node consolidation since cluster is consolidated	{"commit": "9604517-dirty"}
karpenter-79b84777c-tc2lv controller 2023-04-07T18:38:51.042Z	DEBUG	controller.deprovisioning	skipping single node consolidation since cluster is consolidated	{"commit": "9604517-dirty"}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
