### PR TITLE
fix: Requeue immediately after deprovisioning

### DIFF
--- a/pkg/controllers/deprovisioning/controller.go
+++ b/pkg/controllers/deprovisioning/controller.go
@@ -57,6 +57,7 @@ type Controller struct {
 
 // pollingPeriod that we inspect cluster to look for opportunities to deprovision
 const pollingPeriod = 10 * time.Second
+const immediately = time.Millisecond
 
 var errCandidateDeleting = fmt.Errorf("candidate is deleting")
 
@@ -133,14 +134,14 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 			continue
 		}
 		if cmd.action == actionRetry {
-			return reconcile.Result{Requeue: true}, nil
+			return reconcile.Result{RequeueAfter: immediately}, nil
 		}
 
 		// Attempt to deprovision
 		if err := c.executeCommand(ctx, d, cmd); err != nil {
 			return reconcile.Result{}, fmt.Errorf("deprovisioning candidates, %w", err)
 		}
-		return reconcile.Result{Requeue: true}, nil
+		return reconcile.Result{RequeueAfter: immediately}, nil
 	}
 
 	if !isConsolidated {

--- a/pkg/controllers/deprovisioning/controller.go
+++ b/pkg/controllers/deprovisioning/controller.go
@@ -118,7 +118,7 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	for _, d := range c.deprovisioners {
 		success, err := c.deprovision(ctx, d)
 		if err != nil {
-			logging.FromContext(ctx).Errorf("Failed during %q, %s", d, err)
+			return reconcile.Result{}, fmt.Errorf("deprovisioning via %q, %w", d, err)
 		}
 		if success {
 			return reconcile.Result{RequeueAfter: immediately}, nil

--- a/pkg/controllers/deprovisioning/emptymachineconsolidation.go
+++ b/pkg/controllers/deprovisioning/emptymachineconsolidation.go
@@ -80,9 +80,8 @@ func (c *EmptyMachineConsolidation) ComputeCommand(ctx context.Context, candidat
 	// the machine isn't a target of a recent scheduling simulation
 	for _, n := range candidatesToDelete {
 		if len(n.pods) != 0 && !c.cluster.IsNodeNominated(n.Name()) {
-			return Command{action: actionRetry}, nil
+			return Command{}, fmt.Errorf("command is no longer valid, %s", cmd)
 		}
 	}
-
 	return cmd, nil
 }

--- a/pkg/controllers/deprovisioning/expiration_test.go
+++ b/pkg/controllers/deprovisioning/expiration_test.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"knative.dev/pkg/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
@@ -234,8 +233,7 @@ var _ = Describe("Expiration", func() {
 
 		var wg sync.WaitGroup
 		ExpectTriggerVerifyAction(&wg)
-		_, err := deprovisioningController.Reconcile(ctx, reconcile.Request{})
-		Expect(err).To(HaveOccurred())
+		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
 		wg.Wait()
 
 		// We should have tried to create a new machine but failed to do so; therefore, we uncordoned the existing node

--- a/pkg/controllers/deprovisioning/expiration_test.go
+++ b/pkg/controllers/deprovisioning/expiration_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"knative.dev/pkg/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
@@ -233,7 +234,8 @@ var _ = Describe("Expiration", func() {
 
 		var wg sync.WaitGroup
 		ExpectTriggerVerifyAction(&wg)
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		_, err := deprovisioningController.Reconcile(ctx, reconcile.Request{})
+		Expect(err).To(HaveOccurred())
 		wg.Wait()
 
 		// We should have tried to create a new machine but failed to do so; therefore, we uncordoned the existing node

--- a/pkg/controllers/deprovisioning/multimachineconsolidation.go
+++ b/pkg/controllers/deprovisioning/multimachineconsolidation.go
@@ -65,7 +65,7 @@ func (m *MultiMachineConsolidation) ComputeCommand(ctx context.Context, candidat
 	}
 
 	if !isValid {
-		return Command{action: actionRetry}, nil
+		return Command{}, fmt.Errorf("command is no longer valid, %s", cmd)
 	}
 	return cmd, nil
 }

--- a/pkg/controllers/deprovisioning/suite_test.go
+++ b/pkg/controllers/deprovisioning/suite_test.go
@@ -1605,7 +1605,8 @@ var _ = Describe("Consolidation TTL", func() {
 			defer GinkgoRecover()
 			defer wg.Done()
 			defer finished.Store(true)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			_, err := deprovisioningController.Reconcile(ctx, reconcile.Request{})
+			Expect(err).To(HaveOccurred())
 		}()
 
 		// wait for the deprovisioningController to block on the validation timeout
@@ -1744,8 +1745,7 @@ var _ = Describe("Consolidation TTL", func() {
 		ExpectNotFound(ctx, env.Client, node2)
 	})
 	It("should not consolidate if the action becomes invalid during the node TTL wait", func() {
-		// Only allow emptiness consolidation by using an instance type selector
-		pod := test.Pod(test.PodOptions{NodeSelector: map[string]string{v1.LabelInstanceType: node1.Labels[v1.LabelInstanceType]}})
+		pod := test.Pod()
 		ExpectApplied(ctx, env.Client, machine1, node1, prov, pod)
 
 		// inform cluster state about nodes and machines
@@ -1758,7 +1758,8 @@ var _ = Describe("Consolidation TTL", func() {
 			defer GinkgoRecover()
 			defer wg.Done()
 			defer finished.Store(true)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			_, err := deprovisioningController.Reconcile(ctx, reconcile.Request{})
+			Expect(err).To(HaveOccurred())
 		}()
 
 		// wait for the deprovisioningController to block on the validation timeout

--- a/pkg/controllers/deprovisioning/suite_test.go
+++ b/pkg/controllers/deprovisioning/suite_test.go
@@ -1744,7 +1744,8 @@ var _ = Describe("Consolidation TTL", func() {
 		ExpectNotFound(ctx, env.Client, node2)
 	})
 	It("should not consolidate if the action becomes invalid during the node TTL wait", func() {
-		pod := test.Pod()
+		// Only allow emptiness consolidation by using an instance type selector
+		pod := test.Pod(test.PodOptions{NodeSelector: map[string]string{v1.LabelInstanceType: node1.Labels[v1.LabelInstanceType]}})
 		ExpectApplied(ctx, env.Client, machine1, node1, prov, pod)
 
 		// inform cluster state about nodes and machines

--- a/pkg/controllers/deprovisioning/types.go
+++ b/pkg/controllers/deprovisioning/types.go
@@ -127,7 +127,6 @@ type action byte
 const (
 	actionDelete action = iota
 	actionReplace
-	actionRetry
 	actionDoNothing
 )
 
@@ -139,9 +138,6 @@ func (a action) String() string {
 	// Deprovisioning action with replacement machines
 	case actionReplace:
 		return "replace"
-	// Deprovisioning failed for a retryable reason
-	case actionRetry:
-		return "retry"
 	case actionDoNothing:
 		return "do nothing"
 	default:


### PR DESCRIPTION
Fixes:
* https://github.com/aws/karpenter/issues/3708
* https://github.com/aws/karpenter/issues/3576

**Description**

Fixes a bug where Karpenter would exponentially back off upon successful deprovisioning a node, leading to Karpenter appearing to freeze. Semantically, controller-runtime treats `return reconcile.Result{Requeue: true}, nil` as an exponential backoff. Subsequent reconcile loops that return this will increase the time between loops up to a maximum of [1000 seconds](https://github.com/kubernetes/client-go/blob/master/util/workqueue/default_rate_limiters.go#L86), starting at one millisecond. 

For example, after 10 successful expiration/drifts, karpenter would be waiting ~1 second between loops. After 20 successful drifts, karpenter would be waiting ~1000 seconds or 16.67 minutes.

**How was this change tested?**

* Disable consolidation to isolate the delete behavior w/o bulk delete
* Scaled to 10,000 pods of 1 core each
* Apply expiration of 1 minute to the provisioner
* Scale pods to 0
* Observe backoff of deprovisioning

As a follow on, we need to implement comprehensive scale testing of:
* Expiration
* Drift
* Consolidation

## Before 
```
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:15.426Z	INFO	controller.node	annotating node as expired	{"commit": "672a832-dirty", "node": "ip-192-168-184-105.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:15.428Z	INFO	controller.node	annotating node as expired	{"commit": "672a832-dirty", "node": "ip-192-168-115-147.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:15.429Z	INFO	controller.node	annotating node as expired	{"commit": "672a832-dirty", "node": "ip-192-168-15-167.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:15.430Z	INFO	controller.node	annotating node as expired	{"commit": "672a832-dirty", "node": "ip-192-168-99-151.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:15.431Z	INFO	controller.node	annotating node as expired	{"commit": "672a832-dirty", "node": "ip-192-168-182-225.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:15.433Z	INFO	controller.node	annotating node as expired	{"commit": "672a832-dirty", "node": "ip-192-168-78-174.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:15.434Z	INFO	controller.node	annotating node as expired	{"commit": "672a832-dirty", "node": "ip-192-168-189-106.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:15.435Z	INFO	controller.node	annotating node as expired	{"commit": "672a832-dirty", "node": "ip-192-168-27-78.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:15.436Z	INFO	controller.node	annotating node as expired	{"commit": "672a832-dirty", "node": "ip-192-168-167-28.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:15.468Z	INFO	controller.node	annotating node as expired	{"commit": "672a832-dirty", "node": "ip-192-168-27-67.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:15.469Z	INFO	controller.node	annotating node as expired	{"commit": "672a832-dirty", "node": "ip-192-168-93-218.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:15.470Z	INFO	controller.node	annotating node as expired	{"commit": "672a832-dirty", "node": "ip-192-168-191-71.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:15.475Z	INFO	controller.node	annotating node as expired	{"commit": "672a832-dirty", "node": "ip-192-168-11-168.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:15.476Z	INFO	controller.node	annotating node as expired	{"commit": "672a832-dirty", "node": "ip-192-168-71-85.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:15.478Z	INFO	controller.node	annotating node as expired	{"commit": "672a832-dirty", "node": "ip-192-168-191-140.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:15.480Z	INFO	controller.node	annotating node as expired	{"commit": "672a832-dirty", "node": "ip-192-168-103-126.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:15.481Z	INFO	controller.node	annotating node as expired	{"commit": "672a832-dirty", "node": "ip-192-168-83-136.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:15.482Z	INFO	controller.node	annotating node as expired	{"commit": "672a832-dirty", "node": "ip-192-168-14-249.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:15.484Z	INFO	controller.node	annotating node as expired	{"commit": "672a832-dirty", "node": "ip-192-168-113-191.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:15.506Z	INFO	controller.node	annotating node as expired	{"commit": "672a832-dirty", "node": "ip-192-168-17-89.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:15.507Z	INFO	controller.node	annotating node as expired	{"commit": "672a832-dirty", "node": "ip-192-168-168-90.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:15.508Z	INFO	controller.node	annotating node as expired	{"commit": "672a832-dirty", "node": "ip-192-168-2-204.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:16.872Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "9m28.872054909s"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:16.872Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-15-167.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:16.893Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-15-167.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:17.218Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-15-167.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:18.950Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "9m30.950037574s"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:18.950Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-99-151.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:18.974Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-99-151.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:19.297Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-99-151.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:21.059Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "9m33.05999626s"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:21.060Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-163-114.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:21.081Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-163-114.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:21.417Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-163-114.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:23.114Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "9m35.114100165s"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:23.114Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-125-147.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:23.135Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-125-147.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:23.467Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-125-147.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:25.277Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "9m37.277771642s"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:25.277Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-17-89.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:25.311Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-17-89.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:25.661Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-17-89.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:27.388Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "9m4.388936761s"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:27.388Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-121-224.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:27.411Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-121-224.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:27.736Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-121-224.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:29.511Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "9m6.511454396s"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:29.511Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-125-51.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:29.537Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-125-51.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:29.856Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-125-51.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:31.699Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "9m8.699700172s"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:31.699Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-64-190.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:31.722Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-64-190.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:32.118Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-64-190.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:33.895Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "9m10.895186428s"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:33.895Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-165-124.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:33.918Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-165-124.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:34.275Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-165-124.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:36.290Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "9m13.290116139s"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:36.290Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-113-191.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:36.313Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-113-191.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:36.747Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-113-191.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:38.928Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "9m15.928448986s"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:38.928Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-105-4.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:38.970Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-105-4.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:39.346Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-105-4.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:42.086Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "9m19.086775227s"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:42.086Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-110-86.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:42.107Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-110-86.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:42.467Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-110-86.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:46.186Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "9m23.186415789s"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:46.186Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-100-153.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:46.210Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-100-153.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:46.568Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-100-153.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:52.383Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "9m29.383562755s"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:52.383Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-127-48.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:52.429Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-127-48.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:38:52.792Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-127-48.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:39:02.682Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "9m39.682060754s"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:39:02.682Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-115-147.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:39:02.703Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-115-147.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:39:03.050Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-115-147.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:39:21.138Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "9m58.138283352s"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:39:21.138Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-78-59.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:39:21.160Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-78-59.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:39:21.561Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-78-59.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:39:56.084Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "10m33.084663358s"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:39:56.084Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-103-126.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:39:56.115Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-103-126.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:39:56.466Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-103-126.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:41:03.708Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "11m40.708229056s"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:41:03.708Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-70-196.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:41:03.731Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-70-196.us-west-2.compute.internal"}
karpenter-84659d4f58-k5wnw controller 2023-04-07T23:41:04.036Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-70-196.us-west-2.compute.internal"}
```

Observe how in the final few lines, it takes >1 minute.

## After
```
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:20:55.987Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-27-233.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:20:58.119Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-129-230.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:01.280Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-27-233.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:02.585Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "13m25.585698415s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:02.585Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-134-50.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:02.623Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-134-50.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:06.705Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-134-50.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:09.203Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "13m32.203097267s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:09.203Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-141-249.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:09.242Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-141-249.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:13.202Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-141-249.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:15.476Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "13m38.476675523s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:15.476Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-157-188.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:15.502Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-157-188.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:19.516Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-157-188.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:21.680Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "13m44.680004964s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:21.680Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-2-59.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:21.733Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-2-59.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:24.522Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-2-59.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:28.116Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "13m36.11600856s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:28.116Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-57-235.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:28.140Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-57-235.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:28.468Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-57-235.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:30.322Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "13m38.322347809s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:30.322Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-33-97.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:30.349Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-33-97.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:30.880Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-33-97.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:32.541Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "13m40.541035911s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:32.541Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-101-89.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:32.573Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-101-89.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:36.544Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-101-89.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:38.671Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "13m46.671013523s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:38.671Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-163-102.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:38.689Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-163-102.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:39.016Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-163-102.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:41.037Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "13m49.037918563s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:41.037Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-178-130.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:41.089Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-178-130.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:41.674Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-178-130.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:43.301Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "13m51.301301223s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:43.301Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-164-53.us-west-2.compute.internal/c6a.32xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:43.342Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-164-53.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:46.121Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-164-53.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:49.574Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "13m15.574531108s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:49.574Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-139-243.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:49.595Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-139-243.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:52.344Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-139-243.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:55.792Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "13m20.79206584s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:55.792Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-169-131.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:55.843Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-169-131.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:56.465Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-169-131.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:57.877Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "13m22.877867708s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:57.877Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-162-33.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:57.898Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-162-33.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:21:58.232Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-162-33.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:00.106Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "13m7.106331211s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:00.106Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-25-221.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:00.138Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-25-221.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:00.647Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-25-221.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:02.286Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "13m9.286646304s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:02.286Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-14-156.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:02.335Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-14-156.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:05.071Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-14-156.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:08.505Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "13m15.505824432s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:08.505Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-118-160.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:08.542Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-118-160.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:08.930Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-118-160.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:10.634Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "13m17.634806008s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:10.634Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-115-8.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:10.679Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-115-8.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:11.255Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-115-8.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:12.729Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "13m19.729479086s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:12.729Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-64-246.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:12.795Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-64-246.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:13.110Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-64-246.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:14.928Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "12m58.928688146s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:14.928Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-12-0.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:14.962Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-12-0.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:15.298Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-12-0.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:17.089Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "13m0.089581943s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:17.089Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-11-149.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:17.112Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-11-149.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:17.469Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-11-149.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:19.190Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "13m2.190756907s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:19.190Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-3-125.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:19.211Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-3-125.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:19.566Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-3-125.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:21.308Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "13m4.308196581s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:21.308Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-126-251.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:21.326Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-126-251.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:21.832Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-126-251.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:23.435Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "13m6.435464356s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:23.435Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-108-112.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:23.455Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-108-112.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:23.771Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-108-112.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:25.493Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "12m28.493563257s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:25.493Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-90-56.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:25.512Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-90-56.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:25.849Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-90-56.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:27.556Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "12m30.556874606s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:27.556Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-11-76.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:27.577Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-11-76.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:28.097Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-11-76.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:29.638Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "12m31.638684285s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:29.638Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-71-52.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:29.660Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-71-52.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:30.005Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-71-52.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:31.753Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "12m33.753713723s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:31.753Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-66-73.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:31.774Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-66-73.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:32.113Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-66-73.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:33.831Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "12m35.83158375s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:33.831Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-186-135.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:33.851Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-186-135.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:34.198Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-186-135.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:35.879Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "12m37.87903747s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:35.879Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-80-3.us-west-2.compute.internal/c6a.32xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:35.898Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-80-3.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:36.228Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-80-3.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:37.966Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "12m39.966696745s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:37.966Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-72-95.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:37.986Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-72-95.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:38.334Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-72-95.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:40.081Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "12m42.081375179s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:40.081Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-181-148.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:40.101Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-181-148.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:40.474Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-181-148.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:42.192Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "12m44.192355s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:42.192Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-187-146.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:42.221Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-187-146.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:42.552Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-187-146.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:44.260Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "11m52.260653088s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:44.260Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-182-158.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:44.281Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-182-158.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:44.710Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-182-158.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:46.394Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "11m54.394416306s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:46.394Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-121-40.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:46.414Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-121-40.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:46.739Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-121-40.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:48.467Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "11m56.467967326s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:48.468Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-124-254.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:48.488Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-124-254.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:48.815Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-124-254.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:50.549Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "11m58.549488964s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:50.549Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-185-132.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:50.572Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-185-132.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:50.881Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-185-132.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:52.684Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "12m0.68428122s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:52.684Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-0-68.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:52.710Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-0-68.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:53.080Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-0-68.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:54.784Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "12m2.784742846s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:54.785Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-1-213.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:54.802Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-1-213.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:55.141Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-1-213.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:56.845Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "12m4.845734336s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:56.845Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-23-90.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:56.879Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-23-90.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:57.208Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-23-90.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:58.908Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "12m5.908416908s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:58.908Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-181-171.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:58.929Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-181-171.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:22:59.247Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-181-171.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:23:00.985Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "12m7.985764057s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:23:00.985Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-189-81.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:23:01.005Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-189-81.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:23:01.323Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-189-81.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:23:03.092Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "12m10.092966478s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:23:03.093Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-70-168.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:23:03.114Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-70-168.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:23:03.421Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-70-168.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:23:05.140Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "12m12.140456214s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:23:05.140Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-73-171.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:23:05.159Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-73-171.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:23:05.520Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-73-171.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:23:07.201Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "12m14.201456317s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:23:07.201Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-79-41.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:23:07.219Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-79-41.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:23:07.577Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-79-41.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:23:09.290Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "11m38.290896125s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:23:09.290Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-103-140.us-west-2.compute.internal/c5.18xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:23:09.313Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-103-140.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:23:09.664Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-103-140.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:23:11.424Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "11m40.424206078s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:23:11.424Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-17-177.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:23:11.445Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-17-177.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:23:11.779Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-17-177.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:23:13.476Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "11m42.476776156s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:23:13.476Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-86-161.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:23:13.497Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-86-161.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:23:13.830Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-86-161.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:23:15.525Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "8m32.525722803s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:23:15.525Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-41-77.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:23:15.546Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-41-77.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:23:15.851Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-41-77.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:23:17.617Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "7m30.617623559s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:23:17.617Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-46-38.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:23:17.637Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-46-38.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:23:17.936Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-46-38.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:23:19.724Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "6m28.724566776s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:23:19.724Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-99-171.us-west-2.compute.internal/c6a.32xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:23:19.745Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-99-171.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:23:20.086Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-99-171.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:23:21.764Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "5m25.764787073s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:23:21.764Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-89-122.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:23:21.787Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-89-122.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:23:22.107Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-89-122.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:23:23.850Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "672a832-dirty", "ttl": "30s", "delay": "4m23.850730471s"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:23:23.850Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-73-184.us-west-2.compute.internal/c6a.48xlarge/on-demand	{"commit": "672a832-dirty"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:23:23.871Z	INFO	controller.termination	cordoned node	{"commit": "672a832-dirty", "node": "ip-192-168-73-184.us-west-2.compute.internal"}
karpenter-dc5f65c47-w4s9p controller 2023-04-07T23:23:24.181Z	INFO	controller.termination	deleted node	{"commit": "672a832-dirty", "node": "ip-192-168-73-184.us-west-2.compute.internal"}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
