### PR TITLE
chore!: Remove container loglevel from `config-logging`

### DIFF
--- a/charts/karpenter-core/templates/configmap-logging.yaml
+++ b/charts/karpenter-core/templates/configmap-logging.yaml
@@ -35,9 +35,3 @@ data:
         "timeEncoder": "iso8601"
       }
     }
-{{- with .Values.controller.logLevel }}
-  loglevel.controller: {{ . | quote }}
-{{- end }}
-{{- with .Values.webhook.logLevel }}
-  loglevel.webhook: {{ . | quote }}
-{{- end }}

--- a/charts/karpenter-core/values.yaml
+++ b/charts/karpenter-core/values.yaml
@@ -108,17 +108,12 @@ controller:
     limits:
       cpu: 1
       memory: 1Gi
-  # -- Controller log level, defaults to the global log level
-  logLevel: ""
-  # -- Controller log encoding, defaults to the global log encoding
-  logEncoding: ""
   # -- Additional volumeMounts for the controller pod.
   extraVolumeMounts: []
   # - name: aws-iam-token
   #   mountPath: /var/run/secrets/eks.amazonaws.com/serviceaccount
   #   readOnly: true
 webhook:
-  logLevel: error
   # -- The container port to use for the webhook.
   port: 8443
 # -- Global log level


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

Container-based log level should not be supported since the separate containers for the controller and the webhook were removed in #29. These values should be removed from the `values.yaml` file in the helm chart

BREAKING: A user who would normally set the logLevel through `--set controller.logLevel` will now have to set it globally; otherwise, the log level will default to the global level

**How was this change tested?**

`make presubmit`
`make apply`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
