### PR TITLE
fix: add requeue into node expiration controller

### DIFF
--- a/pkg/controllers/node/drift.go
+++ b/pkg/controllers/node/drift.go
@@ -50,7 +50,7 @@ func (d *Drift) Reconcile(ctx context.Context, provisioner *v1alpha5.Provisioner
 	if !settings.FromContext(ctx).DriftEnabled {
 		if val == v1alpha5.VoluntaryDisruptionDriftedAnnotationValue {
 			delete(node.Annotations, v1alpha5.VoluntaryDisruptionAnnotationKey)
-			logging.FromContext(ctx).Infof("removing drift annotation from node as drift has been disabled")
+			logging.FromContext(ctx).Debugf("removing drift annotation from node as drift has been disabled")
 		}
 		return reconcile.Result{}, nil
 	}
@@ -62,13 +62,13 @@ func (d *Drift) Reconcile(ctx context.Context, provisioner *v1alpha5.Provisioner
 	// 2. Otherwise, if the node isn't drifted, but has the annotation, remove it.
 	if !drifted && hasAnnotation {
 		delete(node.Annotations, v1alpha5.VoluntaryDisruptionAnnotationKey)
-		logging.FromContext(ctx).Infof("removing drift annotation from node")
+		logging.FromContext(ctx).Debugf("removing drift annotation from node")
 		// 3. Finally, if the node is drifted, but doesn't have the annotation, add it.
 	} else if drifted && !hasAnnotation {
 		node.Annotations = lo.Assign(node.Annotations, map[string]string{
 			v1alpha5.VoluntaryDisruptionAnnotationKey: v1alpha5.VoluntaryDisruptionDriftedAnnotationValue,
 		})
-		logging.FromContext(ctx).Infof("annotating node as drifted")
+		logging.FromContext(ctx).Debugf("annotating node as drifted")
 	}
 
 	// Requeue after 5 minutes for the cache TTL

--- a/pkg/controllers/node/emptiness.go
+++ b/pkg/controllers/node/emptiness.go
@@ -65,12 +65,12 @@ func (r *Emptiness) Reconcile(ctx context.Context, provisioner *v1alpha5.Provisi
 	_, hasEmptinessTimestamp := n.Annotations[v1alpha5.EmptinessTimestampAnnotationKey]
 	if !empty && hasEmptinessTimestamp {
 		delete(n.Annotations, v1alpha5.EmptinessTimestampAnnotationKey)
-		logging.FromContext(ctx).Infof("removed emptiness TTL from node")
+		logging.FromContext(ctx).Debugf("removed emptiness TTL from node")
 	} else if empty && !hasEmptinessTimestamp {
 		n.Annotations = lo.Assign(n.Annotations, map[string]string{
 			v1alpha5.EmptinessTimestampAnnotationKey: r.clock.Now().Format(time.RFC3339),
 		})
-		logging.FromContext(ctx).Infof("added TTL to empty node")
+		logging.FromContext(ctx).Debugf("added TTL to empty node")
 	}
 
 	// Short requeue result so that we requeue to check for emptiness when the node nomination time ends

--- a/pkg/controllers/node/expiration.go
+++ b/pkg/controllers/node/expiration.go
@@ -46,7 +46,7 @@ func (e *Expiration) Reconcile(ctx context.Context, provisioner *v1alpha5.Provis
 	if provisioner.Spec.TTLSecondsUntilExpired == nil {
 		if val == v1alpha5.VoluntaryDisruptionExpiredAnnotationValue {
 			delete(node.Annotations, v1alpha5.VoluntaryDisruptionAnnotationKey)
-			logging.FromContext(ctx).Infof("removing expiration annotation from node as expiration has been disabled")
+			logging.FromContext(ctx).Debugf("removing expiration annotation from node as expiration has been disabled")
 		}
 		return reconcile.Result{}, nil
 	}
@@ -55,16 +55,17 @@ func (e *Expiration) Reconcile(ctx context.Context, provisioner *v1alpha5.Provis
 	expired := utilsnode.IsExpired(node, e.clock, provisioner)
 	if !expired && hasAnnotation {
 		delete(node.Annotations, v1alpha5.VoluntaryDisruptionAnnotationKey)
-		logging.FromContext(ctx).Infof("removing expiration annotation from node")
+		logging.FromContext(ctx).Debugf("removing expiration annotation from node")
 		// 3. Finally, if the node is expired, but doesn't have the annotation, add it.
 	} else if expired && !hasAnnotation {
 		node.Annotations = lo.Assign(node.Annotations, map[string]string{
 			v1alpha5.VoluntaryDisruptionAnnotationKey: v1alpha5.VoluntaryDisruptionExpiredAnnotationValue,
 		})
-		logging.FromContext(ctx).Infof("annotating node as expired")
+		logging.FromContext(ctx).Debugf("annotating node as expired")
+		return reconcile.Result{}, nil
 	}
 
 	// If the node isn't expired and doesn't have annotation, return.
-	// Use t.Sub(t.Now()) instead of time.Now() to ensure we're using the injected clock.
+	// Use t.Sub(time.Now()) instead of time.Until() to ensure we're using the injected clock.
 	return reconcile.Result{RequeueAfter: utilsnode.GetExpirationTime(node, provisioner).Sub(e.clock.Now())}, nil
 }

--- a/pkg/controllers/node/expiration.go
+++ b/pkg/controllers/node/expiration.go
@@ -65,5 +65,6 @@ func (e *Expiration) Reconcile(ctx context.Context, provisioner *v1alpha5.Provis
 	}
 
 	// If the node isn't expired and doesn't have annotation, return.
-	return reconcile.Result{}, nil
+	// Use t.Sub(t.Now()) instead of time.Now() to ensure we're using the injected clock.
+	return reconcile.Result{RequeueAfter: utilsnode.GetExpirationTime(node, provisioner).Sub(e.clock.Now())}, nil
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
We were previously not re-queuing at the node expiration time. This meant that nodes that weren't expired weren't requeued to get annotated at their pre-determined expiration time.

**How was this change tested?**
`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
