### PR TITLE
add logging if deprovisioners take longer than expected

### DIFF
--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -119,6 +119,7 @@ func (p *Provisioner) Reconcile(ctx context.Context, _ reconcile.Request) (resul
 	// with making any scheduling decision off of our state nodes. Otherwise, we have the potential to make
 	// a scheduling decision based on a smaller subset of nodes in our cluster state than actually exist.
 	if !p.cluster.Synced(ctx) {
+		logging.FromContext(ctx).Debugf("waiting on cluster sync")
 		return reconcile.Result{RequeueAfter: time.Second}, nil
 	}
 


### PR DESCRIPTION
Fixes # <!-- issue number -->

**Description**

Adds logging if deprovisioning takes longer than expected.

**How was this change tested?**


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
