### PR TITLE
chore: cleanup deprovisioning types

### DIFF
--- a/pkg/controllers/deprovisioning/controller.go
+++ b/pkg/controllers/deprovisioning/controller.go
@@ -158,7 +158,7 @@ func (c *Controller) deprovision(ctx context.Context, deprovisioner Deprovisione
 	if err != nil {
 		return false, fmt.Errorf("computing deprovisioning decision, %w", err)
 	}
-	if cmd.Action() == noOpAction {
+	if cmd.Action() == NoOpAction {
 		return false, nil
 	}
 
@@ -175,7 +175,7 @@ func (c *Controller) executeCommand(ctx context.Context, d Deprovisioner, comman
 	logging.FromContext(ctx).Infof("deprovisioning via %s %s", d, command.Action())
 
 	reason := fmt.Sprintf("%s/%s", d, command.Action())
-	if command.Action() == replaceAction {
+	if command.Action() == ReplaceAction {
 		if err := c.launchReplacementMachines(ctx, command, reason); err != nil {
 			// If we failed to launch the replacement, don't deprovision.  If this is some permanent failure,
 			// we don't want to disrupt workloads with no way to provision new nodes for them.

--- a/pkg/controllers/deprovisioning/controller.go
+++ b/pkg/controllers/deprovisioning/controller.go
@@ -158,7 +158,7 @@ func (c *Controller) deprovision(ctx context.Context, deprovisioner Deprovisione
 	if err != nil {
 		return false, fmt.Errorf("computing deprovisioning decision, %w", err)
 	}
-	if len(cmd.candidates) == 0 {
+	if cmd.Action() == noOpAction {
 		return false, nil
 	}
 
@@ -176,7 +176,7 @@ func (c *Controller) executeCommand(ctx context.Context, d Deprovisioner, comman
 	logging.FromContext(ctx).Infof("deprovisioning via %s %s", d, action)
 
 	reason := fmt.Sprintf("%s/%s", d, action)
-	if len(command.replacements) > 0 {
+	if command.Action() == replaceAction {
 		if err := c.launchReplacementMachines(ctx, command, reason); err != nil {
 			// If we failed to launch the replacement, don't deprovision.  If this is some permanent failure,
 			// we don't want to disrupt workloads with no way to provision new nodes for them.

--- a/pkg/controllers/deprovisioning/controller.go
+++ b/pkg/controllers/deprovisioning/controller.go
@@ -172,7 +172,7 @@ func (c *Controller) deprovision(ctx context.Context, deprovisioner Deprovisione
 
 func (c *Controller) executeCommand(ctx context.Context, d Deprovisioner, command Command) error {
 	action := lo.Ternary(len(command.replacements) > 0, "replace", "delete")
-	deprovisioningActionsPerformedCounter.With(prometheus.Labels{"action": fmt.Sprintf("%s/%s", d, action)}).Add(1)
+	deprovisioningActionsPerformedCounter.With(prometheus.Labels{"action": fmt.Sprintf("%s/%s", d, action)}).Inc()
 	logging.FromContext(ctx).Infof("deprovisioning via %s %s", d, action)
 
 	reason := fmt.Sprintf("%s/%s", d, action)

--- a/pkg/controllers/deprovisioning/controller.go
+++ b/pkg/controllers/deprovisioning/controller.go
@@ -158,7 +158,7 @@ func (c *Controller) deprovision(ctx context.Context, deprovisioner Deprovisione
 	if err != nil {
 		return false, fmt.Errorf("computing deprovisioning decision, %w", err)
 	}
-	if cmd.action == actionDoNothing {
+	if len(cmd.candidates) == 0 {
 		return false, nil
 	}
 
@@ -171,11 +171,12 @@ func (c *Controller) deprovision(ctx context.Context, deprovisioner Deprovisione
 }
 
 func (c *Controller) executeCommand(ctx context.Context, d Deprovisioner, command Command) error {
-	deprovisioningActionsPerformedCounter.With(prometheus.Labels{"action": fmt.Sprintf("%s/%s", d, command.action)}).Add(1)
-	logging.FromContext(ctx).Infof("deprovisioning via %s %s", d, command)
+	action := lo.Ternary(len(command.replacements) > 0, "replace", "delete")
+	deprovisioningActionsPerformedCounter.With(prometheus.Labels{"action": fmt.Sprintf("%s/%s", d, action)}).Add(1)
+	logging.FromContext(ctx).Infof("deprovisioning via %s %s", d, action)
 
-	reason := fmt.Sprintf("%s/%s", d, command.action)
-	if command.action == actionReplace {
+	reason := fmt.Sprintf("%s/%s", d, action)
+	if len(command.replacements) > 0 {
 		if err := c.launchReplacementMachines(ctx, command, reason); err != nil {
 			// If we failed to launch the replacement, don't deprovision.  If this is some permanent failure,
 			// we don't want to disrupt workloads with no way to provision new nodes for them.

--- a/pkg/controllers/deprovisioning/controller.go
+++ b/pkg/controllers/deprovisioning/controller.go
@@ -171,7 +171,7 @@ func (c *Controller) deprovision(ctx context.Context, deprovisioner Deprovisione
 }
 
 func (c *Controller) executeCommand(ctx context.Context, d Deprovisioner, command Command) error {
-	action := lo.Ternary(len(command.replacements) > 0, "replace", "delete")
+	action := lo.Ternary(len(command.replacements) > 0, replaceAction, deleteAction)
 	deprovisioningActionsPerformedCounter.With(prometheus.Labels{"action": fmt.Sprintf("%s/%s", d, action)}).Inc()
 	logging.FromContext(ctx).Infof("deprovisioning via %s %s", d, action)
 

--- a/pkg/controllers/deprovisioning/controller.go
+++ b/pkg/controllers/deprovisioning/controller.go
@@ -158,7 +158,7 @@ func (c *Controller) deprovision(ctx context.Context, deprovisioner Deprovisione
 	if err != nil {
 		return false, fmt.Errorf("computing deprovisioning decision, %w", err)
 	}
-	if cmd.action() == noOpAction {
+	if cmd.Action() == noOpAction {
 		return false, nil
 	}
 
@@ -171,11 +171,11 @@ func (c *Controller) deprovision(ctx context.Context, deprovisioner Deprovisione
 }
 
 func (c *Controller) executeCommand(ctx context.Context, d Deprovisioner, command Command) error {
-	deprovisioningActionsPerformedCounter.With(prometheus.Labels{"action": fmt.Sprintf("%s/%s", d, command.action())}).Inc()
-	logging.FromContext(ctx).Infof("deprovisioning via %s %s", d, command.action())
+	deprovisioningActionsPerformedCounter.With(prometheus.Labels{"action": fmt.Sprintf("%s/%s", d, command.Action())}).Inc()
+	logging.FromContext(ctx).Infof("deprovisioning via %s %s", d, command.Action())
 
-	reason := fmt.Sprintf("%s/%s", d, command.action())
-	if command.action() == replaceAction {
+	reason := fmt.Sprintf("%s/%s", d, command.Action())
+	if command.Action() == replaceAction {
 		if err := c.launchReplacementMachines(ctx, command, reason); err != nil {
 			// If we failed to launch the replacement, don't deprovision.  If this is some permanent failure,
 			// we don't want to disrupt workloads with no way to provision new nodes for them.

--- a/pkg/controllers/deprovisioning/drift.go
+++ b/pkg/controllers/deprovisioning/drift.go
@@ -71,7 +71,6 @@ func (d *Drift) ComputeCommand(ctx context.Context, nodes ...*Candidate) (Comman
 	}); len(empty) > 0 {
 		return Command{
 			candidates: empty,
-			action:     actionDelete,
 		}, nil
 	}
 
@@ -92,16 +91,14 @@ func (d *Drift) ComputeCommand(ctx context.Context, nodes ...*Candidate) (Comman
 		if len(results.NewMachines) == 0 {
 			return Command{
 				candidates: []*Candidate{candidate},
-				action:     actionDelete,
 			}, nil
 		}
 		return Command{
 			candidates:   []*Candidate{candidate},
-			action:       actionReplace,
 			replacements: results.NewMachines,
 		}, nil
 	}
-	return Command{action: actionDoNothing}, nil
+	return Command{}, nil
 }
 
 // String is the string representation of the deprovisioner

--- a/pkg/controllers/deprovisioning/emptiness.go
+++ b/pkg/controllers/deprovisioning/emptiness.go
@@ -67,12 +67,8 @@ func (e *Emptiness) ComputeCommand(_ context.Context, candidates ...*Candidate) 
 		return cn.Machine.DeletionTimestamp.IsZero() && len(cn.pods) == 0
 	})
 
-	if len(emptyCandidates) == 0 {
-		return Command{action: actionDoNothing}, nil
-	}
 	return Command{
 		candidates: emptyCandidates,
-		action:     actionDelete,
 	}, nil
 }
 

--- a/pkg/controllers/deprovisioning/emptymachineconsolidation.go
+++ b/pkg/controllers/deprovisioning/emptymachineconsolidation.go
@@ -43,7 +43,7 @@ func NewEmptyMachineConsolidation(clk clock.Clock, cluster *state.Cluster, kubeC
 // ComputeCommand generates a deprovisioning command given deprovisionable machines
 func (c *EmptyMachineConsolidation) ComputeCommand(ctx context.Context, candidates ...*Candidate) (Command, error) {
 	if c.cluster.Consolidated() {
-		return Command{action: actionDoNothing}, nil
+		return Command{}, nil
 	}
 	candidates, err := c.sortAndFilterCandidates(ctx, candidates)
 	if err != nil {
@@ -53,12 +53,11 @@ func (c *EmptyMachineConsolidation) ComputeCommand(ctx context.Context, candidat
 	// select the entirely empty nodes
 	emptyCandidates := lo.Filter(candidates, func(n *Candidate, _ int) bool { return len(n.pods) == 0 })
 	if len(emptyCandidates) == 0 {
-		return Command{action: actionDoNothing}, nil
+		return Command{}, nil
 	}
 
 	cmd := Command{
 		candidates: emptyCandidates,
-		action:     actionDelete,
 	}
 
 	// empty machine consolidation doesn't use Validation as we get to take advantage of cluster.IsNodeNominated.  This

--- a/pkg/controllers/deprovisioning/expiration.go
+++ b/pkg/controllers/deprovisioning/expiration.go
@@ -92,7 +92,6 @@ func (e *Expiration) ComputeCommand(ctx context.Context, nodes ...*Candidate) (C
 	}); len(empty) > 0 {
 		return Command{
 			candidates: empty,
-			action:     actionDelete,
 		}, nil
 	}
 
@@ -115,11 +114,10 @@ func (e *Expiration) ComputeCommand(ctx context.Context, nodes ...*Candidate) (C
 			With("delay", time.Since(node.GetExpirationTime(candidates[0].Node, candidates[0].provisioner))).Infof("triggering termination for expired node after TTL")
 		return Command{
 			candidates:   []*Candidate{candidate},
-			action:       actionReplace,
 			replacements: results.NewMachines,
 		}, nil
 	}
-	return Command{action: actionDoNothing}, nil
+	return Command{}, nil
 }
 
 // String is the string representation of the deprovisioner

--- a/pkg/controllers/deprovisioning/multimachineconsolidation.go
+++ b/pkg/controllers/deprovisioning/multimachineconsolidation.go
@@ -89,7 +89,7 @@ func (m *MultiMachineConsolidation) firstNMachineConsolidationOption(ctx context
 
 		candidatesToConsolidate := candidates[0 : mid+1]
 
-		action, err := m.computeConsolidation(ctx, candidatesToConsolidate...)
+		cmd, err := m.computeConsolidation(ctx, candidatesToConsolidate...)
 		if err != nil {
 			return Command{}, err
 		}
@@ -97,14 +97,14 @@ func (m *MultiMachineConsolidation) firstNMachineConsolidationOption(ctx context
 		// ensure that the action is sensical for replacements, see explanation on filterOutSameType for why this is
 		// required
 		instanceTypeFiltered := false
-		if action.Action() == ReplaceAction {
-			action.replacements[0].InstanceTypeOptions = filterOutSameType(action.replacements[0], candidatesToConsolidate)
-			instanceTypeFiltered = len(action.replacements[0].InstanceTypeOptions) == 0
+		if cmd.Action() == ReplaceAction {
+			cmd.replacements[0].InstanceTypeOptions = filterOutSameType(cmd.replacements[0], candidatesToConsolidate)
+			instanceTypeFiltered = len(cmd.replacements[0].InstanceTypeOptions) == 0
 		}
 
-		if !instanceTypeFiltered {
+		if !instanceTypeFiltered || cmd.Action() == DeleteAction {
 			// we can consolidate machines [0,mid]
-			lastSavedCommand = action
+			lastSavedCommand = cmd
 			min = mid + 1
 		} else {
 			max = mid - 1

--- a/pkg/controllers/deprovisioning/multimachineconsolidation.go
+++ b/pkg/controllers/deprovisioning/multimachineconsolidation.go
@@ -54,7 +54,7 @@ func (m *MultiMachineConsolidation) ComputeCommand(ctx context.Context, candidat
 	if err != nil {
 		return Command{}, err
 	}
-	if cmd.Action() == noOpAction {
+	if cmd.Action() == NoOpAction {
 		return cmd, nil
 	}
 
@@ -97,7 +97,7 @@ func (m *MultiMachineConsolidation) firstNMachineConsolidationOption(ctx context
 		// ensure that the action is sensical for replacements, see explanation on filterOutSameType for why this is
 		// required
 		instanceTypeFiltered := false
-		if action.Action() == replaceAction {
+		if action.Action() == ReplaceAction {
 			action.replacements[0].InstanceTypeOptions = filterOutSameType(action.replacements[0], candidatesToConsolidate)
 			instanceTypeFiltered = len(action.replacements[0].InstanceTypeOptions) == 0
 		}

--- a/pkg/controllers/deprovisioning/multimachineconsolidation.go
+++ b/pkg/controllers/deprovisioning/multimachineconsolidation.go
@@ -54,7 +54,7 @@ func (m *MultiMachineConsolidation) ComputeCommand(ctx context.Context, candidat
 	if err != nil {
 		return Command{}, err
 	}
-	if cmd.Action() == noOpAction {
+	if cmd.action() == noOpAction {
 		return cmd, nil
 	}
 
@@ -97,7 +97,7 @@ func (m *MultiMachineConsolidation) firstNMachineConsolidationOption(ctx context
 		// ensure that the action is sensical for replacements, see explanation on filterOutSameType for why this is
 		// required
 		instanceTypeFiltered := false
-		if action.Action() == replaceAction {
+		if action.action() == replaceAction {
 			action.replacements[0].InstanceTypeOptions = filterOutSameType(action.replacements[0], candidatesToConsolidate)
 			instanceTypeFiltered = len(action.replacements[0].InstanceTypeOptions) == 0
 		}

--- a/pkg/controllers/deprovisioning/multimachineconsolidation.go
+++ b/pkg/controllers/deprovisioning/multimachineconsolidation.go
@@ -54,7 +54,7 @@ func (m *MultiMachineConsolidation) ComputeCommand(ctx context.Context, candidat
 	if err != nil {
 		return Command{}, err
 	}
-	if len(cmd.candidates) == 0 {
+	if cmd.Action() == noOpAction {
 		return cmd, nil
 	}
 
@@ -97,7 +97,7 @@ func (m *MultiMachineConsolidation) firstNMachineConsolidationOption(ctx context
 		// ensure that the action is sensical for replacements, see explanation on filterOutSameType for why this is
 		// required
 		instanceTypeFiltered := false
-		if len(action.replacements) > 0 {
+		if action.Action() == replaceAction {
 			action.replacements[0].InstanceTypeOptions = filterOutSameType(action.replacements[0], candidatesToConsolidate)
 			instanceTypeFiltered = len(action.replacements[0].InstanceTypeOptions) == 0
 		}

--- a/pkg/controllers/deprovisioning/multimachineconsolidation.go
+++ b/pkg/controllers/deprovisioning/multimachineconsolidation.go
@@ -41,7 +41,7 @@ func NewMultiMachineConsolidation(clk clock.Clock, cluster *state.Cluster, kubeC
 
 func (m *MultiMachineConsolidation) ComputeCommand(ctx context.Context, candidates ...*Candidate) (Command, error) {
 	if m.cluster.Consolidated() {
-		return Command{action: actionDoNothing}, nil
+		return Command{}, nil
 	}
 	candidates, err := m.sortAndFilterCandidates(ctx, candidates)
 	if err != nil {
@@ -54,7 +54,7 @@ func (m *MultiMachineConsolidation) ComputeCommand(ctx context.Context, candidat
 	if err != nil {
 		return Command{}, err
 	}
-	if cmd.action == actionDoNothing {
+	if len(cmd.candidates) == 0 {
 		return cmd, nil
 	}
 
@@ -75,14 +75,14 @@ func (m *MultiMachineConsolidation) ComputeCommand(ctx context.Context, candidat
 func (m *MultiMachineConsolidation) firstNMachineConsolidationOption(ctx context.Context, candidates []*Candidate, max int) (Command, error) {
 	// we always operate on at least two machines at once, for single machines standard consolidation will find all solutions
 	if len(candidates) < 2 {
-		return Command{action: actionDoNothing}, nil
+		return Command{}, nil
 	}
 	min := 1
 	if len(candidates) <= max {
 		max = len(candidates) - 1
 	}
 
-	lastSavedCommand := Command{action: actionDoNothing}
+	lastSavedCommand := Command{}
 	// binary search to find the maximum number of machines we can terminate
 	for min <= max {
 		mid := (min + max) / 2
@@ -96,14 +96,13 @@ func (m *MultiMachineConsolidation) firstNMachineConsolidationOption(ctx context
 
 		// ensure that the action is sensical for replacements, see explanation on filterOutSameType for why this is
 		// required
-		if action.action == actionReplace {
+		instanceTypeFiltered := false
+		if len(action.replacements) > 0 {
 			action.replacements[0].InstanceTypeOptions = filterOutSameType(action.replacements[0], candidatesToConsolidate)
-			if len(action.replacements[0].InstanceTypeOptions) == 0 {
-				action.action = actionDoNothing
-			}
+			instanceTypeFiltered = len(action.replacements[0].InstanceTypeOptions) == 0
 		}
 
-		if action.action == actionReplace || action.action == actionDelete {
+		if !instanceTypeFiltered {
 			// we can consolidate machines [0,mid]
 			lastSavedCommand = action
 			min = mid + 1

--- a/pkg/controllers/deprovisioning/multimachineconsolidation.go
+++ b/pkg/controllers/deprovisioning/multimachineconsolidation.go
@@ -96,14 +96,14 @@ func (m *MultiMachineConsolidation) firstNMachineConsolidationOption(ctx context
 
 		// ensure that the action is sensical for replacements, see explanation on filterOutSameType for why this is
 		// required
-		instanceTypeFiltered := false
+		replacementHasValidInstanceTypes := false
 		if cmd.Action() == ReplaceAction {
 			cmd.replacements[0].InstanceTypeOptions = filterOutSameType(cmd.replacements[0], candidatesToConsolidate)
-			instanceTypeFiltered = len(cmd.replacements[0].InstanceTypeOptions) == 0
+			replacementHasValidInstanceTypes = len(cmd.replacements[0].InstanceTypeOptions) > 0
 		}
 
-		// instanceTypeFiltered will be false if the replacement action has valid instance types remaining after filtering.
-		if !instanceTypeFiltered || cmd.Action() == DeleteAction {
+		// replacementHasValidInstanceTypes will be false if the replacement action has valid instance types remaining after filtering.
+		if replacementHasValidInstanceTypes || cmd.Action() == DeleteAction {
 			// we can consolidate machines [0,mid]
 			lastSavedCommand = cmd
 			min = mid + 1

--- a/pkg/controllers/deprovisioning/multimachineconsolidation.go
+++ b/pkg/controllers/deprovisioning/multimachineconsolidation.go
@@ -102,6 +102,7 @@ func (m *MultiMachineConsolidation) firstNMachineConsolidationOption(ctx context
 			instanceTypeFiltered = len(cmd.replacements[0].InstanceTypeOptions) == 0
 		}
 
+		// instanceTypeFiltered will be false if the replacement action has valid instance types remaining after filtering.
 		if !instanceTypeFiltered || cmd.Action() == DeleteAction {
 			// we can consolidate machines [0,mid]
 			lastSavedCommand = cmd

--- a/pkg/controllers/deprovisioning/multimachineconsolidation.go
+++ b/pkg/controllers/deprovisioning/multimachineconsolidation.go
@@ -54,7 +54,7 @@ func (m *MultiMachineConsolidation) ComputeCommand(ctx context.Context, candidat
 	if err != nil {
 		return Command{}, err
 	}
-	if cmd.action() == noOpAction {
+	if cmd.Action() == noOpAction {
 		return cmd, nil
 	}
 
@@ -97,7 +97,7 @@ func (m *MultiMachineConsolidation) firstNMachineConsolidationOption(ctx context
 		// ensure that the action is sensical for replacements, see explanation on filterOutSameType for why this is
 		// required
 		instanceTypeFiltered := false
-		if action.action() == replaceAction {
+		if action.Action() == replaceAction {
 			action.replacements[0].InstanceTypeOptions = filterOutSameType(action.replacements[0], candidatesToConsolidate)
 			instanceTypeFiltered = len(action.replacements[0].InstanceTypeOptions) == 0
 		}

--- a/pkg/controllers/deprovisioning/singlemachineconsolidation.go
+++ b/pkg/controllers/deprovisioning/singlemachineconsolidation.go
@@ -57,7 +57,7 @@ func (c *SingleMachineConsolidation) ComputeCommand(ctx context.Context, candida
 			logging.FromContext(ctx).Errorf("computing consolidation %s", err)
 			continue
 		}
-		if cmd.action() == noOpAction {
+		if cmd.Action() == noOpAction {
 			continue
 		}
 
@@ -70,7 +70,7 @@ func (c *SingleMachineConsolidation) ComputeCommand(ctx context.Context, candida
 			return Command{}, fmt.Errorf("command is no longer valid, %s", cmd)
 		}
 
-		if cmd.action() != noOpAction {
+		if cmd.Action() != noOpAction {
 			return cmd, nil
 		}
 	}

--- a/pkg/controllers/deprovisioning/singlemachineconsolidation.go
+++ b/pkg/controllers/deprovisioning/singlemachineconsolidation.go
@@ -57,7 +57,7 @@ func (c *SingleMachineConsolidation) ComputeCommand(ctx context.Context, candida
 			logging.FromContext(ctx).Errorf("computing consolidation %s", err)
 			continue
 		}
-		if cmd.Action() == noOpAction {
+		if cmd.Action() == NoOpAction {
 			continue
 		}
 
@@ -70,7 +70,7 @@ func (c *SingleMachineConsolidation) ComputeCommand(ctx context.Context, candida
 			return Command{}, fmt.Errorf("command is no longer valid, %s", cmd)
 		}
 
-		if cmd.Action() != noOpAction {
+		if cmd.Action() != NoOpAction {
 			return cmd, nil
 		}
 	}

--- a/pkg/controllers/deprovisioning/singlemachineconsolidation.go
+++ b/pkg/controllers/deprovisioning/singlemachineconsolidation.go
@@ -42,7 +42,7 @@ func NewSingleMachineConsolidation(clk clock.Clock, cluster *state.Cluster, kube
 // nolint:gocyclo
 func (c *SingleMachineConsolidation) ComputeCommand(ctx context.Context, candidates ...*Candidate) (Command, error) {
 	if c.cluster.Consolidated() {
-		return Command{action: actionDoNothing}, nil
+		return Command{}, nil
 	}
 	candidates, err := c.sortAndFilterCandidates(ctx, candidates)
 	if err != nil {
@@ -57,7 +57,7 @@ func (c *SingleMachineConsolidation) ComputeCommand(ctx context.Context, candida
 			logging.FromContext(ctx).Errorf("computing consolidation %s", err)
 			continue
 		}
-		if cmd.action == actionDoNothing {
+		if len(cmd.candidates) == 0 {
 			continue
 		}
 
@@ -70,9 +70,9 @@ func (c *SingleMachineConsolidation) ComputeCommand(ctx context.Context, candida
 			return Command{}, fmt.Errorf("command is no longer valid, %s", cmd)
 		}
 
-		if cmd.action == actionReplace || cmd.action == actionDelete {
+		if len(cmd.candidates) > 0 {
 			return cmd, nil
 		}
 	}
-	return Command{action: actionDoNothing}, nil
+	return Command{}, nil
 }

--- a/pkg/controllers/deprovisioning/singlemachineconsolidation.go
+++ b/pkg/controllers/deprovisioning/singlemachineconsolidation.go
@@ -69,10 +69,7 @@ func (c *SingleMachineConsolidation) ComputeCommand(ctx context.Context, candida
 		if !isValid {
 			return Command{}, fmt.Errorf("command is no longer valid, %s", cmd)
 		}
-
-		if cmd.Action() != NoOpAction {
-			return cmd, nil
-		}
+		return cmd, nil
 	}
 	return Command{}, nil
 }

--- a/pkg/controllers/deprovisioning/singlemachineconsolidation.go
+++ b/pkg/controllers/deprovisioning/singlemachineconsolidation.go
@@ -57,7 +57,7 @@ func (c *SingleMachineConsolidation) ComputeCommand(ctx context.Context, candida
 			logging.FromContext(ctx).Errorf("computing consolidation %s", err)
 			continue
 		}
-		if cmd.Action() == noOpAction {
+		if cmd.action() == noOpAction {
 			continue
 		}
 
@@ -70,7 +70,7 @@ func (c *SingleMachineConsolidation) ComputeCommand(ctx context.Context, candida
 			return Command{}, fmt.Errorf("command is no longer valid, %s", cmd)
 		}
 
-		if cmd.Action() != noOpAction {
+		if cmd.action() != noOpAction {
 			return cmd, nil
 		}
 	}

--- a/pkg/controllers/deprovisioning/singlemachineconsolidation.go
+++ b/pkg/controllers/deprovisioning/singlemachineconsolidation.go
@@ -57,7 +57,7 @@ func (c *SingleMachineConsolidation) ComputeCommand(ctx context.Context, candida
 			logging.FromContext(ctx).Errorf("computing consolidation %s", err)
 			continue
 		}
-		if len(cmd.candidates) == 0 {
+		if cmd.Action() == noOpAction {
 			continue
 		}
 
@@ -70,7 +70,7 @@ func (c *SingleMachineConsolidation) ComputeCommand(ctx context.Context, candida
 			return Command{}, fmt.Errorf("command is no longer valid, %s", cmd)
 		}
 
-		if len(cmd.candidates) > 0 {
+		if cmd.Action() != noOpAction {
 			return cmd, nil
 		}
 	}

--- a/pkg/controllers/deprovisioning/suite_test.go
+++ b/pkg/controllers/deprovisioning/suite_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"math/rand"
 	"sort"
 	"strings"
 	"sync"
@@ -51,6 +52,7 @@ import (
 	"github.com/aws/karpenter-core/pkg/controllers/provisioning"
 	"github.com/aws/karpenter-core/pkg/controllers/state"
 	"github.com/aws/karpenter-core/pkg/controllers/state/informer"
+	"github.com/aws/karpenter-core/pkg/events"
 	"github.com/aws/karpenter-core/pkg/operator/controller"
 	"github.com/aws/karpenter-core/pkg/operator/scheme"
 	"github.com/aws/karpenter-core/pkg/scheduling"
@@ -1134,6 +1136,166 @@ var _ = Describe("Delete Node", func() {
 
 		// shouldn't delete the node
 		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(2))
+
+		// Expect Unconsolidatable events to be fired
+		evts := recorder.Events()
+		_, ok := lo.Find(evts, func(e events.Event) bool {
+			return strings.Contains(e.Message, "not all pods would schedule")
+		})
+		Expect(ok).To(BeTrue())
+		_, ok = lo.Find(evts, func(e events.Event) bool {
+			return strings.Contains(e.Message, "would schedule against a non-initialized node")
+		})
+		Expect(ok).To(BeTrue())
+	})
+	It("should consider initialized nodes before un-initialized nodes", func() {
+		defaultInstanceType := fake.NewInstanceType(fake.InstanceTypeOptions{
+			Name: "default-instance-type",
+			Resources: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("3"),
+				v1.ResourceMemory: resource.MustParse("3Gi"),
+				v1.ResourcePods:   resource.MustParse("110"),
+			},
+		})
+		smallInstanceType := fake.NewInstanceType(fake.InstanceTypeOptions{
+			Name: "small-instance-type",
+			Resources: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("1"),
+				v1.ResourceMemory: resource.MustParse("1Gi"),
+				v1.ResourcePods:   resource.MustParse("10"),
+			},
+		})
+		cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{
+			defaultInstanceType,
+			smallInstanceType,
+		}
+		labels := map[string]string{
+			"app": "test",
+		}
+		// create our RS so we can link a pod to it
+		rs := test.ReplicaSet()
+		ExpectApplied(ctx, env.Client, rs)
+
+		podCount := 100
+		pods := test.Pods(podCount, test.PodOptions{
+			ObjectMeta: metav1.ObjectMeta{Labels: labels,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion:         "apps/v1",
+						Kind:               "ReplicaSet",
+						Name:               rs.Name,
+						UID:                rs.UID,
+						Controller:         ptr.Bool(true),
+						BlockOwnerDeletion: ptr.Bool(true),
+					},
+				},
+			},
+			ResourceRequirements: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("2"),
+					v1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+			},
+		})
+		ExpectApplied(ctx, env.Client, rs, prov)
+
+		// Setup 100 machines/nodes with a single machine/node that is initialized
+		elem := rand.Intn(100)
+		for i := 0; i < podCount; i++ {
+			m, n := test.MachineAndNode(v1alpha5.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						v1alpha5.ProvisionerNameLabelKey: prov.Name,
+						v1.LabelInstanceTypeStable:       defaultInstanceType.Name,
+						v1alpha5.LabelCapacityType:       defaultInstanceType.Offerings[0].CapacityType,
+						v1.LabelTopologyZone:             defaultInstanceType.Offerings[0].Zone,
+					},
+				},
+				Status: v1alpha5.MachineStatus{
+					ProviderID: test.RandomProviderID(),
+					Allocatable: map[v1.ResourceName]resource.Quantity{
+						v1.ResourceCPU:    resource.MustParse("3"),
+						v1.ResourceMemory: resource.MustParse("3Gi"),
+						v1.ResourcePods:   resource.MustParse("100"),
+					},
+				},
+			})
+			ExpectApplied(ctx, env.Client, pods[i], m, n)
+			ExpectManualBinding(ctx, env.Client, pods[i], n)
+
+			if i == elem {
+				ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{n}, []*v1alpha5.Machine{m})
+			} else {
+				ExpectReconcileSucceeded(ctx, machineStateController, client.ObjectKeyFromObject(m))
+				ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(n))
+			}
+		}
+
+		// Create a pod and machine/node that will eventually be scheduled onto the initialized node
+		consolidatableMachine, consolidatableNode := test.MachineAndNode(v1alpha5.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					v1alpha5.ProvisionerNameLabelKey: prov.Name,
+					v1.LabelInstanceTypeStable:       smallInstanceType.Name,
+					v1alpha5.LabelCapacityType:       smallInstanceType.Offerings[0].CapacityType,
+					v1.LabelTopologyZone:             smallInstanceType.Offerings[0].Zone,
+				},
+			},
+			Status: v1alpha5.MachineStatus{
+				ProviderID: test.RandomProviderID(),
+				Allocatable: map[v1.ResourceName]resource.Quantity{
+					v1.ResourceCPU:    resource.MustParse("1"),
+					v1.ResourceMemory: resource.MustParse("1Gi"),
+					v1.ResourcePods:   resource.MustParse("100"),
+				},
+			},
+		})
+
+		// create a new RS so we can link a pod to it
+		rs = test.ReplicaSet()
+		ExpectApplied(ctx, env.Client, rs)
+		consolidatablePod := test.Pod(test.PodOptions{
+			ObjectMeta: metav1.ObjectMeta{Labels: labels,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion:         "apps/v1",
+						Kind:               "ReplicaSet",
+						Name:               rs.Name,
+						UID:                rs.UID,
+						Controller:         ptr.Bool(true),
+						BlockOwnerDeletion: ptr.Bool(true),
+					},
+				},
+			},
+			ResourceRequirements: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("1"),
+					v1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+			},
+		})
+		ExpectApplied(ctx, env.Client, consolidatableMachine, consolidatableNode, consolidatablePod)
+		ExpectManualBinding(ctx, env.Client, consolidatablePod, consolidatableNode)
+		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{consolidatableNode}, []*v1alpha5.Machine{consolidatableMachine})
+
+		var wg sync.WaitGroup
+		ExpectTriggerVerifyAction(&wg)
+		ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+		wg.Wait()
+
+		ExpectMachinesCascadeDeletion(ctx, env.Client, consolidatableMachine)
+
+		// Expect no events that state that the pods would schedule against a non-initialized node
+		evts := recorder.Events()
+		_, ok := lo.Find(evts, func(e events.Event) bool {
+			return strings.Contains(e.Message, "would schedule against a non-initialized node")
+		})
+		Expect(ok).To(BeFalse())
+
+		// the machine with the small instance should consolidate onto the initialized node
+		Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(100))
+		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(100))
+		ExpectNotFound(ctx, env.Client, consolidatableMachine, consolidatableNode)
 		Expect(fakeRecorder.Events).To(HaveLen(2))
 		event := <-fakeRecorder.Events
 		Expect(strings.Contains(event, "not all pods would schedule")).To(BeTrue())

--- a/pkg/controllers/deprovisioning/suite_test.go
+++ b/pkg/controllers/deprovisioning/suite_test.go
@@ -1127,8 +1127,6 @@ var _ = Describe("Delete Node", func() {
 		ExpectReconcileSucceeded(ctx, machineStateController, client.ObjectKeyFromObject(machine1))
 		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node2}, []*v1alpha5.Machine{machine2})
 
-		fakeClock.Step(10 * time.Minute)
-
 		var wg sync.WaitGroup
 		ExpectTriggerVerifyAction(&wg)
 		ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
@@ -1296,10 +1294,6 @@ var _ = Describe("Delete Node", func() {
 		Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(100))
 		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(100))
 		ExpectNotFound(ctx, env.Client, consolidatableMachine, consolidatableNode)
-		Expect(fakeRecorder.Events).To(HaveLen(2))
-		event := <-fakeRecorder.Events
-		Expect(strings.Contains(event, "not all pods would schedule")).To(BeTrue())
-		Expect(strings.Contains(event, "would schedule against a non-initialized node")).To(BeTrue())
 	})
 })
 

--- a/pkg/controllers/deprovisioning/types.go
+++ b/pkg/controllers/deprovisioning/types.go
@@ -147,7 +147,7 @@ const (
 	deleteAction = "delete"
 )
 
-func (o Command) Action() string {
+func (o Command) action() string {
 	if len(o.candidates) == 0 {
 		return noOpAction
 	}
@@ -159,7 +159,7 @@ func (o Command) Action() string {
 
 func (o Command) String() string {
 	var buf bytes.Buffer
-	fmt.Fprintf(&buf, "%s, terminating %d machines ", o.Action(), len(o.candidates))
+	fmt.Fprintf(&buf, "%s, terminating %d machines ", o.action(), len(o.candidates))
 	for i, old := range o.candidates {
 		if i != 0 {
 			fmt.Fprint(&buf, ", ")

--- a/pkg/controllers/deprovisioning/types.go
+++ b/pkg/controllers/deprovisioning/types.go
@@ -144,19 +144,19 @@ type Command struct {
 type Action string
 
 var (
-	noOpAction    Action = "no-op"
-	replaceAction Action = "replace"
-	deleteAction  Action = "delete"
+	NoOpAction    Action = "no-op"
+	ReplaceAction Action = "replace"
+	DeleteAction  Action = "delete"
 )
 
 func (o Command) Action() Action {
 	switch {
 	case len(o.candidates) > 0 && len(o.replacements) > 0:
-		return replaceAction
+		return ReplaceAction
 	case len(o.candidates) > 0 && len(o.replacements) == 0:
-		return deleteAction
+		return DeleteAction
 	default:
-		return noOpAction
+		return NoOpAction
 	}
 }
 

--- a/pkg/controllers/deprovisioning/types.go
+++ b/pkg/controllers/deprovisioning/types.go
@@ -104,6 +104,9 @@ func NewCandidate(ctx context.Context, kubeClient client.Client, recorder events
 		recorder.Publish(deprovisioningevents.Blocked(node.Node, node.Machine, "machine is nominated")...)
 		return nil, fmt.Errorf("state node is nominated")
 	}
+	if node.Node == nil || node.Machine == nil {
+		return nil, fmt.Errorf("state node doesn't contain both a node and a machine")
+	}
 
 	pods, err := node.Pods(ctx, kubeClient)
 	if err != nil {

--- a/pkg/controllers/deprovisioning/types.go
+++ b/pkg/controllers/deprovisioning/types.go
@@ -136,38 +136,22 @@ func (c *Candidate) lifetimeRemaining(clock clock.Clock) float64 {
 	return remaining
 }
 
-type action byte
-
-const (
-	actionDelete action = iota
-	actionReplace
-	actionDoNothing
-)
-
-func (a action) String() string {
-	switch a {
-	// Deprovisioning action with no replacement machines
-	case actionDelete:
-		return "delete"
-	// Deprovisioning action with replacement machines
-	case actionReplace:
-		return "replace"
-	case actionDoNothing:
-		return "do nothing"
-	default:
-		return fmt.Sprintf("unknown (%d)", a)
-	}
-}
-
 type Command struct {
 	candidates   []*Candidate
-	action       action
 	replacements []*scheduling.Machine
 }
 
 func (o Command) String() string {
+	var action string
+	if len(o.candidates) == 0 {
+		return "do nothing"
+	} else if len(o.replacements) > 0 {
+		action = "replace"
+	} else {
+		action = "delete"
+	}
 	var buf bytes.Buffer
-	fmt.Fprintf(&buf, "%s, terminating %d machines ", o.action, len(o.candidates))
+	fmt.Fprintf(&buf, "%s, terminating %d machines ", action, len(o.candidates))
 	for i, old := range o.candidates {
 		if i != 0 {
 			fmt.Fprint(&buf, ", ")

--- a/pkg/controllers/deprovisioning/types.go
+++ b/pkg/controllers/deprovisioning/types.go
@@ -144,14 +144,14 @@ type Command struct {
 type Action string
 
 var (
-	noOpAction Action = "no-op"
+	noOpAction    Action = "no-op"
 	replaceAction Action = "replace"
-	deleteAction Action = "delete"
+	deleteAction  Action = "delete"
 )
 
 func (o Command) Action() Action {
 	switch {
-	case len(o.candidates) > 0 && len(o.replacements) == 0:
+	case len(o.candidates) > 0 && len(o.replacements) > 0:
 		return replaceAction
 	case len(o.candidates) > 0 && len(o.replacements) == 0:
 		return deleteAction

--- a/pkg/controllers/deprovisioning/types.go
+++ b/pkg/controllers/deprovisioning/types.go
@@ -56,9 +56,6 @@ type Candidate struct {
 func NewCandidate(ctx context.Context, kubeClient client.Client, recorder events.Recorder, clk clock.Clock, node *state.StateNode,
 	provisionerMap map[string]*v1alpha5.Provisioner, provisionerToInstanceTypes map[string]map[string]*cloudprovider.InstanceType) (*Candidate, error) {
 
-	if node.Node == nil || node.Machine == nil {
-		return nil, fmt.Errorf("state node doesn't contain both a node and a machine")
-	}
 	// check whether the node has all the labels we need
 	for _, label := range []string{
 		v1alpha5.LabelCapacityType,

--- a/pkg/controllers/deprovisioning/types.go
+++ b/pkg/controllers/deprovisioning/types.go
@@ -141,13 +141,15 @@ type Command struct {
 	replacements []*scheduling.Machine
 }
 
-const (
-	noOpAction = "no-op"
-	replaceAction = "replace"
-	deleteAction = "delete"
+type Action string
+
+var (
+	noOpAction Action = "no-op"
+	replaceAction Action = "replace"
+	deleteAction Action = "delete"
 )
 
-func (o Command) Action() string {
+func (o Command) Action() Action {
 	switch {
 	case len(o.candidates) > 0 && len(o.replacements) == 0:
 		return replaceAction

--- a/pkg/controllers/deprovisioning/types.go
+++ b/pkg/controllers/deprovisioning/types.go
@@ -144,17 +144,25 @@ type Command struct {
 	replacements []*scheduling.Machine
 }
 
-func (o Command) String() string {
-	var action string
+const (
+	noOpAction = "no-op"
+	replaceAction = "replace"
+	deleteAction = "delete"
+)
+
+func (o Command) Action() string {
 	if len(o.candidates) == 0 {
-		return "do nothing"
-	} else if len(o.replacements) > 0 {
-		action = "replace"
-	} else {
-		action = "delete"
+		return noOpAction
 	}
+	if len(o.replacements) > 0 {
+		return replaceAction
+	}
+	return deleteAction
+}
+
+func (o Command) String() string {
 	var buf bytes.Buffer
-	fmt.Fprintf(&buf, "%s, terminating %d machines ", action, len(o.candidates))
+	fmt.Fprintf(&buf, "%s, terminating %d machines ", o.Action(), len(o.candidates))
 	for i, old := range o.candidates {
 		if i != 0 {
 			fmt.Fprint(&buf, ", ")


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes #280  <!-- issue number -->

**Description**
Removes an the old `action` type in the deprovisioning controller since the type of action can be inferred from the len(candidates) to replace or len(replacements). 

**How was this change tested?**
- make presubmit

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
