### PR TITLE
Revert "Extend operator with healthz checks and hide manager (#286)"

### DIFF
--- a/pkg/cloudprovider/types.go
+++ b/pkg/cloudprovider/types.go
@@ -23,11 +23,30 @@ import (
 
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/utils/clock"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
+	"github.com/aws/karpenter-core/pkg/events"
 	"github.com/aws/karpenter-core/pkg/scheduling"
 	"github.com/aws/karpenter-core/pkg/utils/resources"
 )
+
+// Context is injected into CloudProvider's factories
+type Context struct {
+	context.Context
+
+	RESTConfig          *rest.Config
+	KubernetesInterface kubernetes.Interface
+	KubeClient          client.Client
+	EventRecorder       events.Recorder
+	Clock               clock.Clock
+	// StartAsync is a channel that is closed when leader election has been won.  This is a signal to start any  async
+	// processing that should only occur while the cloud provider is the leader.
+	StartAsync <-chan struct{}
+}
 
 // CloudProvider interface is implemented by cloud providers to support provisioning.
 type CloudProvider interface {

--- a/pkg/controllers/consistency/metrics.go
+++ b/pkg/controllers/consistency/metrics.go
@@ -26,14 +26,14 @@ func init() {
 }
 
 const (
-	checkLabel           = "check"
-	consistencySubsystem = "consistency"
+	checkLabel = "check"
+	subsystem  = "consistency"
 )
 
 var consistencyErrors = prometheus.NewCounterVec(
 	prometheus.CounterOpts{
 		Namespace: metrics.Namespace,
-		Subsystem: consistencySubsystem,
+		Subsystem: subsystem,
 		Name:      "errors",
 		Help:      "Number of consistency checks that have failed.",
 	},


### PR DESCRIPTION
This reverts commit 31975c49a097d565ed7f57c80418a99a380fae5b which breaks the karpenter repo.

<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

**How was this change tested?**


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
