### PR TITLE
fix: only log after cordon succeeds

### DIFF
--- a/pkg/controllers/termination/terminator/terminator.go
+++ b/pkg/controllers/termination/terminator/terminator.go
@@ -56,10 +56,10 @@ func (t *Terminator) Cordon(ctx context.Context, node *v1.Node) error {
 		v1.LabelNodeExcludeBalancers: "karpenter",
 	})
 	if !equality.Semantic.DeepEqual(node, stored) {
-		logging.FromContext(ctx).Infof("cordoned node")
 		if err := t.kubeClient.Patch(ctx, node, client.MergeFrom(stored)); err != nil {
 			return err
 		}
+		logging.FromContext(ctx).Infof("cordoned node")
 	}
 	return nil
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
If the cordon in a termination reconcile failed, we would still log as cordoned.

**How was this change tested?**
`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
