### PR TITLE
fix: Fix log formatting on startup logs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	k8s.io/apimachinery v0.25.4
 	k8s.io/client-go v0.25.4
 	k8s.io/csi-translation-lib v0.25.4
+	k8s.io/klog/v2 v2.80.2-0.20221028030830-9ae4992afb54
 	k8s.io/utils v0.0.0-20221108210102-8e77b1f39fe2
 	knative.dev/pkg v0.0.0-20221123154742-05b694ec4d3a
 	sigs.k8s.io/controller-runtime v0.13.1
@@ -95,7 +96,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/component-base v0.25.4 // indirect
-	k8s.io/klog/v2 v2.80.2-0.20221028030830-9ae4992afb54 // indirect
 	k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 // indirect
 	sigs.k8s.io/json v0.0.0-20220713155537-f223a00ba0e2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect

--- a/pkg/operator/injection/injection.go
+++ b/pkg/operator/injection/injection.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
-	"knative.dev/pkg/logging"
 	"knative.dev/pkg/system"
 
 	"github.com/aws/karpenter-core/pkg/apis/settings"
@@ -85,7 +84,6 @@ func WithSettingsOrDie(ctx context.Context, kubernetesInterface kubernetes.Inter
 	cancelCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	logging.FromContext(ctx).Debugf("waiting for configmaps")
 	factory := informers.NewSharedInformerFactoryWithOptions(kubernetesInterface, time.Second*30, informers.WithNamespace(system.Namespace()))
 	informer := factory.Core().V1().ConfigMaps().Informer()
 	factory.Start(cancelCtx.Done())

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -96,6 +96,7 @@ func NewOperator() (context.Context, *Operator) {
 	// Logging
 	logger := NewLogger(ctx, component, config, configMapWatcher)
 	ctx = logging.WithLogger(ctx, logger)
+	ConfigureGlobalLoggers(ctx)
 
 	// Inject settings from the ConfigMap(s) into the context
 	ctx = injection.WithSettingsOrDie(ctx, kubernetesInterface, apis.Settings...)


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes https://github.com/aws/karpenter/issues/3560

**Description**

- Fix log formatting on startup logs so that all logs are structured using the `*zap.SugaredLogger`

**How was this change tested?**

`make presubmit`

### Old Logs

```console
2023-04-19T05:55:38.652Z        DEBUG   Successfully created the logger.
2023-04-19T05:55:38.652Z        DEBUG   Logging level set to: debug
{"level":"info","ts":1681883738.6558979,"logger":"fallback","caller":"injection/injection.go:63","msg":"Starting informers..."}
2023-04-19T05:55:38.756Z        DEBUG   controller      waiting for configmaps  {"commit": "7131be2-dirty"}
2023-04-19T05:55:39.269Z        DEBUG   controller      waiting for configmaps  {"commit": "7131be2-dirty"}
2023-04-19T05:55:39.770Z        DEBUG   controller      waiting for configmaps  {"commit": "7131be2-dirty"}
2023-04-19T05:55:40.270Z        DEBUG   controller      waiting for configmaps  {"commit": "7131be2-dirty"}
2023-04-19T05:55:40.771Z        DEBUG   controller      waiting for configmaps  {"commit": "7131be2-dirty"}
2023-04-19T05:55:41.330Z        DEBUG   controller.aws  discovered region       {"commit": "7131be2-dirty", "region": "us-west-2"}
2023-04-19T05:55:41.330Z        DEBUG   controller.aws  discovered cluster endpoint     {"commit": "7131be2-dirty", "cluster-endpoint": "https://2B3A0347E5BF8D9935288F4311843065.gr7.us-west-2.eks.amazonaws.com"}
2023-04-19T05:55:41.336Z        DEBUG   controller.aws  discovered kube dns     {"commit": "7131be2-dirty", "kube-dns-ip": "10.100.0.10"}
2023-04-19T05:55:41.336Z        DEBUG   controller.aws  discovered version      {"commit": "7131be2-dirty", "version": "v0.27.1"}
2023/04/19 05:55:41 Registering 2 clients
2023/04/19 05:55:41 Registering 2 informer factories
2023/04/19 05:55:41 Registering 3 informers
2023/04/19 05:55:41 Registering 5 controllers
2023-04-19T05:55:41.337Z        INFO    controller      Starting server {"commit": "7131be2-dirty", "path": "/metrics", "kind": "metrics", "addr": "[::]:8080"}
2023-04-19T05:55:41.337Z        INFO    controller      Starting server {"commit": "7131be2-dirty", "kind": "health probe", "addr": "[::]:8081"}
I0419 05:55:41.438781       1 leaderelection.go:248] attempting to acquire leader lease karpenter/karpenter-leader-election...
2023-04-19T05:55:41.469Z        INFO    controller      Starting informers...   {"commit": "7131be2-dirty"}
2023-04-19T05:55:41.669Z        INFO    controller.aws.pricing  updated spot pricing with instance types and offerings  {"commit": "7131be2-dirty", "instance-type-count": 631, "offering-count": 2178}
```

### New Logs

```console
2023-04-19T06:00:00.905Z        DEBUG   Successfully created the logger.
2023-04-19T06:00:00.905Z        DEBUG   Logging level set to: debug
2023-04-19T06:00:06.233Z        DEBUG   controller      discovered region       {"commit": "6bdd213-dirty", "region": "us-west-2"}
2023-04-19T06:00:06.233Z        DEBUG   controller      discovered cluster endpoint     {"commit": "6bdd213-dirty", "cluster-endpoint": "https://2B3A0347E5BF8D9935288F4311843065.gr7.us-west-2.eks.amazonaws.com"}
2023-04-19T06:00:06.246Z        DEBUG   controller      discovered kube dns     {"commit": "6bdd213-dirty", "kube-dns-ip": "10.100.0.10"}
2023-04-19T06:00:06.246Z        DEBUG   controller      discovered version      {"commit": "6bdd213-dirty", "version": "v0.27.1-55-g6bdd2138"}
2023-04-19T06:00:06.246Z        DEBUG   controller      Registering 2 clients   {"commit": "6bdd213-dirty"}
2023-04-19T06:00:06.246Z        DEBUG   controller      Registering 2 informer factories        {"commit": "6bdd213-dirty"}
2023-04-19T06:00:06.246Z        DEBUG   controller      Registering 3 informers {"commit": "6bdd213-dirty"}
2023-04-19T06:00:06.246Z        DEBUG   controller      Registering 5 controllers       {"commit": "6bdd213-dirty"}
2023-04-19T06:00:06.247Z        INFO    controller      Starting server {"commit": "6bdd213-dirty", "path": "/metrics", "kind": "metrics", "addr": "[::]:8080"}
2023-04-19T06:00:06.247Z        INFO    controller      Starting server {"commit": "6bdd213-dirty", "kind": "health probe", "addr": "[::]:8081"}
2023-04-19T06:00:06.348Z        INFO    controller      attempting to acquire leader lease karpenter/karpenter-leader-election...
        {"commit": "6bdd213-dirty"}
2023-04-19T06:00:06.382Z        INFO    controller      Starting informers...   {"commit": "6bdd213-dirty"}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
