### PR TITLE
chore: add in empty check for expiration and drift

### DIFF
--- a/pkg/controllers/deprovisioning/drift_test.go
+++ b/pkg/controllers/deprovisioning/drift_test.go
@@ -151,18 +151,17 @@ var _ = Describe("Drift", func() {
 				},
 			},
 			Status: v1alpha5.MachineStatus{
-				ProviderID: test.RandomProviderID(),
 				Allocatable: map[v1.ResourceName]resource.Quantity{
 					v1.ResourceCPU:  resource.MustParse("32"),
 					v1.ResourcePods: resource.MustParse("100"),
 				},
 			},
 		})
-		for _, machine := range machines {
-			ExpectApplied(ctx, env.Client, machine)
+		for _, m := range machines {
+			ExpectApplied(ctx, env.Client, m)
 		}
-		for _, node := range nodes {
-			ExpectApplied(ctx, env.Client, node)
+		for _, n := range nodes {
+			ExpectApplied(ctx, env.Client, n)
 		}
 		ExpectApplied(ctx, env.Client, prov)
 
@@ -176,7 +175,6 @@ var _ = Describe("Drift", func() {
 
 		// Expect that the expired machines are gone
 		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(0))
-		ExpectNotFound(ctx, env.Client, node)
 	})
 	It("can replace drifted nodes", func() {
 		labels := map[string]string{

--- a/pkg/controllers/deprovisioning/drift_test.go
+++ b/pkg/controllers/deprovisioning/drift_test.go
@@ -138,7 +138,7 @@ var _ = Describe("Drift", func() {
 		ExpectNotFound(ctx, env.Client, node)
 	})
 	It("should deprovision all empty drifted nodes in parallel", func() {
-		machine2, node2 := test.MachineAndNode(v1alpha5.Machine{
+		machines, nodes := test.MachinesAndNodes(100, v1alpha5.Machine{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
 					v1alpha5.VoluntaryDisruptionAnnotationKey: v1alpha5.VoluntaryDisruptionDriftedAnnotationValue,
@@ -158,30 +158,16 @@ var _ = Describe("Drift", func() {
 				},
 			},
 		})
-		machine3, node3 := test.MachineAndNode(v1alpha5.Machine{
-			ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{
-					v1alpha5.VoluntaryDisruptionAnnotationKey: v1alpha5.VoluntaryDisruptionDriftedAnnotationValue,
-				},
-				Labels: map[string]string{
-					v1alpha5.ProvisionerNameLabelKey: prov.Name,
-					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name,
-					v1alpha5.LabelCapacityType:       mostExpensiveOffering.CapacityType,
-					v1.LabelTopologyZone:             mostExpensiveOffering.Zone,
-				},
-			},
-			Status: v1alpha5.MachineStatus{
-				ProviderID: test.RandomProviderID(),
-				Allocatable: map[v1.ResourceName]resource.Quantity{
-					v1.ResourceCPU:  resource.MustParse("32"),
-					v1.ResourcePods: resource.MustParse("100"),
-				},
-			},
-		})
-		ExpectApplied(ctx, env.Client, machine, node, machine2, node2, machine3, node3, prov)
+		for _, machine := range machines {
+			ExpectApplied(ctx, env.Client, machine)
+		}
+		for _, node := range nodes {
+			ExpectApplied(ctx, env.Client, node)
+		}
+		ExpectApplied(ctx, env.Client, prov)
 
 		// inform cluster state about nodes and machines
-		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node, node2, node3}, []*v1alpha5.Machine{machine, machine2, machine3})
+		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, nodes, machines)
 
 		var wg sync.WaitGroup
 		ExpectTriggerVerifyAction(&wg)

--- a/pkg/controllers/deprovisioning/expiration.go
+++ b/pkg/controllers/deprovisioning/expiration.go
@@ -27,6 +27,8 @@ import (
 	"knative.dev/pkg/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/samber/lo"
+
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/controllers/provisioning"
 	"github.com/aws/karpenter-core/pkg/controllers/state"
@@ -82,6 +84,16 @@ func (e *Expiration) ComputeCommand(ctx context.Context, nodes ...*Candidate) (C
 	candidates, err := e.filterAndSortCandidates(ctx, nodes)
 	if err != nil {
 		return Command{}, fmt.Errorf("filtering candidates, %w", err)
+	}
+
+	// Deprovision all empty expired nodes, as they require no scheduling simulations.
+	if empty := lo.Filter(candidates, func(c *Candidate, _ int) bool {
+		return len(c.pods) == 0
+	}); len(empty) > 0 {
+		return Command{
+			candidates: empty,
+			action:     actionDelete,
+		}, nil
 	}
 
 	for _, candidate := range candidates {

--- a/pkg/controllers/deprovisioning/expiration_test.go
+++ b/pkg/controllers/deprovisioning/expiration_test.go
@@ -108,10 +108,89 @@ var _ = Describe("Expiration", func() {
 		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(0))
 		ExpectNotFound(ctx, env.Client, node)
 	})
-	It("should expire one node at a time, starting with most expired", func() {
+	It("should deprovision all empty expired nodes in parallel", func() {
+		machine2, node2 := test.MachineAndNode(v1alpha5.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					v1alpha5.VoluntaryDisruptionAnnotationKey: v1alpha5.VoluntaryDisruptionExpiredAnnotationValue,
+				},
+				Labels: map[string]string{
+					v1alpha5.ProvisionerNameLabelKey: prov.Name,
+					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name,
+					v1alpha5.LabelCapacityType:       mostExpensiveOffering.CapacityType,
+					v1.LabelTopologyZone:             mostExpensiveOffering.Zone,
+				},
+			},
+			Status: v1alpha5.MachineStatus{
+				ProviderID: test.RandomProviderID(),
+				Allocatable: map[v1.ResourceName]resource.Quantity{
+					v1.ResourceCPU:  resource.MustParse("32"),
+					v1.ResourcePods: resource.MustParse("100"),
+				},
+			},
+		})
+		machine3, node3 := test.MachineAndNode(v1alpha5.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					v1alpha5.VoluntaryDisruptionAnnotationKey: v1alpha5.VoluntaryDisruptionExpiredAnnotationValue,
+				},
+				Labels: map[string]string{
+					v1alpha5.ProvisionerNameLabelKey: prov.Name,
+					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name,
+					v1alpha5.LabelCapacityType:       mostExpensiveOffering.CapacityType,
+					v1.LabelTopologyZone:             mostExpensiveOffering.Zone,
+				},
+			},
+			Status: v1alpha5.MachineStatus{
+				ProviderID: test.RandomProviderID(),
+				Allocatable: map[v1.ResourceName]resource.Quantity{
+					v1.ResourceCPU:  resource.MustParse("32"),
+					v1.ResourcePods: resource.MustParse("100"),
+				},
+			},
+		})
+		ExpectApplied(ctx, env.Client, machine, node, machine2, node2, machine3, node3, prov)
+
+		// inform cluster state about nodes and machines
+		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node, node2, node3}, []*v1alpha5.Machine{machine, machine2, machine3})
+
+		var wg sync.WaitGroup
+		ExpectTriggerVerifyAction(&wg)
+		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		wg.Wait()
+
+		// Expect that the expired machines are gone
+		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(0))
+		ExpectNotFound(ctx, env.Client, node)
+	})
+	It("should expire one non-empty node at a time, starting with most expired", func() {
 		expireProv := test.Provisioner(test.ProvisionerOptions{
 			TTLSecondsUntilExpired: ptr.Int64(100),
 		})
+
+		labels := map[string]string{
+			"app": "test",
+		}
+
+		// create our RS so we can link a pod to it
+		rs := test.ReplicaSet()
+		ExpectApplied(ctx, env.Client, rs)
+
+		pods := test.Pods(2, test.PodOptions{
+			ObjectMeta: metav1.ObjectMeta{Labels: labels,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion:         "apps/v1",
+						Kind:               "ReplicaSet",
+						Name:               rs.Name,
+						UID:                rs.UID,
+						Controller:         ptr.Bool(true),
+						BlockOwnerDeletion: ptr.Bool(true),
+					},
+				},
+			},
+		})
+
 		machineToExpire, nodeToExpire := test.MachineAndNode(v1alpha5.Machine{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
@@ -144,15 +223,24 @@ var _ = Describe("Expiration", func() {
 			},
 		})
 
-		ExpectApplied(ctx, env.Client, machineToExpire, nodeToExpire, machineNotExpire, nodeNotExpire, expireProv, prov)
+		ExpectApplied(ctx, env.Client, rs, pods[0], pods[1], machineToExpire, nodeToExpire, machineNotExpire, nodeNotExpire, expireProv, prov)
+
+		// bind pods to node so that they're not empty and don't deprovision in parallel.
+		ExpectManualBinding(ctx, env.Client, pods[0], nodeToExpire)
+		ExpectManualBinding(ctx, env.Client, pods[1], nodeNotExpire)
 
 		// inform cluster state about nodes and machines
 		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{nodeToExpire, nodeNotExpire}, []*v1alpha5.Machine{machineToExpire, machineNotExpire})
 
+		// deprovisioning won't delete the old node until the new node is ready
+		var wg sync.WaitGroup
+		ExpectTriggerVerifyAction(&wg)
+		ExpectMakeNewNodesReady(ctx, env.Client, &wg, 1)
 		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		wg.Wait()
 
-		// Expect that one of the expired machines is gone
-		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
+		// Expect that one of the expired machines is replaced
+		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(2))
 		ExpectNotFound(ctx, env.Client, nodeToExpire)
 	})
 	It("can replace node for expiration", func() {

--- a/pkg/test/machine.go
+++ b/pkg/test/machine.go
@@ -36,6 +36,9 @@ func Machine(overrides ...v1alpha5.Machine) *v1alpha5.Machine {
 	if override.Name == "" {
 		override.Name = RandomName()
 	}
+	if override.Status.ProviderID == "" {
+		override.Status.ProviderID = RandomProviderID()
+	}
 	override.ObjectMeta.Labels = lo.Assign(override.ObjectMeta.Labels, map[string]string{
 		v1alpha5.MachineNameLabelKey: override.Name,
 	})

--- a/pkg/test/machine.go
+++ b/pkg/test/machine.go
@@ -50,3 +50,17 @@ func MachineAndNode(overrides ...v1alpha5.Machine) (*v1alpha5.Machine, *v1.Node)
 	m := Machine(overrides...)
 	return m, MachineLinkedNode(m)
 }
+
+// MachinesAndNodes creates homogeneous groups of machines and nodes based on the passed in options, evenly divided by the total machines requested
+func MachinesAndNodes(total int, options ...v1alpha5.Machine) ([]*v1alpha5.Machine, []*v1.Node) {
+	machines := make([]*v1alpha5.Machine, total)
+	nodes := make([]*v1.Node, total)
+	for _, opts := range options {
+		for i := 0; i < total/len(options); i++ {
+			machine, node := MachineAndNode(opts)
+			machines[i] = machine
+			nodes[i] = node
+		}
+	}
+	return machines, nodes
+}


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes https://github.com/aws/karpenter/issues/3742 <!-- issue number -->

**Description**
Expiration and Drift deprovisioning would do a scheduling simulation even if there are no pods scheduled to the node. Since we know we want to deprovision these nodes that are empty, we can terminate them in parallel. 

**How was this change tested?**

- `make presubmit`

--- With commit, scaling down 10 nodes took about 2 seconds.
```
karpenter-8b946654b-xz2lz controller 2023-04-20T17:00:45.603Z	DEBUG	controller.node	annotating node as expired	{"commit": "49a318e-dirty", "node": "ip-192-168-93-8.us-west-2.compute.internal"}
karpenter-8b946654b-xz2lz controller 2023-04-20T17:00:45.604Z	DEBUG	controller.node	annotating node as expired	{"commit": "49a318e-dirty", "node": "ip-192-168-191-174.us-west-2.compute.internal"}
karpenter-8b946654b-xz2lz controller 2023-04-20T17:00:45.605Z	DEBUG	controller.node	annotating node as expired	{"commit": "49a318e-dirty", "node": "ip-192-168-81-163.us-west-2.compute.internal"}
karpenter-8b946654b-xz2lz controller 2023-04-20T17:00:45.606Z	DEBUG	controller.node	annotating node as expired	{"commit": "49a318e-dirty", "node": "ip-192-168-40-96.us-west-2.compute.internal"}
karpenter-8b946654b-xz2lz controller 2023-04-20T17:00:45.608Z	DEBUG	controller.node	annotating node as expired	{"commit": "49a318e-dirty", "node": "ip-192-168-187-90.us-west-2.compute.internal"}
karpenter-8b946654b-xz2lz controller 2023-04-20T17:00:45.609Z	DEBUG	controller.node	annotating node as expired	{"commit": "49a318e-dirty", "node": "ip-192-168-23-33.us-west-2.compute.internal"}
karpenter-8b946654b-xz2lz controller 2023-04-20T17:00:45.610Z	DEBUG	controller.node	annotating node as expired	{"commit": "49a318e-dirty", "node": "ip-192-168-99-65.us-west-2.compute.internal"}
karpenter-8b946654b-xz2lz controller 2023-04-20T17:00:45.611Z	DEBUG	controller.node	annotating node as expired	{"commit": "49a318e-dirty", "node": "ip-192-168-18-98.us-west-2.compute.internal"}
karpenter-8b946654b-xz2lz controller 2023-04-20T17:00:45.612Z	DEBUG	controller.node	annotating node as expired	{"commit": "49a318e-dirty", "node": "ip-192-168-129-209.us-west-2.compute.internal"}
karpenter-8b946654b-xz2lz controller 2023-04-20T17:00:45.613Z	DEBUG	controller.node	annotating node as expired	{"commit": "49a318e-dirty", "node": "ip-192-168-110-253.us-west-2.compute.internal"}
karpenter-8b946654b-xz2lz controller 2023-04-20T17:00:46.551Z	INFO	controller.deprovisioning	deprovisioning via expiration delete, terminating 10 machines ip-192-168-93-8.us-west-2.compute.internal/c5.4xlarge/spot, ip-192-168-23-33.us-west-2.compute.internal/c5.4xlarge/spot, ip-192-168-99-65.us-west-2.compute.internal/c5.4xlarge/spot, ip-192-168-191-174.us-west-2.compute.internal/c5.4xlarge/spot, ip-192-168-81-163.us-west-2.compute.internal/c5.4xlarge/spot, ip-192-168-40-96.us-west-2.compute.internal/c5.4xlarge/spot, ip-192-168-18-98.us-west-2.compute.internal/c5.4xlarge/spot, ip-192-168-129-209.us-west-2.compute.internal/c5.4xlarge/spot, ip-192-168-110-253.us-west-2.compute.internal/c5.4xlarge/spot, ip-192-168-187-90.us-west-2.compute.internal/c5.4xlarge/spot	{"commit": "49a318e-dirty"}
karpenter-8b946654b-xz2lz controller 2023-04-20T17:00:46.612Z	INFO	controller.termination	cordoned node	{"commit": "49a318e-dirty", "node": "ip-192-168-93-8.us-west-2.compute.internal"}
karpenter-8b946654b-xz2lz controller 2023-04-20T17:00:46.622Z	INFO	controller.termination	cordoned node	{"commit": "49a318e-dirty", "node": "ip-192-168-23-33.us-west-2.compute.internal"}
karpenter-8b946654b-xz2lz controller 2023-04-20T17:00:46.685Z	INFO	controller.termination	cordoned node	{"commit": "49a318e-dirty", "node": "ip-192-168-99-65.us-west-2.compute.internal"}
karpenter-8b946654b-xz2lz controller 2023-04-20T17:00:46.696Z	INFO	controller.termination	cordoned node	{"commit": "49a318e-dirty", "node": "ip-192-168-191-174.us-west-2.compute.internal"}
karpenter-8b946654b-xz2lz controller 2023-04-20T17:00:46.740Z	INFO	controller.termination	cordoned node	{"commit": "49a318e-dirty", "node": "ip-192-168-81-163.us-west-2.compute.internal"}
karpenter-8b946654b-xz2lz controller 2023-04-20T17:00:46.794Z	INFO	controller.termination	cordoned node	{"commit": "49a318e-dirty", "node": "ip-192-168-40-96.us-west-2.compute.internal"}
karpenter-8b946654b-xz2lz controller 2023-04-20T17:00:46.807Z	INFO	controller.termination	cordoned node	{"commit": "49a318e-dirty", "node": "ip-192-168-18-98.us-west-2.compute.internal"}
karpenter-8b946654b-xz2lz controller 2023-04-20T17:00:46.843Z	INFO	controller.termination	cordoned node	{"commit": "49a318e-dirty", "node": "ip-192-168-129-209.us-west-2.compute.internal"}
karpenter-8b946654b-xz2lz controller 2023-04-20T17:00:46.881Z	INFO	controller.termination	cordoned node	{"commit": "49a318e-dirty", "node": "ip-192-168-110-253.us-west-2.compute.internal"}
karpenter-8b946654b-xz2lz controller 2023-04-20T17:00:46.962Z	INFO	controller.termination	cordoned node	{"commit": "49a318e-dirty", "node": "ip-192-168-187-90.us-west-2.compute.internal"}
karpenter-8b946654b-xz2lz controller 2023-04-20T17:00:47.568Z	INFO	controller.termination	deleted node	{"commit": "49a318e-dirty", "node": "ip-192-168-93-8.us-west-2.compute.internal"}
karpenter-8b946654b-xz2lz controller 2023-04-20T17:00:47.569Z	INFO	controller.termination	deleted node	{"commit": "49a318e-dirty", "node": "ip-192-168-191-174.us-west-2.compute.internal"}
karpenter-8b946654b-xz2lz controller 2023-04-20T17:00:47.570Z	INFO	controller.termination	deleted node	{"commit": "49a318e-dirty", "node": "ip-192-168-99-65.us-west-2.compute.internal"}
karpenter-8b946654b-xz2lz controller 2023-04-20T17:00:47.571Z	INFO	controller.termination	deleted node	{"commit": "49a318e-dirty", "node": "ip-192-168-23-33.us-west-2.compute.internal"}
karpenter-8b946654b-xz2lz controller 2023-04-20T17:00:47.572Z	INFO	controller.termination	deleted node	{"commit": "49a318e-dirty", "node": "ip-192-168-187-90.us-west-2.compute.internal"}
karpenter-8b946654b-xz2lz controller 2023-04-20T17:00:47.577Z	INFO	controller.termination	deleted node	{"commit": "49a318e-dirty", "node": "ip-192-168-40-96.us-west-2.compute.internal"}
karpenter-8b946654b-xz2lz controller 2023-04-20T17:00:47.578Z	INFO	controller.termination	deleted node	{"commit": "49a318e-dirty", "node": "ip-192-168-81-163.us-west-2.compute.internal"}
karpenter-8b946654b-xz2lz controller 2023-04-20T17:00:47.578Z	INFO	controller.termination	deleted node	{"commit": "49a318e-dirty", "node": "ip-192-168-18-98.us-west-2.compute.internal"}
karpenter-8b946654b-xz2lz controller 2023-04-20T17:00:47.594Z	INFO	controller.termination	deleted node	{"commit": "49a318e-dirty", "node": "ip-192-168-129-209.us-west-2.compute.internal"}
karpenter-8b946654b-xz2lz controller 2023-04-20T17:00:47.643Z	INFO	controller.termination	deleted node	{"commit": "49a318e-dirty", "node": "ip-192-168-110-253.us-west-2.compute.internal"}
```

--- Without commit it took about 30 seconds.
```
karpenter-79447db679-snx6x controller 2023-04-20T17:07:59.219Z	DEBUG	controller.node	annotating node as expired	{"commit": "49a318e-dirty", "node": "ip-192-168-170-94.us-west-2.compute.internal"}
karpenter-79447db679-snx6x controller 2023-04-20T17:07:59.220Z	DEBUG	controller.node	annotating node as expired	{"commit": "49a318e-dirty", "node": "ip-192-168-106-91.us-west-2.compute.internal"}
karpenter-79447db679-snx6x controller 2023-04-20T17:07:59.221Z	DEBUG	controller.node	annotating node as expired	{"commit": "49a318e-dirty", "node": "ip-192-168-43-139.us-west-2.compute.internal"}
karpenter-79447db679-snx6x controller 2023-04-20T17:07:59.222Z	DEBUG	controller.node	annotating node as expired	{"commit": "49a318e-dirty", "node": "ip-192-168-181-69.us-west-2.compute.internal"}
karpenter-79447db679-snx6x controller 2023-04-20T17:07:59.223Z	DEBUG	controller.node	annotating node as expired	{"commit": "49a318e-dirty", "node": "ip-192-168-100-55.us-west-2.compute.internal"}
karpenter-79447db679-snx6x controller 2023-04-20T17:07:59.224Z	DEBUG	controller.node	annotating node as expired	{"commit": "49a318e-dirty", "node": "ip-192-168-128-249.us-west-2.compute.internal"}
karpenter-79447db679-snx6x controller 2023-04-20T17:07:59.224Z	DEBUG	controller.node	annotating node as expired	{"commit": "49a318e-dirty", "node": "ip-192-168-16-244.us-west-2.compute.internal"}
karpenter-79447db679-snx6x controller 2023-04-20T17:07:59.225Z	DEBUG	controller.node	annotating node as expired	{"commit": "49a318e-dirty", "node": "ip-192-168-92-206.us-west-2.compute.internal"}
karpenter-79447db679-snx6x controller 2023-04-20T17:07:59.226Z	DEBUG	controller.node	annotating node as expired	{"commit": "49a318e-dirty", "node": "ip-192-168-11-9.us-west-2.compute.internal"}
karpenter-79447db679-snx6x controller 2023-04-20T17:07:59.227Z	DEBUG	controller.node	annotating node as expired	{"commit": "49a318e-dirty", "node": "ip-192-168-69-24.us-west-2.compute.internal"}
karpenter-79447db679-snx6x controller 2023-04-20T17:08:08.944Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "49a318e-dirty", "ttl": "1m40s", "delay": "40.944486706s"}
karpenter-79447db679-snx6x controller 2023-04-20T17:08:08.944Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-100-55.us-west-2.compute.internal/c5.4xlarge/spot	{"commit": "49a318e-dirty"}
karpenter-79447db679-snx6x controller 2023-04-20T17:08:09.026Z	INFO	controller.termination	cordoned node	{"commit": "49a318e-dirty", "node": "ip-192-168-100-55.us-west-2.compute.internal"}
karpenter-79447db679-snx6x controller 2023-04-20T17:08:09.375Z	INFO	controller.termination	deleted node	{"commit": "49a318e-dirty", "node": "ip-192-168-100-55.us-west-2.compute.internal"}
karpenter-79447db679-snx6x controller 2023-04-20T17:08:11.065Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "49a318e-dirty", "ttl": "1m40s", "delay": "43.06529949s"}
karpenter-79447db679-snx6x controller 2023-04-20T17:08:11.065Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-92-206.us-west-2.compute.internal/c5.4xlarge/spot	{"commit": "49a318e-dirty"}
karpenter-79447db679-snx6x controller 2023-04-20T17:08:11.197Z	INFO	controller.termination	cordoned node	{"commit": "49a318e-dirty", "node": "ip-192-168-92-206.us-west-2.compute.internal"}
karpenter-79447db679-snx6x controller 2023-04-20T17:08:11.533Z	INFO	controller.termination	deleted node	{"commit": "49a318e-dirty", "node": "ip-192-168-92-206.us-west-2.compute.internal"}
karpenter-79447db679-snx6x controller 2023-04-20T17:08:13.234Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "49a318e-dirty", "ttl": "1m40s", "delay": "45.234857139s"}
karpenter-79447db679-snx6x controller 2023-04-20T17:08:13.234Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-128-249.us-west-2.compute.internal/c5.4xlarge/spot	{"commit": "49a318e-dirty"}
karpenter-79447db679-snx6x controller 2023-04-20T17:08:13.312Z	INFO	controller.termination	cordoned node	{"commit": "49a318e-dirty", "node": "ip-192-168-128-249.us-west-2.compute.internal"}
karpenter-79447db679-snx6x controller 2023-04-20T17:08:13.615Z	INFO	controller.termination	deleted node	{"commit": "49a318e-dirty", "node": "ip-192-168-128-249.us-west-2.compute.internal"}
karpenter-79447db679-snx6x controller 2023-04-20T17:08:15.349Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "49a318e-dirty", "ttl": "1m40s", "delay": "47.349799127s"}
karpenter-79447db679-snx6x controller 2023-04-20T17:08:15.349Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-16-244.us-west-2.compute.internal/c5.4xlarge/spot	{"commit": "49a318e-dirty"}
karpenter-79447db679-snx6x controller 2023-04-20T17:08:15.409Z	INFO	controller.termination	cordoned node	{"commit": "49a318e-dirty", "node": "ip-192-168-16-244.us-west-2.compute.internal"}
karpenter-79447db679-snx6x controller 2023-04-20T17:08:15.725Z	INFO	controller.termination	deleted node	{"commit": "49a318e-dirty", "node": "ip-192-168-16-244.us-west-2.compute.internal"}
karpenter-79447db679-snx6x controller 2023-04-20T17:08:17.416Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "49a318e-dirty", "ttl": "1m40s", "delay": "49.416481266s"}
karpenter-79447db679-snx6x controller 2023-04-20T17:08:17.416Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-106-91.us-west-2.compute.internal/c5.4xlarge/spot	{"commit": "49a318e-dirty"}
karpenter-79447db679-snx6x controller 2023-04-20T17:08:17.488Z	INFO	controller.termination	cordoned node	{"commit": "49a318e-dirty", "node": "ip-192-168-106-91.us-west-2.compute.internal"}
karpenter-79447db679-snx6x controller 2023-04-20T17:08:17.810Z	INFO	controller.termination	deleted node	{"commit": "49a318e-dirty", "node": "ip-192-168-106-91.us-west-2.compute.internal"}
karpenter-79447db679-snx6x controller 2023-04-20T17:08:19.532Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "49a318e-dirty", "ttl": "1m40s", "delay": "51.532393027s"}
karpenter-79447db679-snx6x controller 2023-04-20T17:08:19.532Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-43-139.us-west-2.compute.internal/c5.4xlarge/spot	{"commit": "49a318e-dirty"}
karpenter-79447db679-snx6x controller 2023-04-20T17:08:19.620Z	INFO	controller.termination	cordoned node	{"commit": "49a318e-dirty", "node": "ip-192-168-43-139.us-west-2.compute.internal"}
karpenter-79447db679-snx6x controller 2023-04-20T17:08:19.930Z	INFO	controller.termination	deleted node	{"commit": "49a318e-dirty", "node": "ip-192-168-43-139.us-west-2.compute.internal"}
karpenter-79447db679-snx6x controller 2023-04-20T17:08:21.641Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "49a318e-dirty", "ttl": "1m40s", "delay": "53.641408138s"}
karpenter-79447db679-snx6x controller 2023-04-20T17:08:21.641Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-181-69.us-west-2.compute.internal/c5.4xlarge/spot	{"commit": "49a318e-dirty"}
karpenter-79447db679-snx6x controller 2023-04-20T17:08:21.715Z	INFO	controller.termination	cordoned node	{"commit": "49a318e-dirty", "node": "ip-192-168-181-69.us-west-2.compute.internal"}
karpenter-79447db679-snx6x controller 2023-04-20T17:08:22.052Z	INFO	controller.termination	deleted node	{"commit": "49a318e-dirty", "node": "ip-192-168-181-69.us-west-2.compute.internal"}
karpenter-79447db679-snx6x controller 2023-04-20T17:08:23.714Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "49a318e-dirty", "ttl": "1m40s", "delay": "55.714744251s"}
karpenter-79447db679-snx6x controller 2023-04-20T17:08:23.714Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-11-9.us-west-2.compute.internal/c5.4xlarge/spot	{"commit": "49a318e-dirty"}
karpenter-79447db679-snx6x controller 2023-04-20T17:08:23.833Z	INFO	controller.termination	cordoned node	{"commit": "49a318e-dirty", "node": "ip-192-168-11-9.us-west-2.compute.internal"}
karpenter-79447db679-snx6x controller 2023-04-20T17:08:24.142Z	INFO	controller.termination	deleted node	{"commit": "49a318e-dirty", "node": "ip-192-168-11-9.us-west-2.compute.internal"}
karpenter-79447db679-snx6x controller 2023-04-20T17:08:25.864Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "49a318e-dirty", "ttl": "1m40s", "delay": "57.864524407s"}
karpenter-79447db679-snx6x controller 2023-04-20T17:08:25.864Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-69-24.us-west-2.compute.internal/c5.4xlarge/spot	{"commit": "49a318e-dirty"}
karpenter-79447db679-snx6x controller 2023-04-20T17:08:25.940Z	INFO	controller.termination	cordoned node	{"commit": "49a318e-dirty", "node": "ip-192-168-69-24.us-west-2.compute.internal"}
karpenter-79447db679-snx6x controller 2023-04-20T17:08:26.261Z	INFO	controller.termination	deleted node	{"commit": "49a318e-dirty", "node": "ip-192-168-69-24.us-west-2.compute.internal"}
karpenter-79447db679-snx6x controller 2023-04-20T17:08:27.925Z	INFO	controller.deprovisioning	triggering termination for expired node after TTL	{"commit": "49a318e-dirty", "ttl": "1m40s", "delay": "59.925393348s"}
karpenter-79447db679-snx6x controller 2023-04-20T17:08:27.925Z	INFO	controller.deprovisioning	deprovisioning via expiration replace, terminating 1 machines ip-192-168-170-94.us-west-2.compute.internal/c5.4xlarge/spot	{"commit": "49a318e-dirty"}
karpenter-79447db679-snx6x controller 2023-04-20T17:08:28.036Z	INFO	controller.termination	cordoned node	{"commit": "49a318e-dirty", "node": "ip-192-168-170-94.us-west-2.compute.internal"}
karpenter-79447db679-snx6x controller 2023-04-20T17:08:28.392Z	INFO	controller.termination	deleted node	{"commit": "49a318e-dirty", "node": "ip-192-168-170-94.us-west-2.compute.internal"}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
