### PR TITLE
fix: Fix empty machine validation check

### DIFF
--- a/pkg/controllers/deprovisioning/emptymachineconsolidation.go
+++ b/pkg/controllers/deprovisioning/emptymachineconsolidation.go
@@ -79,7 +79,7 @@ func (c *EmptyMachineConsolidation) ComputeCommand(ctx context.Context, candidat
 	// the deletion of empty machines is easy to validate, we just ensure that all the candidatesToDelete are still empty and that
 	// the machine isn't a target of a recent scheduling simulation
 	for _, n := range candidatesToDelete {
-		if len(n.pods) != 0 && !c.cluster.IsNodeNominated(n.Name()) {
+		if len(n.pods) != 0 || c.cluster.IsNodeNominated(n.Name()) {
 			return Command{}, fmt.Errorf("command is no longer valid, %s", cmd)
 		}
 	}


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

The `EmptyMachineConsolidation` validation check was validating if both the candidate had more than one pod scheduled to it and if it wasn't nominated. Based on the comment and understanding, the correct validation is to fail validation when _either_ of the following things are true:
1. There is a pod scheduled to the node
2. The node is nominated in the cluster state for a pod very soon

**How was this change tested?**


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
