### PR TITLE
chore: Order initialized nodes for Consolidation

### DIFF
--- a/pkg/controllers/deprovisioning/suite_test.go
+++ b/pkg/controllers/deprovisioning/suite_test.go
@@ -12,13 +12,16 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+// nolint:gosec
 package deprovisioning_test
 
 import (
 	"context"
 	"fmt"
 	"math"
+	"math/rand"
 	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -49,6 +52,7 @@ import (
 	"github.com/aws/karpenter-core/pkg/controllers/provisioning"
 	"github.com/aws/karpenter-core/pkg/controllers/state"
 	"github.com/aws/karpenter-core/pkg/controllers/state/informer"
+	"github.com/aws/karpenter-core/pkg/events"
 	"github.com/aws/karpenter-core/pkg/operator/controller"
 	"github.com/aws/karpenter-core/pkg/operator/scheme"
 	"github.com/aws/karpenter-core/pkg/scheduling"
@@ -1123,8 +1127,6 @@ var _ = Describe("Delete Node", func() {
 		ExpectReconcileSucceeded(ctx, machineStateController, client.ObjectKeyFromObject(machine1))
 		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node2}, []*v1alpha5.Machine{machine2})
 
-		fakeClock.Step(10 * time.Minute)
-
 		var wg sync.WaitGroup
 		ExpectTriggerVerifyAction(&wg)
 		ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
@@ -1139,6 +1141,155 @@ var _ = Describe("Delete Node", func() {
 
 		Expect(evts[0].Message).To(ContainSubstring("not all pods would schedule"))
 		Expect(evts[1].Message).To(ContainSubstring("would schedule against a non-initialized node"))
+	})
+	It("should consider initialized nodes before un-initialized nodes", func() {
+		defaultInstanceType := fake.NewInstanceType(fake.InstanceTypeOptions{
+			Name: "default-instance-type",
+			Resources: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("3"),
+				v1.ResourceMemory: resource.MustParse("3Gi"),
+				v1.ResourcePods:   resource.MustParse("110"),
+			},
+		})
+		smallInstanceType := fake.NewInstanceType(fake.InstanceTypeOptions{
+			Name: "small-instance-type",
+			Resources: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("1"),
+				v1.ResourceMemory: resource.MustParse("1Gi"),
+				v1.ResourcePods:   resource.MustParse("10"),
+			},
+		})
+		cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{
+			defaultInstanceType,
+			smallInstanceType,
+		}
+		labels := map[string]string{
+			"app": "test",
+		}
+		// create our RS so we can link a pod to it
+		rs := test.ReplicaSet()
+		ExpectApplied(ctx, env.Client, rs)
+
+		podCount := 100
+		pods := test.Pods(podCount, test.PodOptions{
+			ObjectMeta: metav1.ObjectMeta{Labels: labels,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion:         "apps/v1",
+						Kind:               "ReplicaSet",
+						Name:               rs.Name,
+						UID:                rs.UID,
+						Controller:         ptr.Bool(true),
+						BlockOwnerDeletion: ptr.Bool(true),
+					},
+				},
+			},
+			ResourceRequirements: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("2"),
+					v1.ResourceMemory: resource.MustParse("2Gi"),
+				},
+			},
+		})
+		ExpectApplied(ctx, env.Client, rs, prov)
+
+		// Setup 100 machines/nodes with a single machine/node that is initialized
+		elem := rand.Intn(100)
+		for i := 0; i < podCount; i++ {
+			m, n := test.MachineAndNode(v1alpha5.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						v1alpha5.ProvisionerNameLabelKey: prov.Name,
+						v1.LabelInstanceTypeStable:       defaultInstanceType.Name,
+						v1alpha5.LabelCapacityType:       defaultInstanceType.Offerings[0].CapacityType,
+						v1.LabelTopologyZone:             defaultInstanceType.Offerings[0].Zone,
+					},
+				},
+				Status: v1alpha5.MachineStatus{
+					ProviderID: test.RandomProviderID(),
+					Allocatable: map[v1.ResourceName]resource.Quantity{
+						v1.ResourceCPU:    resource.MustParse("3"),
+						v1.ResourceMemory: resource.MustParse("3Gi"),
+						v1.ResourcePods:   resource.MustParse("100"),
+					},
+				},
+			})
+			ExpectApplied(ctx, env.Client, pods[i], m, n)
+			ExpectManualBinding(ctx, env.Client, pods[i], n)
+
+			if i == elem {
+				ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{n}, []*v1alpha5.Machine{m})
+			} else {
+				ExpectReconcileSucceeded(ctx, machineStateController, client.ObjectKeyFromObject(m))
+				ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(n))
+			}
+		}
+
+		// Create a pod and machine/node that will eventually be scheduled onto the initialized node
+		consolidatableMachine, consolidatableNode := test.MachineAndNode(v1alpha5.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					v1alpha5.ProvisionerNameLabelKey: prov.Name,
+					v1.LabelInstanceTypeStable:       smallInstanceType.Name,
+					v1alpha5.LabelCapacityType:       smallInstanceType.Offerings[0].CapacityType,
+					v1.LabelTopologyZone:             smallInstanceType.Offerings[0].Zone,
+				},
+			},
+			Status: v1alpha5.MachineStatus{
+				ProviderID: test.RandomProviderID(),
+				Allocatable: map[v1.ResourceName]resource.Quantity{
+					v1.ResourceCPU:    resource.MustParse("1"),
+					v1.ResourceMemory: resource.MustParse("1Gi"),
+					v1.ResourcePods:   resource.MustParse("100"),
+				},
+			},
+		})
+
+		// create a new RS so we can link a pod to it
+		rs = test.ReplicaSet()
+		ExpectApplied(ctx, env.Client, rs)
+		consolidatablePod := test.Pod(test.PodOptions{
+			ObjectMeta: metav1.ObjectMeta{Labels: labels,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion:         "apps/v1",
+						Kind:               "ReplicaSet",
+						Name:               rs.Name,
+						UID:                rs.UID,
+						Controller:         ptr.Bool(true),
+						BlockOwnerDeletion: ptr.Bool(true),
+					},
+				},
+			},
+			ResourceRequirements: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU:    resource.MustParse("1"),
+					v1.ResourceMemory: resource.MustParse("1Gi"),
+				},
+			},
+		})
+		ExpectApplied(ctx, env.Client, consolidatableMachine, consolidatableNode, consolidatablePod)
+		ExpectManualBinding(ctx, env.Client, consolidatablePod, consolidatableNode)
+		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{consolidatableNode}, []*v1alpha5.Machine{consolidatableMachine})
+
+		var wg sync.WaitGroup
+		ExpectTriggerVerifyAction(&wg)
+		ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+		wg.Wait()
+
+		ExpectMachinesCascadeDeletion(ctx, env.Client, consolidatableMachine)
+
+		// Expect no events that state that the pods would schedule against a non-initialized node
+		evts := recorder.Events()
+		_, ok := lo.Find(evts, func(e events.Event) bool {
+			return strings.Contains(e.Message, "would schedule against a non-initialized node")
+		})
+		Expect(ok).To(BeFalse())
+
+		// the machine with the small instance should consolidate onto the initialized node
+		Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(100))
+		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(100))
+		ExpectNotFound(ctx, env.Client, consolidatableMachine, consolidatableNode)
 	})
 })
 

--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -292,7 +292,13 @@ func (s *Scheduler) calculateExistingMachines(stateNodes []*state.StateNode, dae
 	// This is done specifically for consolidation where we want to make sure we schedule to initialized nodes
 	// before we attempt to schedule un-initialized ones
 	sort.SliceStable(s.existingNodes, func(i, j int) bool {
-		return s.existingNodes[i].Initialized()
+		if s.existingNodes[i].Initialized() && !s.existingNodes[j].Initialized() {
+			return true
+		}
+		if !s.existingNodes[i].Initialized() && s.existingNodes[j].Initialized() {
+			return false
+		}
+		return s.existingNodes[i].Name() < s.existingNodes[j].Name()
 	})
 }
 

--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -288,6 +288,12 @@ func (s *Scheduler) calculateExistingMachines(stateNodes []*state.StateNode, dae
 			s.remainingResources[node.Labels()[v1alpha5.ProvisionerNameLabelKey]] = resources.Subtract(s.remainingResources[node.Labels()[v1alpha5.ProvisionerNameLabelKey]], node.Capacity())
 		}
 	}
+	// Order the existing nodes for scheduling with initialized nodes first
+	// This is done specifically for consolidation where we want to make sure we schedule to initialized nodes
+	// before we attempt to schedule un-initialized ones
+	sort.SliceStable(s.existingNodes, func(i, j int) bool {
+		return s.existingNodes[i].Initialized()
+	})
 }
 
 func getDaemonOverhead(nodeTemplates []*MachineTemplate, daemonSetPods []*v1.Pod) map[*MachineTemplate]v1.ResourceList {


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

Orders the `existingNodes` in a consistent manner in the scheduling algorithm. This ensures that:
1. Existing nodes that are being simulated against will have a consistent ordering so that the nomination mechanism should often pick the same node on multiple scheduling simulations (making PodNominations more consistent)
2. Initialized nodes will be tried first in consolidation so that it's less likely for consolidation to fail by scheduling a pod that it is trying to consolidate against an un-initialized node

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
