### PR TITLE
feat: add errors_total CloudProvider metric

### DIFF
--- a/pkg/cloudprovider/metrics/cloudprovider_test.go
+++ b/pkg/cloudprovider/metrics/cloudprovider_test.go
@@ -1,0 +1,47 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics_test
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/aws/karpenter-core/pkg/cloudprovider"
+	"github.com/aws/karpenter-core/pkg/cloudprovider/metrics"
+)
+
+var _ = Describe("Cloudprovider", func() {
+	var machineNotFoundErr = cloudprovider.NewMachineNotFoundError(errors.New("not found"))
+	var insufficientCapacityErr = cloudprovider.NewInsufficientCapacityError(errors.New("not enough capacity"))
+	var unknownErr = errors.New("this is an error we don't know about")
+
+	Describe("CloudProvider machine errors via GetErrorTypeLabelValue()", func() {
+		Context("when the error is known", func() {
+			It("machine not found should be recognized", func() {
+				Expect(metrics.GetErrorTypeLabelValue(machineNotFoundErr)).To(Equal(metrics.MachineNotFoundError))
+			})
+			It("insufficient capacity should be recognized", func() {
+				Expect(metrics.GetErrorTypeLabelValue(insufficientCapacityErr)).To(Equal(metrics.InsufficientCapacityError))
+			})
+		})
+		Context("when the error is unknown", func() {
+			It("should always return empty string", func() {
+				Expect(metrics.GetErrorTypeLabelValue(unknownErr)).To(Equal(metrics.MetricLabelErrorDefaultVal))
+			})
+		})
+	})
+})

--- a/pkg/cloudprovider/metrics/suite_test.go
+++ b/pkg/cloudprovider/metrics/suite_test.go
@@ -1,0 +1,27 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestMetrics(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Metrics Suite")
+}


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes #244

**Description**

This PR introduces a simple metric incrementor into the CloudProvider flow to count total number of errors by well-known error types.

**How was this change tested?**

// TODO

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
