### PR TITLE
test: Fix panic on tests that don't schedule to nodes

### DIFF
--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -1872,7 +1872,9 @@ var _ = Describe("In-Flight Nodes", func() {
 				if i == elem {
 					m, node = ExpectMachineDeployed(ctx, env.Client, cluster, cloudProvider, m)
 				} else {
-					m = ExpectMachineDeployedNoNode(ctx, env.Client, cluster, cloudProvider, m)
+					var err error
+					m, err = ExpectMachineDeployedNoNode(ctx, env.Client, cluster, cloudProvider, m)
+					Expect(err).ToNot(HaveOccurred())
 				}
 				machines = append(machines, m)
 			}


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

Fix a panic on testing that failed to schedule pods to a Machine/Node combination. We should return back a nil Machine if we fail to schedule and pass that back up so that we don't do any binding of that pod to the Machine/Node.

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
