### PR TITLE
fix: Fix provisioner name dereference panic

### DIFF
--- a/pkg/controllers/deprovisioning/types.go
+++ b/pkg/controllers/deprovisioning/types.go
@@ -78,7 +78,7 @@ func NewCandidate(ctx context.Context, kubeClient client.Client, recorder events
 	instanceTypeMap := provisionerToInstanceTypes[node.Labels()[v1alpha5.ProvisionerNameLabelKey]]
 	// skip any nodes where we can't determine the provisioner
 	if provisioner == nil || instanceTypeMap == nil {
-		recorder.Publish(deprovisioningevents.Blocked(node.Node, node.Machine, fmt.Sprintf("owning provisioner %q not found", provisioner.Name))...)
+		recorder.Publish(deprovisioningevents.Blocked(node.Node, node.Machine, fmt.Sprintf("owning provisioner %q not found", node.Labels()[v1alpha5.ProvisionerNameLabelKey]))...)
 		return nil, fmt.Errorf("provisioner '%s' can't be resolved for state node", node.Labels()[v1alpha5.ProvisionerNameLabelKey])
 	}
 	instanceType := instanceTypeMap[node.Labels()[v1.LabelInstanceTypeStable]]


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

Fix panic on dereferencing a provisioner name when the provisioner is `nil`

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
