### PR TITLE
chore: deduplicate deprovisioning filtering logic

### DIFF
--- a/pkg/controllers/deprovisioning/consolidation.go
+++ b/pkg/controllers/deprovisioning/consolidation.go
@@ -70,11 +70,11 @@ func (c *consolidation) String() string {
 }
 
 // sortCandidates orders deprovisionable nodes by the disruptionCost.
-func (c *consolidation) sortCandidates(nodes []*Candidate) []*Candidate {
-	sort.Slice(nodes, func(i int, j int) bool {
-		return nodes[i].disruptionCost < nodes[j].disruptionCost
+func (c *consolidation) sortCandidates(candidates []*Candidate) []*Candidate {
+	sort.Slice(candidates, func(i int, j int) bool {
+		return candidates[i].disruptionCost < candidates[j].disruptionCost
 	})
-	return nodes
+	return candidates
 }
 
 // ShouldDeprovision is a predicate used to filter deprovisionable nodes

--- a/pkg/controllers/deprovisioning/consolidation.go
+++ b/pkg/controllers/deprovisioning/consolidation.go
@@ -69,18 +69,13 @@ func (c *consolidation) String() string {
 	return metrics.ConsolidationReason
 }
 
-// sortAndFilterCandidates orders deprovisionable nodes by the disruptionCost, removing any that we already know won't
+// sortCandidates orders deprovisionable nodes by the disruptionCost, removing any that we already know won't
 // be viable consolidation options.
-func (c *consolidation) sortAndFilterCandidates(ctx context.Context, nodes []*Candidate) ([]*Candidate, error) {
-	candidates, err := filterCandidates(ctx, c.kubeClient, c.recorder, nodes)
-	if err != nil {
-		return nil, fmt.Errorf("filtering candidates, %w", err)
-	}
-
-	sort.Slice(candidates, func(i int, j int) bool {
-		return candidates[i].disruptionCost < candidates[j].disruptionCost
+func (c *consolidation) sortCandidates(nodes []*Candidate) []*Candidate {
+	sort.Slice(nodes, func(i int, j int) bool {
+		return nodes[i].disruptionCost < nodes[j].disruptionCost
 	})
-	return candidates, nil
+	return nodes
 }
 
 // ShouldDeprovision is a predicate used to filter deprovisionable nodes

--- a/pkg/controllers/deprovisioning/consolidation.go
+++ b/pkg/controllers/deprovisioning/consolidation.go
@@ -69,8 +69,7 @@ func (c *consolidation) String() string {
 	return metrics.ConsolidationReason
 }
 
-// sortCandidates orders deprovisionable nodes by the disruptionCost, removing any that we already know won't
-// be viable consolidation options.
+// sortCandidates orders deprovisionable nodes by the disruptionCost.
 func (c *consolidation) sortCandidates(nodes []*Candidate) []*Candidate {
 	sort.Slice(nodes, func(i int, j int) bool {
 		return nodes[i].disruptionCost < nodes[j].disruptionCost

--- a/pkg/controllers/deprovisioning/controller.go
+++ b/pkg/controllers/deprovisioning/controller.go
@@ -149,7 +149,6 @@ func (c *Controller) deprovision(ctx context.Context, deprovisioner Deprovisione
 	if err != nil {
 		return false, fmt.Errorf("determining candidates, %w", err)
 	}
-
 	// If there are no candidate nodes, move to the next deprovisioner
 	if len(candidates) == 0 {
 		return false, nil

--- a/pkg/controllers/deprovisioning/controller.go
+++ b/pkg/controllers/deprovisioning/controller.go
@@ -149,6 +149,7 @@ func (c *Controller) deprovision(ctx context.Context, deprovisioner Deprovisione
 	if err != nil {
 		return false, fmt.Errorf("determining candidates, %w", err)
 	}
+
 	// If there are no candidate nodes, move to the next deprovisioner
 	if len(candidates) == 0 {
 		return false, nil

--- a/pkg/controllers/deprovisioning/drift.go
+++ b/pkg/controllers/deprovisioning/drift.go
@@ -58,9 +58,9 @@ func (d *Drift) ShouldDeprovision(ctx context.Context, c *Candidate) bool {
 }
 
 // ComputeCommand generates a deprovisioning command given deprovisionable machines
-func (d *Drift) ComputeCommand(ctx context.Context, nodes ...*Candidate) (Command, error) {
+func (d *Drift) ComputeCommand(ctx context.Context, candidates ...*Candidate) (Command, error) {
 	// Deprovision all empty drifted nodes, as they require no scheduling simulations.
-	if empty := lo.Filter(nodes, func(c *Candidate, _ int) bool {
+	if empty := lo.Filter(candidates, func(c *Candidate, _ int) bool {
 		return len(c.pods) == 0
 	}); len(empty) > 0 {
 		return Command{
@@ -68,7 +68,7 @@ func (d *Drift) ComputeCommand(ctx context.Context, nodes ...*Candidate) (Comman
 		}, nil
 	}
 
-	for _, candidate := range nodes {
+	for _, candidate := range candidates {
 		// Check if we need to create any machines.
 		results, err := simulateScheduling(ctx, d.kubeClient, d.cluster, d.provisioner, candidate)
 		if err != nil {

--- a/pkg/controllers/deprovisioning/emptymachineconsolidation.go
+++ b/pkg/controllers/deprovisioning/emptymachineconsolidation.go
@@ -45,11 +45,7 @@ func (c *EmptyMachineConsolidation) ComputeCommand(ctx context.Context, candidat
 	if c.cluster.Consolidated() {
 		return Command{}, nil
 	}
-	candidates, err := c.sortAndFilterCandidates(ctx, candidates)
-	if err != nil {
-		return Command{}, fmt.Errorf("sorting candidates, %w", err)
-	}
-	deprovisioningEligibleMachinesGauge.WithLabelValues(c.String()).Set(float64(len(candidates)))
+	candidates = c.sortCandidates(candidates)
 
 	// select the entirely empty nodes
 	emptyCandidates := lo.Filter(candidates, func(n *Candidate, _ int) bool { return len(n.pods) == 0 })

--- a/pkg/controllers/deprovisioning/expiration.go
+++ b/pkg/controllers/deprovisioning/expiration.go
@@ -17,7 +17,6 @@ package deprovisioning
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sort"
 	"time"
 
@@ -67,28 +66,15 @@ func (e *Expiration) ShouldDeprovision(ctx context.Context, c *Candidate) bool {
 	return c.Node.Annotations[v1alpha5.VoluntaryDisruptionAnnotationKey] == v1alpha5.VoluntaryDisruptionExpiredAnnotationValue
 }
 
-// SortCandidates orders expired nodes by when they've expired
-func (e *Expiration) filterAndSortCandidates(ctx context.Context, nodes []*Candidate) ([]*Candidate, error) {
-	candidates, err := filterCandidates(ctx, e.kubeClient, e.recorder, nodes)
-	if err != nil {
-		return nil, fmt.Errorf("filtering candidates, %w", err)
-	}
-	sort.Slice(candidates, func(i int, j int) bool {
-		return node.GetExpirationTime(candidates[i].Node, candidates[i].provisioner).Before(node.GetExpirationTime(candidates[j].Node, candidates[j].provisioner))
-	})
-	return candidates, nil
-}
-
 // ComputeCommand generates a deprovisioning command given deprovisionable nodes
 func (e *Expiration) ComputeCommand(ctx context.Context, nodes ...*Candidate) (Command, error) {
-	candidates, err := e.filterAndSortCandidates(ctx, nodes)
-	if err != nil {
-		return Command{}, fmt.Errorf("filtering candidates, %w", err)
-	}
-	deprovisioningEligibleMachinesGauge.WithLabelValues(e.String()).Set(float64(len(candidates)))
+	// Order expired nodes by when they've expired
+	sort.Slice(nodes, func(i int, j int) bool {
+		return node.GetExpirationTime(nodes[i].Node, nodes[i].provisioner).Before(node.GetExpirationTime(nodes[j].Node, nodes[j].provisioner))
+	})
 
 	// Deprovision all empty expired nodes, as they require no scheduling simulations.
-	if empty := lo.Filter(candidates, func(c *Candidate, _ int) bool {
+	if empty := lo.Filter(nodes, func(c *Candidate, _ int) bool {
 		return len(c.pods) == 0
 	}); len(empty) > 0 {
 		return Command{
@@ -96,7 +82,7 @@ func (e *Expiration) ComputeCommand(ctx context.Context, nodes ...*Candidate) (C
 		}, nil
 	}
 
-	for _, candidate := range candidates {
+	for _, candidate := range nodes {
 		// Check if we need to create any nodes.
 		results, err := simulateScheduling(ctx, e.kubeClient, e.cluster, e.provisioner, candidate)
 		if err != nil {
@@ -111,8 +97,8 @@ func (e *Expiration) ComputeCommand(ctx context.Context, nodes ...*Candidate) (C
 			logging.FromContext(ctx).With("node", candidate.Name).Debugf("continuing to expire node after scheduling simulation failed to schedule all pods, %s", results.PodSchedulingErrors())
 		}
 
-		logging.FromContext(ctx).With("ttl", time.Duration(ptr.Int64Value(candidates[0].provisioner.Spec.TTLSecondsUntilExpired))*time.Second).
-			With("delay", time.Since(node.GetExpirationTime(candidates[0].Node, candidates[0].provisioner))).Infof("triggering termination for expired node after TTL")
+		logging.FromContext(ctx).With("ttl", time.Duration(ptr.Int64Value(nodes[0].provisioner.Spec.TTLSecondsUntilExpired))*time.Second).
+			With("delay", time.Since(node.GetExpirationTime(nodes[0].Node, nodes[0].provisioner))).Infof("triggering termination for expired node after TTL")
 		return Command{
 			candidates:   []*Candidate{candidate},
 			replacements: results.NewMachines,

--- a/pkg/controllers/deprovisioning/helpers.go
+++ b/pkg/controllers/deprovisioning/helpers.go
@@ -184,7 +184,7 @@ func GetCandidates(ctx context.Context, cluster *state.Cluster, kubeClient clien
 		return cn, e == nil
 	})
 	// Filter only the valid candidates that we should deprovision
-	return lo.Filter(candidates, func(c *Candidate, _ int) bool { return shouldDeprovision(ctx, c) }), nil
+	return lo.Filter(candidates, func(c *Candidate, _ int) bool { return c != nil && shouldDeprovision(ctx, c) }), nil
 }
 
 // buildProvisionerMap builds a provName -> provisioner map and a provName -> instanceName -> instance type map

--- a/pkg/controllers/deprovisioning/multimachineconsolidation.go
+++ b/pkg/controllers/deprovisioning/multimachineconsolidation.go
@@ -44,11 +44,7 @@ func (m *MultiMachineConsolidation) ComputeCommand(ctx context.Context, candidat
 	if m.cluster.Consolidated() {
 		return Command{}, nil
 	}
-	candidates, err := m.sortAndFilterCandidates(ctx, candidates)
-	if err != nil {
-		return Command{}, fmt.Errorf("sorting candidates, %w", err)
-	}
-	deprovisioningEligibleMachinesGauge.WithLabelValues(m.String()).Set(float64(len(candidates)))
+	candidates = m.sortCandidates(candidates)
 
 	// For now, we will consider up to every machine in the cluster, might be configurable in the future.
 	maxParallel := len(candidates)

--- a/pkg/controllers/deprovisioning/singlemachineconsolidation.go
+++ b/pkg/controllers/deprovisioning/singlemachineconsolidation.go
@@ -44,11 +44,7 @@ func (c *SingleMachineConsolidation) ComputeCommand(ctx context.Context, candida
 	if c.cluster.Consolidated() {
 		return Command{}, nil
 	}
-	candidates, err := c.sortAndFilterCandidates(ctx, candidates)
-	if err != nil {
-		return Command{}, fmt.Errorf("sorting candidates, %w", err)
-	}
-	deprovisioningEligibleMachinesGauge.WithLabelValues(c.String()).Set(float64(len(candidates)))
+	candidates = c.sortCandidates(candidates)
 
 	v := NewValidation(consolidationTTL, c.clock, c.cluster, c.kubeClient, c.provisioner, c.cloudProvider, c.recorder)
 	for _, candidate := range candidates {


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
Each sub-deprovisioner in the deprovisioning was doing the same filtering logic before each call. Moving this to the GetCandidate() call ensures that we only consider a node as a candidate if it is terminable. 

**How was this change tested?**
`make presubmit`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
