### PR TITLE
chore: Perform metrics tracking through a `MetricStore` abstraction

### DIFF
--- a/pkg/metrics/store.go
+++ b/pkg/metrics/store.go
@@ -1,0 +1,105 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"sync"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/samber/lo"
+	"k8s.io/apimachinery/pkg/api/equality"
+)
+
+// Store is a mapping from a key to a list of Metrics
+// Each time Update() is called for a key on Store, the metric store ensures that all metrics are "refreshed"
+// for all currently tracked metrics assigned to the key. This means that any metric that contains the same labels
+// as a previous metric will be updated through the standard prometheus.Gauge metric Set() call while any metric with
+// different labels than the recently fired metrics will be removed from the prometheus client response and the Store
+type Store struct {
+	sync.Mutex
+	store map[string][]*StoreMetric
+}
+
+func NewStore() *Store {
+	return &Store{store: map[string][]*StoreMetric{}}
+}
+
+// StoreMetric is a single state metric associated with a prometheus.GaugeVec
+type StoreMetric struct {
+	*prometheus.GaugeVec
+	Value  float64
+	Labels prometheus.Labels
+}
+
+// update is an internal non-thread-safe method for updating metrics given a key in the Store
+func (s *Store) update(key string, metrics []*StoreMetric) {
+	for _, metric := range metrics {
+		metric.With(metric.Labels).Set(metric.Value)
+	}
+	// Cleanup old metrics if the old metric family has metrics that weren't updated by this round of metrics
+	if oldMetrics, ok := s.store[key]; ok {
+		for _, oldMetric := range oldMetrics {
+			if _, ok = lo.Find(metrics, func(m *StoreMetric) bool {
+				return oldMetric.GaugeVec == m.GaugeVec && equality.Semantic.DeepEqual(oldMetric.Labels, m.Labels)
+			}); !ok {
+				oldMetric.Delete(oldMetric.Labels)
+			}
+		}
+	}
+	s.store[key] = metrics
+}
+
+// Update calls the update() method internally
+func (s *Store) Update(key string, metrics []*StoreMetric) {
+	s.Lock()
+	defer s.Unlock()
+
+	s.update(key, metrics)
+}
+
+// ReplaceAll replaces all metrics in the store with the new metrics passes into the ReplaceAll function. This calls
+// the update method as normal for any keys that match existing keys while removing any keys that existed in the old
+// store but don't exist in the new store.
+func (s *Store) ReplaceAll(newStore map[string][]*StoreMetric) {
+	s.Lock()
+	defer s.Unlock()
+
+	for k, v := range newStore {
+		s.update(k, v)
+	}
+	for k := range s.store {
+		if _, ok := newStore[k]; !ok {
+			s.delete(k)
+		}
+	}
+}
+
+// delete is an internal non-thread-safe method for deleting metrics given a key in the Store
+func (s *Store) delete(key string) {
+	if metrics, ok := s.store[key]; ok {
+		for _, metric := range metrics {
+			metric.Delete(metric.Labels)
+		}
+		delete(s.store, key)
+	}
+}
+
+// Delete calls the delete() method internally
+func (s *Store) Delete(key string) {
+	s.Lock()
+	defer s.Unlock()
+
+	s.delete(key)
+}

--- a/pkg/metrics/suite_test.go
+++ b/pkg/metrics/suite_test.go
@@ -1,0 +1,365 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/samber/lo"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	"github.com/aws/karpenter-core/pkg/metrics"
+	. "github.com/aws/karpenter-core/pkg/test/expectations"
+)
+
+var testGauge1, testGauge2 *prometheus.GaugeVec
+
+func TestAPIs(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Store")
+}
+
+var _ = BeforeSuite(func() {
+	testGauge1 = prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "test_gauge_1"}, []string{"label_1", "label_2"})
+	testGauge2 = prometheus.NewGaugeVec(prometheus.GaugeOpts{Name: "test_gauge_2"}, []string{"label_1", "label_2"})
+	crmetrics.Registry.MustRegister(testGauge1, testGauge2)
+})
+
+var _ = Describe("Store", func() {
+	var ms *metrics.Store
+	var key client.ObjectKey
+
+	BeforeEach(func() {
+		ms = metrics.NewStore()
+		key = client.ObjectKey{Namespace: "default", Name: "test"}
+	})
+	Context("Update", func() {
+		It("should create metrics when calling update", func() {
+			storeMetrics := []*metrics.StoreMetric{
+				{
+					GaugeVec: testGauge1,
+					Value:    3.65,
+					Labels: prometheus.Labels{
+						"label_1": "test",
+						"label_2": "test",
+					},
+				},
+				{
+					GaugeVec: testGauge2,
+					Value:    5.3,
+					Labels: prometheus.Labels{
+						"label_1": "test",
+						"label_2": "test",
+					},
+				},
+			}
+			ms.Update(key.String(), storeMetrics)
+
+			// Expect to find the metrics with the correct values
+			m, ok := FindMetricWithLabelValues("test_gauge_1", map[string]string{"label_1": "test", "label_2": "test"})
+			Expect(ok).To(BeTrue())
+			Expect(lo.FromPtr(m.Gauge.Value)).To(BeNumerically("==", storeMetrics[0].Value))
+
+			m, ok = FindMetricWithLabelValues("test_gauge_2", map[string]string{"label_1": "test", "label_2": "test"})
+			Expect(ok).To(BeTrue())
+			Expect(lo.FromPtr(m.Gauge.Value)).To(BeNumerically("==", storeMetrics[1].Value))
+
+		})
+		It("should delete metrics when calling update", func() {
+			storeMetrics := []*metrics.StoreMetric{
+				{
+					GaugeVec: testGauge1,
+					Value:    3.65,
+					Labels: prometheus.Labels{
+						"label_1": "test",
+						"label_2": "test",
+					},
+				},
+				{
+					GaugeVec: testGauge2,
+					Value:    5.3,
+					Labels: prometheus.Labels{
+						"label_1": "test",
+						"label_2": "test",
+					},
+				},
+			}
+			ms.Update(key.String(), storeMetrics)
+
+			newStoreMetrics := []*metrics.StoreMetric{
+				{
+					GaugeVec: testGauge1,
+					Value:    3.65,
+					Labels: prometheus.Labels{
+						"label_1": "test_2",
+						"label_2": "test_2",
+					},
+				},
+				{
+					GaugeVec: testGauge2,
+					Value:    5.3,
+					Labels: prometheus.Labels{
+						"label_1": "test_2",
+						"label_2": "test_2",
+					},
+				},
+			}
+			ms.Update(key.String(), newStoreMetrics)
+
+			// Expect to not find the old metrics
+			_, ok := FindMetricWithLabelValues("test_gauge_1", map[string]string{"label_1": "test", "label_2": "test"})
+			Expect(ok).To(BeFalse())
+			_, ok = FindMetricWithLabelValues("test_gauge_2", map[string]string{"label_1": "test", "label_2": "test"})
+			Expect(ok).To(BeFalse())
+
+			// Expect to find the new metrics with the correct values
+			m, ok := FindMetricWithLabelValues("test_gauge_1", map[string]string{"label_1": "test_2", "label_2": "test_2"})
+			Expect(ok).To(BeTrue())
+			Expect(lo.FromPtr(m.Gauge.Value)).To(BeNumerically("==", newStoreMetrics[0].Value))
+			m, ok = FindMetricWithLabelValues("test_gauge_2", map[string]string{"label_1": "test_2", "label_2": "test_2"})
+			Expect(ok).To(BeTrue())
+			Expect(lo.FromPtr(m.Gauge.Value)).To(BeNumerically("==", newStoreMetrics[1].Value))
+		})
+		It("should consider metrics equal with the same labels", func() {
+			storeMetrics := []*metrics.StoreMetric{
+				{
+					GaugeVec: testGauge1,
+					Value:    3.65,
+					Labels: prometheus.Labels{
+						"label_1": "test",
+						"label_2": "test",
+					},
+				},
+				{
+					GaugeVec: testGauge2,
+					Value:    5.3,
+					Labels: prometheus.Labels{
+						"label_1": "test",
+						"label_2": "test",
+					},
+				},
+			}
+			ms.Update(key.String(), storeMetrics)
+
+			// Expect to find the metrics with the correct values
+			m, ok := FindMetricWithLabelValues("test_gauge_1", map[string]string{"label_1": "test", "label_2": "test"})
+			Expect(ok).To(BeTrue())
+			Expect(lo.FromPtr(m.Gauge.Value)).To(BeNumerically("==", storeMetrics[0].Value))
+
+			m, ok = FindMetricWithLabelValues("test_gauge_2", map[string]string{"label_1": "test", "label_2": "test"})
+			Expect(ok).To(BeTrue())
+			Expect(lo.FromPtr(m.Gauge.Value)).To(BeNumerically("==", storeMetrics[1].Value))
+
+			// Flip around the labels in the map
+			newStoreMetrics := []*metrics.StoreMetric{
+				{
+					GaugeVec: testGauge1,
+					Value:    4.5,
+					Labels: prometheus.Labels{
+						"label_2": "test",
+						"label_1": "test",
+					},
+				},
+				{
+					GaugeVec: testGauge2,
+					Value:    6.9,
+					Labels: prometheus.Labels{
+						"label_2": "test",
+						"label_1": "test",
+					},
+				},
+			}
+			ms.Update(key.String(), newStoreMetrics)
+
+			// Expect to find the metrics with the new values
+			m, ok = FindMetricWithLabelValues("test_gauge_1", map[string]string{"label_1": "test", "label_2": "test"})
+			Expect(ok).To(BeTrue())
+			Expect(lo.FromPtr(m.Gauge.Value)).To(BeNumerically("==", newStoreMetrics[0].Value))
+
+			m, ok = FindMetricWithLabelValues("test_gauge_2", map[string]string{"label_1": "test", "label_2": "test"})
+			Expect(ok).To(BeTrue())
+			Expect(lo.FromPtr(m.Gauge.Value)).To(BeNumerically("==", newStoreMetrics[1].Value))
+		})
+	})
+	Context("Delete", func() {
+		It("should delete metrics by key", func() {
+			storeMetrics := []*metrics.StoreMetric{
+				{
+					GaugeVec: testGauge1,
+					Value:    3.65,
+					Labels: prometheus.Labels{
+						"label_1": "test",
+						"label_2": "test",
+					},
+				},
+				{
+					GaugeVec: testGauge2,
+					Value:    5.3,
+					Labels: prometheus.Labels{
+						"label_1": "test",
+						"label_2": "test",
+					},
+				},
+			}
+			ms.Update(key.String(), storeMetrics)
+
+			// Expect to find the metrics
+			_, ok := FindMetricWithLabelValues("test_gauge_1", map[string]string{"label_1": "test", "label_2": "test"})
+			Expect(ok).To(BeTrue())
+			_, ok = FindMetricWithLabelValues("test_gauge_2", map[string]string{"label_1": "test", "label_2": "test"})
+			Expect(ok).To(BeTrue())
+
+			ms.Delete(key.String())
+
+			// Expect the metrics to be gone
+			_, ok = FindMetricWithLabelValues("test_gauge_1", map[string]string{"label_1": "test", "label_2": "test"})
+			Expect(ok).To(BeFalse())
+			_, ok = FindMetricWithLabelValues("test_gauge_2", map[string]string{"label_1": "test", "label_2": "test"})
+			Expect(ok).To(BeFalse())
+		})
+		It("should delete the metrics if key didn't previously exist", func() {
+			ms.Delete(key.String())
+		})
+	})
+	Context("ReplaceAll", func() {
+		It("should replace all metrics", func() {
+			storeMetrics := []*metrics.StoreMetric{
+				{
+					GaugeVec: testGauge1,
+					Value:    3.65,
+					Labels: prometheus.Labels{
+						"label_1": "test",
+						"label_2": "test",
+					},
+				},
+				{
+					GaugeVec: testGauge2,
+					Value:    5.3,
+					Labels: prometheus.Labels{
+						"label_1": "test",
+						"label_2": "test",
+					},
+				},
+			}
+			ms.Update(key.String(), storeMetrics)
+
+			// Expect to find the metrics
+			_, ok := FindMetricWithLabelValues("test_gauge_1", map[string]string{"label_1": "test", "label_2": "test"})
+			Expect(ok).To(BeTrue())
+			_, ok = FindMetricWithLabelValues("test_gauge_2", map[string]string{"label_1": "test", "label_2": "test"})
+			Expect(ok).To(BeTrue())
+
+			key2 := client.ObjectKey{Namespace: "default", Name: "test2"}
+			key3 := client.ObjectKey{Namespace: "default", Name: "test3"}
+
+			newStore := map[string][]*metrics.StoreMetric{
+				key2.String(): {
+					{
+						GaugeVec: testGauge1,
+						Value:    3.65,
+						Labels: prometheus.Labels{
+							"label_1": "test2",
+							"label_2": "test2",
+						},
+					},
+					{
+						GaugeVec: testGauge2,
+						Value:    4.3,
+						Labels: prometheus.Labels{
+							"label_1": "test2",
+							"label_2": "test2",
+						},
+					},
+				},
+				key3.String(): {
+					{
+						GaugeVec: testGauge1,
+						Value:    2.1,
+						Labels: prometheus.Labels{
+							"label_1": "test3",
+							"label_2": "test3",
+						},
+					},
+					{
+						GaugeVec: testGauge2,
+						Value:    8.9,
+						Labels: prometheus.Labels{
+							"label_1": "test3",
+							"label_2": "test3",
+						},
+					},
+				},
+			}
+			ms.ReplaceAll(newStore)
+
+			// Expect to not find the old metrics
+			_, ok = FindMetricWithLabelValues("test_gauge_1", map[string]string{"label_1": "test", "label_2": "test"})
+			Expect(ok).To(BeFalse())
+			_, ok = FindMetricWithLabelValues("test_gauge_2", map[string]string{"label_1": "test", "label_2": "test"})
+			Expect(ok).To(BeFalse())
+
+			// Expect to find the new metrics for test2
+			_, ok = FindMetricWithLabelValues("test_gauge_1", map[string]string{"label_1": "test2", "label_2": "test2"})
+			Expect(ok).To(BeTrue())
+			_, ok = FindMetricWithLabelValues("test_gauge_2", map[string]string{"label_1": "test2", "label_2": "test2"})
+			Expect(ok).To(BeTrue())
+
+			// Expect to find the new metrics for test3
+			_, ok = FindMetricWithLabelValues("test_gauge_1", map[string]string{"label_1": "test3", "label_2": "test3"})
+			Expect(ok).To(BeTrue())
+			_, ok = FindMetricWithLabelValues("test_gauge_2", map[string]string{"label_1": "test3", "label_2": "test3"})
+			Expect(ok).To(BeTrue())
+		})
+		It("should replace with an empty store", func() {
+			storeMetrics := []*metrics.StoreMetric{
+				{
+					GaugeVec: testGauge1,
+					Value:    3.65,
+					Labels: prometheus.Labels{
+						"label_1": "test",
+						"label_2": "test",
+					},
+				},
+				{
+					GaugeVec: testGauge2,
+					Value:    5.3,
+					Labels: prometheus.Labels{
+						"label_1": "test",
+						"label_2": "test",
+					},
+				},
+			}
+			ms.Update(key.String(), storeMetrics)
+
+			// Expect to find the metrics
+			_, ok := FindMetricWithLabelValues("test_gauge_1", map[string]string{"label_1": "test", "label_2": "test"})
+			Expect(ok).To(BeTrue())
+			_, ok = FindMetricWithLabelValues("test_gauge_2", map[string]string{"label_1": "test", "label_2": "test"})
+			Expect(ok).To(BeTrue())
+
+			ms.ReplaceAll(nil)
+
+			// Expect to not find the metrics now
+			_, ok = FindMetricWithLabelValues("test_gauge_1", map[string]string{"label_1": "test", "label_2": "test"})
+			Expect(ok).To(BeFalse())
+			_, ok = FindMetricWithLabelValues("test_gauge_2", map[string]string{"label_1": "test", "label_2": "test"})
+			Expect(ok).To(BeFalse())
+		})
+	})
+})


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

This PR removes the individual logic in each controller for metric tracking and moves this as an abstraction over to the `metrics.Store` for tracking and replacing metrics.

This mechanism performs a very similar mechanism to `kube-state-metrics`, where it tracks the metrics for a particular "metric family" based on a given string key (in this case only one metric family is stored per key in each metric store). 

When a call to `Update` is made, the metric store will "refresh" these metrics by updating any existing metrics with the new values for those that match the labels and sweeping any old metrics assigned to the key that aren't in the new set.

When a call to `ReplaceAll` is made, the metric store will effectively perform `Update` across all of its metric keys, while also sweeping any keys that are no longer part of the new metric store set.

### Memory Impact

This change has no tangible memory impact. This change was tested with 100 nodes of churn before the PR (blue) and after the PR (red) and no noticeable difference between the `container_memory_working_set_bytes` was noticed.

<img width="725" alt="Screenshot 2023-08-22 at 11 23 26 PM" src="https://github.com/aws/karpenter-core/assets/26334334/d541d6c4-2840-48c4-b728-b078ba06f5e7">

This change was also tested over a period of 4h with 100 pod/100 node churn generated every 5m with no impact seen to the memory footprint

<img width="720" alt="Screenshot 2023-08-23 at 9 20 46 AM" src="https://github.com/aws/karpenter-core/assets/26334334/ea9b2458-0194-498e-871b-5de6e5f5eb94">

**How was this change tested?**

`make presubmit`
`make apply`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
