### PR TITLE
feat: add deprovisioning metrics for eligible machines

### DIFF
--- a/pkg/controllers/deprovisioning/consolidation.go
+++ b/pkg/controllers/deprovisioning/consolidation.go
@@ -104,7 +104,6 @@ func (c *consolidation) ShouldDeprovision(_ context.Context, cn *Candidate) bool
 //
 // nolint:gocyclo
 func (c *consolidation) computeConsolidation(ctx context.Context, candidates ...*Candidate) (Command, error) {
-	defer metrics.Measure(deprovisioningDurationHistogram.WithLabelValues("Replace/Delete"))()
 	// Run scheduling simulation to compute consolidation option
 	results, err := simulateScheduling(ctx, c.kubeClient, c.cluster, c.provisioner, candidates...)
 	if err != nil {

--- a/pkg/controllers/deprovisioning/controller.go
+++ b/pkg/controllers/deprovisioning/controller.go
@@ -173,7 +173,8 @@ func (c *Controller) deprovision(ctx context.Context, deprovisioner Deprovisione
 
 func (c *Controller) executeCommand(ctx context.Context, d Deprovisioner, command Command) error {
 	deprovisioningActionsPerformedCounter.With(map[string]string{
-		actionLabel:        string(command.Action()),
+		// TODO: make this just command.Action() since we've added the deprovisioner as its own label.
+		actionLabel:        fmt.Sprintf("%s/%s", d, command.Action()),
 		deprovisionerLabel: d.String(),
 	}).Add(1)
 	logging.FromContext(ctx).Infof("deprovisioning via %s %s", d, command)

--- a/pkg/controllers/deprovisioning/controller.go
+++ b/pkg/controllers/deprovisioning/controller.go
@@ -149,7 +149,6 @@ func (c *Controller) deprovision(ctx context.Context, deprovisioner Deprovisione
 	if err != nil {
 		return false, fmt.Errorf("determining candidates, %w", err)
 	}
-	deprovisioningEligibleMachinesGauge.WithLabelValues(deprovisioner.String()).Set(float64(len(candidates)))
 	// If there are no candidate nodes, move to the next deprovisioner
 	if len(candidates) == 0 {
 		return false, nil

--- a/pkg/controllers/deprovisioning/controller.go
+++ b/pkg/controllers/deprovisioning/controller.go
@@ -176,7 +176,7 @@ func (c *Controller) executeCommand(ctx context.Context, d Deprovisioner, comman
 		// TODO: make this just command.Action() since we've added the deprovisioner as its own label.
 		actionLabel:        fmt.Sprintf("%s/%s", d, command.Action()),
 		deprovisionerLabel: d.String(),
-	}).Add(1)
+	}).Inc()
 	logging.FromContext(ctx).Infof("deprovisioning via %s %s", d, command)
 
 	reason := fmt.Sprintf("%s/%s", d, command.Action())

--- a/pkg/controllers/deprovisioning/controller.go
+++ b/pkg/controllers/deprovisioning/controller.go
@@ -172,7 +172,7 @@ func (c *Controller) deprovision(ctx context.Context, deprovisioner Deprovisione
 }
 
 func (c *Controller) executeCommand(ctx context.Context, d Deprovisioner, command Command) error {
-	deprovisioningActionsPerformedCounter.WithLabelValues(fmt.Sprintf("%s/%s", d, command.Action())).Add(1)
+	deprovisioningActionsPerformedCounter.WithLabelValues(string(command.Action()), d.String()).Add(1)
 	logging.FromContext(ctx).Infof("deprovisioning via %s %s", d, command)
 
 	reason := fmt.Sprintf("%s/%s", d, command.Action())

--- a/pkg/controllers/deprovisioning/controller.go
+++ b/pkg/controllers/deprovisioning/controller.go
@@ -145,7 +145,7 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 
 func (c *Controller) deprovision(ctx context.Context, deprovisioner Deprovisioner) (bool, error) {
 	defer metrics.Measure(deprovisioningDurationHistogram.WithLabelValues(deprovisioner.String()))()
-	candidates, err := GetCandidates(ctx, c.cluster, c.kubeClient, c.clock, c.cloudProvider, deprovisioner.ShouldDeprovision)
+	candidates, err := GetCandidates(ctx, c.cluster, c.kubeClient, c.recorder, c.clock, c.cloudProvider, deprovisioner.ShouldDeprovision)
 	if err != nil {
 		return false, fmt.Errorf("determining candidates, %w", err)
 	}
@@ -172,7 +172,7 @@ func (c *Controller) deprovision(ctx context.Context, deprovisioner Deprovisione
 }
 
 func (c *Controller) executeCommand(ctx context.Context, d Deprovisioner, command Command) error {
-	deprovisioningActionsPerformedCounter.WithLabelValues(fmt.Sprintf("%s/%s", d, command.action)).Add(1)
+	deprovisioningActionsPerformedCounter.WithLabelValues(fmt.Sprintf("%s/%s", d, command.Action())).Add(1)
 	logging.FromContext(ctx).Infof("deprovisioning via %s %s", d, command)
 
 	reason := fmt.Sprintf("%s/%s", d, command.Action())

--- a/pkg/controllers/deprovisioning/controller.go
+++ b/pkg/controllers/deprovisioning/controller.go
@@ -172,7 +172,10 @@ func (c *Controller) deprovision(ctx context.Context, deprovisioner Deprovisione
 }
 
 func (c *Controller) executeCommand(ctx context.Context, d Deprovisioner, command Command) error {
-	deprovisioningActionsPerformedCounter.WithLabelValues(string(command.Action()), d.String()).Add(1)
+	deprovisioningActionsPerformedCounter.With(map[string]string{
+		actionLabel:        string(command.Action()),
+		deprovisionerLabel: d.String(),
+	}).Add(1)
 	logging.FromContext(ctx).Infof("deprovisioning via %s %s", d, command)
 
 	reason := fmt.Sprintf("%s/%s", d, command.Action())

--- a/pkg/controllers/deprovisioning/drift.go
+++ b/pkg/controllers/deprovisioning/drift.go
@@ -64,6 +64,7 @@ func (d *Drift) ComputeCommand(ctx context.Context, nodes ...*Candidate) (Comman
 	if err != nil {
 		return Command{}, fmt.Errorf("filtering candidates, %w", err)
 	}
+	deprovisioningEligibleMachinesGauge.WithLabelValues(d.String()).Set(float64(len(candidates)))
 
 	// Deprovision all empty drifted nodes, as they require no scheduling simulations.
 	if empty := lo.Filter(candidates, func(c *Candidate, _ int) bool {

--- a/pkg/controllers/deprovisioning/emptiness.go
+++ b/pkg/controllers/deprovisioning/emptiness.go
@@ -66,6 +66,7 @@ func (e *Emptiness) ComputeCommand(_ context.Context, candidates ...*Candidate) 
 	emptyCandidates := lo.Filter(candidates, func(cn *Candidate, _ int) bool {
 		return cn.Machine.DeletionTimestamp.IsZero() && len(cn.pods) == 0
 	})
+	deprovisioningEligibleMachinesGauge.WithLabelValues(e.String()).Set(float64(len(candidates)))
 
 	return Command{
 		candidates: emptyCandidates,

--- a/pkg/controllers/deprovisioning/emptymachineconsolidation.go
+++ b/pkg/controllers/deprovisioning/emptymachineconsolidation.go
@@ -85,7 +85,3 @@ func (c *EmptyMachineConsolidation) ComputeCommand(ctx context.Context, candidat
 	}
 	return cmd, nil
 }
-
-func (c *EmptyMachineConsolidation) String() string {
-	return "empty-consolidation"
-}

--- a/pkg/controllers/deprovisioning/emptymachineconsolidation.go
+++ b/pkg/controllers/deprovisioning/emptymachineconsolidation.go
@@ -49,6 +49,7 @@ func (c *EmptyMachineConsolidation) ComputeCommand(ctx context.Context, candidat
 	if err != nil {
 		return Command{}, fmt.Errorf("sorting candidates, %w", err)
 	}
+	deprovisioningEligibleMachinesGauge.WithLabelValues(c.String()).Set(float64(len(candidates)))
 
 	// select the entirely empty nodes
 	emptyCandidates := lo.Filter(candidates, func(n *Candidate, _ int) bool { return len(n.pods) == 0 })
@@ -83,4 +84,8 @@ func (c *EmptyMachineConsolidation) ComputeCommand(ctx context.Context, candidat
 		}
 	}
 	return cmd, nil
+}
+
+func (c *EmptyMachineConsolidation) String() string {
+	return "empty-consolidation"
 }

--- a/pkg/controllers/deprovisioning/expiration.go
+++ b/pkg/controllers/deprovisioning/expiration.go
@@ -85,6 +85,7 @@ func (e *Expiration) ComputeCommand(ctx context.Context, nodes ...*Candidate) (C
 	if err != nil {
 		return Command{}, fmt.Errorf("filtering candidates, %w", err)
 	}
+	deprovisioningEligibleMachinesGauge.WithLabelValues(e.String()).Set(float64(len(candidates)))
 
 	// Deprovision all empty expired nodes, as they require no scheduling simulations.
 	if empty := lo.Filter(candidates, func(c *Candidate, _ int) bool {

--- a/pkg/controllers/deprovisioning/metrics.go
+++ b/pkg/controllers/deprovisioning/metrics.go
@@ -35,23 +35,22 @@ const (
 )
 
 var (
-	deprovisioningDurationHistogram = prometheus.NewSummaryVec(
-		prometheus.SummaryOpts{
-			Namespace:  metrics.Namespace,
-			Subsystem:  deprovisioningSubsystem,
-			Name:       "evaluation_duration_seconds",
-			Help:       "Duration of the deprovisioning evaluation process in seconds. Labeled by deprovisioner",
-			Objectives: metrics.SummaryObjectives(),
+	deprovisioningDurationHistogram = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: deprovisioningSubsystem,
+			Name:      "evaluation_duration_seconds",
+			Help:      "Duration of the deprovisioning evaluation process in seconds.",
+			Buckets:   metrics.DurationBuckets(),
 		},
-		[]string{deprovisionerLabel},
-	)
-	deprovisioningReplacementNodeInitializedHistogram = prometheus.NewSummary(
-		prometheus.SummaryOpts{
-			Namespace:  metrics.Namespace,
-			Subsystem:  deprovisioningSubsystem,
-			Name:       "replacement_machine_initialized_seconds",
-			Help:       "Amount of time required for a replacement machine to become initialized.",
-			Objectives: metrics.SummaryObjectives(),
+		[]string{"method"})
+	deprovisioningReplacementNodeInitializedHistogram = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: deprovisioningSubsystem,
+			Name:      "replacement_machine_initialized_seconds",
+			Help:      "Amount of time required for a replacement machine to become initialized.",
+			Buckets:   metrics.DurationBuckets(),
 		})
 	deprovisioningActionsPerformedCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{

--- a/pkg/controllers/deprovisioning/metrics.go
+++ b/pkg/controllers/deprovisioning/metrics.go
@@ -25,36 +25,49 @@ func init() {
 	crmetrics.Registry.MustRegister(deprovisioningDurationHistogram)
 	crmetrics.Registry.MustRegister(deprovisioningReplacementNodeInitializedHistogram)
 	crmetrics.Registry.MustRegister(deprovisioningActionsPerformedCounter)
+	crmetrics.Registry.MustRegister(deprovisioningEligibleMachinesGauge)
 }
 
-const deprovisioningSubsystem = "deprovisioning"
-
-var deprovisioningDurationHistogram = prometheus.NewHistogramVec(
-	prometheus.HistogramOpts{
-		Namespace: metrics.Namespace,
-		Subsystem: deprovisioningSubsystem,
-		Name:      "evaluation_duration_seconds",
-		Help:      "Duration of the deprovisioning evaluation process in seconds.",
-		Buckets:   metrics.DurationBuckets(),
-	},
-	[]string{"method"},
+const (
+	deprovisioningSubsystem = "deprovisioning"
+	deprovisionerLabel      = "deprovisioner"
 )
 
-var deprovisioningReplacementNodeInitializedHistogram = prometheus.NewHistogram(
-	prometheus.HistogramOpts{
-		Namespace: metrics.Namespace,
-		Subsystem: deprovisioningSubsystem,
-		Name:      "replacement_machine_initialized_seconds",
-		Help:      "Amount of time required for a replacement machine to become initialized.",
-		Buckets:   metrics.DurationBuckets(),
-	})
-
-var deprovisioningActionsPerformedCounter = prometheus.NewCounterVec(
-	prometheus.CounterOpts{
-		Namespace: metrics.Namespace,
-		Subsystem: deprovisioningSubsystem,
-		Name:      "actions_performed",
-		Help:      "Number of deprovisioning actions performed. Labeled by action.",
-	},
-	[]string{"action"},
+var (
+	deprovisioningDurationHistogram = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: deprovisioningSubsystem,
+			Name:      "evaluation_duration_seconds",
+			Help:      "Duration of the deprovisioning evaluation process in seconds. Labeled by deprovisioner",
+			Buckets:   metrics.DurationBuckets(),
+		},
+		[]string{deprovisionerLabel},
+	)
+	deprovisioningReplacementNodeInitializedHistogram = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: deprovisioningSubsystem,
+			Name:      "replacement_machine_initialized_seconds",
+			Help:      "Amount of time required for a replacement machine to become initialized.",
+			Buckets:   metrics.DurationBuckets(),
+		})
+	deprovisioningActionsPerformedCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: deprovisioningSubsystem,
+			Name:      "actions_performed",
+			Help:      "Number of deprovisioning actions performed. Labeled by deprovisioner.",
+		},
+		[]string{deprovisionerLabel},
+	)
+	deprovisioningEligibleMachinesGauge = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: metrics.Namespace,
+			Subsystem: deprovisioningSubsystem,
+			Name:      "eligible_machines",
+			Help:      "Number of machines eligible for deprovisioning by Karpenter. Labeled by deprovisioner",
+		},
+		[]string{deprovisionerLabel},
+	)
 )

--- a/pkg/controllers/deprovisioning/metrics.go
+++ b/pkg/controllers/deprovisioning/metrics.go
@@ -31,6 +31,7 @@ func init() {
 const (
 	deprovisioningSubsystem = "deprovisioning"
 	deprovisionerLabel      = "deprovisioner"
+	actionLabel 			= "action"
 )
 
 var (
@@ -59,7 +60,7 @@ var (
 			Name:      "actions_performed",
 			Help:      "Number of deprovisioning actions performed. Labeled by deprovisioner.",
 		},
-		[]string{deprovisionerLabel},
+		[]string{actionLabel, deprovisionerLabel},
 	)
 	deprovisioningEligibleMachinesGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{

--- a/pkg/controllers/deprovisioning/metrics.go
+++ b/pkg/controllers/deprovisioning/metrics.go
@@ -31,27 +31,27 @@ func init() {
 const (
 	deprovisioningSubsystem = "deprovisioning"
 	deprovisionerLabel      = "deprovisioner"
-	actionLabel 			= "action"
+	actionLabel             = "action"
 )
 
 var (
-	deprovisioningDurationHistogram = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Namespace: metrics.Namespace,
-			Subsystem: deprovisioningSubsystem,
-			Name:      "evaluation_duration_seconds",
-			Help:      "Duration of the deprovisioning evaluation process in seconds. Labeled by deprovisioner",
-			Buckets:   metrics.DurationBuckets(),
+	deprovisioningDurationHistogram = prometheus.NewSummaryVec(
+		prometheus.SummaryOpts{
+			Namespace:  metrics.Namespace,
+			Subsystem:  deprovisioningSubsystem,
+			Name:       "evaluation_duration_seconds",
+			Help:       "Duration of the deprovisioning evaluation process in seconds. Labeled by deprovisioner",
+			Objectives: metrics.SummaryObjectives(),
 		},
 		[]string{deprovisionerLabel},
 	)
-	deprovisioningReplacementNodeInitializedHistogram = prometheus.NewHistogram(
-		prometheus.HistogramOpts{
-			Namespace: metrics.Namespace,
-			Subsystem: deprovisioningSubsystem,
-			Name:      "replacement_machine_initialized_seconds",
-			Help:      "Amount of time required for a replacement machine to become initialized.",
-			Buckets:   metrics.DurationBuckets(),
+	deprovisioningReplacementNodeInitializedHistogram = prometheus.NewSummary(
+		prometheus.SummaryOpts{
+			Namespace:  metrics.Namespace,
+			Subsystem:  deprovisioningSubsystem,
+			Name:       "replacement_machine_initialized_seconds",
+			Help:       "Amount of time required for a replacement machine to become initialized.",
+			Objectives: metrics.SummaryObjectives(),
 		})
 	deprovisioningActionsPerformedCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{

--- a/pkg/controllers/deprovisioning/multimachineconsolidation.go
+++ b/pkg/controllers/deprovisioning/multimachineconsolidation.go
@@ -47,6 +47,7 @@ func (m *MultiMachineConsolidation) ComputeCommand(ctx context.Context, candidat
 	if err != nil {
 		return Command{}, fmt.Errorf("sorting candidates, %w", err)
 	}
+	deprovisioningEligibleMachinesGauge.WithLabelValues(m.String()).Set(float64(len(candidates)))
 
 	// For now, we will consider up to every machine in the cluster, might be configurable in the future.
 	maxParallel := len(candidates)
@@ -163,4 +164,8 @@ func filterOutSameType(newMachine *scheduling.Machine, consolidate []*Candidate)
 	}
 
 	return filterByPrice(newMachine.InstanceTypeOptions, newMachine.Requirements, maxPrice)
+}
+
+func (c *EmptyMachineConsolidation) String() string {
+	return "multi-consolidation"
 }

--- a/pkg/controllers/deprovisioning/multimachineconsolidation.go
+++ b/pkg/controllers/deprovisioning/multimachineconsolidation.go
@@ -165,7 +165,3 @@ func filterOutSameType(newMachine *scheduling.Machine, consolidate []*Candidate)
 
 	return filterByPrice(newMachine.InstanceTypeOptions, newMachine.Requirements, maxPrice)
 }
-
-func (c *MultiMachineConsolidation) String() string {
-	return "multi-consolidation"
-}

--- a/pkg/controllers/deprovisioning/multimachineconsolidation.go
+++ b/pkg/controllers/deprovisioning/multimachineconsolidation.go
@@ -166,6 +166,6 @@ func filterOutSameType(newMachine *scheduling.Machine, consolidate []*Candidate)
 	return filterByPrice(newMachine.InstanceTypeOptions, newMachine.Requirements, maxPrice)
 }
 
-func (c *EmptyMachineConsolidation) String() string {
+func (c *MultiMachineConsolidation) String() string {
 	return "multi-consolidation"
 }

--- a/pkg/controllers/deprovisioning/singlemachineconsolidation.go
+++ b/pkg/controllers/deprovisioning/singlemachineconsolidation.go
@@ -48,6 +48,7 @@ func (c *SingleMachineConsolidation) ComputeCommand(ctx context.Context, candida
 	if err != nil {
 		return Command{}, fmt.Errorf("sorting candidates, %w", err)
 	}
+	deprovisioningEligibleMachinesGauge.WithLabelValues(c.String()).Set(float64(len(candidates)))
 
 	v := NewValidation(consolidationTTL, c.clock, c.cluster, c.kubeClient, c.provisioner, c.cloudProvider, c.recorder)
 	for _, candidate := range candidates {
@@ -72,4 +73,8 @@ func (c *SingleMachineConsolidation) ComputeCommand(ctx context.Context, candida
 		return cmd, nil
 	}
 	return Command{}, nil
+}
+
+func (c *SingleMachineConsolidation) String() string {
+	return "single-consolidation"
 }

--- a/pkg/controllers/deprovisioning/singlemachineconsolidation.go
+++ b/pkg/controllers/deprovisioning/singlemachineconsolidation.go
@@ -74,7 +74,3 @@ func (c *SingleMachineConsolidation) ComputeCommand(ctx context.Context, candida
 	}
 	return Command{}, nil
 }
-
-func (c *SingleMachineConsolidation) String() string {
-	return "single-consolidation"
-}


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**
This adds in metrics to distinguish per-deprovisioner metrics and adds in a metric that shows how many machines are eligible for deprovisioning

**How was this change tested?**
- make presubmit
- make apply && look at prometheus server

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
