### PR TITLE
feat: Include knative webhooks in readiness probes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	k8s.io/csi-translation-lib v0.25.4
 	k8s.io/klog/v2 v2.100.1
 	k8s.io/utils v0.0.0-20221108210102-8e77b1f39fe2
-	knative.dev/pkg v0.0.0-20221123154742-05b694ec4d3a
+	knative.dev/pkg v0.0.0-20230502134655-db8a35330281
 	sigs.k8s.io/controller-runtime v0.13.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -839,6 +839,8 @@ k8s.io/utils v0.0.0-20221108210102-8e77b1f39fe2 h1:GfD9OzL11kvZN5iArC6oTS7RTj7oJ
 k8s.io/utils v0.0.0-20221108210102-8e77b1f39fe2/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 knative.dev/pkg v0.0.0-20221123154742-05b694ec4d3a h1:mTDxXL+zRBMz7BcdM3WOgw9FVbmkIN/3cvEj4MeS8zI=
 knative.dev/pkg v0.0.0-20221123154742-05b694ec4d3a/go.mod h1:fckNBPf9bu5/p1RbnOhEauX7r+kfN1zSQupEVtkaYBs=
+knative.dev/pkg v0.0.0-20230502134655-db8a35330281 h1:9mN8O5XO68DKlkzEhFAShUx+O/I+TQR71vmTvYt8oF4=
+knative.dev/pkg v0.0.0-20230502134655-db8a35330281/go.mod h1:2qWPP9Gjh9Q7ETti+WRHnBnGCSCq+6q7m3p/nmUQviE=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -153,10 +153,10 @@ func (o *Operator) WithControllers(ctx context.Context, controllers ...corecontr
 	return o
 }
 
-func (o *Operator) WithWebhooks(ctx context.Context, webhooks ...knativeinjection.ControllerConstructor) *Operator {
+func (o *Operator) WithWebhooks(webhooks ...knativeinjection.ControllerConstructor) *Operator {
 	o.webhooks = append(o.webhooks, webhooks...)
-	lo.Must0(o.Manager.AddReadyzCheck("webhooks", knativeChecker(ctx, "readiness")))
-	lo.Must0(o.Manager.AddHealthzCheck("webhooks", knativeChecker(ctx, "health")))
+	lo.Must0(o.Manager.AddReadyzCheck("webhooks", knativeChecker("readiness")))
+	lo.Must0(o.Manager.AddHealthzCheck("webhooks", knativeChecker("health")))
 	return o
 }
 
@@ -177,13 +177,8 @@ func (o *Operator) Start(ctx context.Context) {
 	wg.Wait()
 }
 
-func knativeChecker(ctx context.Context, path string) healthz.Checker {
+func knativeChecker(path string) healthz.Checker {
 	return func(req *http.Request) (err error) {
-		defer func() {
-			if err != nil {
-				logging.FromContext(ctx).Errorf("probe failed: %s", err.Error())
-			}
-		}()
 		res, err := http.Get(fmt.Sprintf("http://:%d/%s", knativeinjection.HealthCheckDefaultPort, path))
 		if err != nil {
 			return err

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -153,10 +153,10 @@ func (o *Operator) WithControllers(ctx context.Context, controllers ...corecontr
 	return o
 }
 
-func (o *Operator) WithWebhooks(webhooks ...knativeinjection.ControllerConstructor) *Operator {
+func (o *Operator) WithWebhooks(ctx context.Context, webhooks ...knativeinjection.ControllerConstructor) *Operator {
 	o.webhooks = append(o.webhooks, webhooks...)
-	lo.Must0(o.Manager.AddReadyzCheck("webhooks", knativeChecker("readiness")))
-	lo.Must0(o.Manager.AddHealthzCheck("webhooks", knativeChecker("health")))
+	lo.Must0(o.Manager.AddReadyzCheck("webhooks", knativeChecker(ctx, "readiness")))
+	lo.Must0(o.Manager.AddHealthzCheck("webhooks", knativeChecker(ctx, "health")))
 	return o
 }
 
@@ -177,18 +177,17 @@ func (o *Operator) Start(ctx context.Context) {
 	wg.Wait()
 }
 
-func knativeChecker(path string) healthz.Checker {
+func knativeChecker(ctx context.Context, path string) healthz.Checker {
 	return func(req *http.Request) (err error) {
 		defer func() {
 			if err != nil {
-				fmt.Printf("probe failed: %s", err.Error())
+				logging.FromContext(ctx).Errorf("probe failed: %s", err.Error())
 			}
 		}()
 		res, err := http.Get(fmt.Sprintf("http://:%d/%s", knativeinjection.HealthCheckDefaultPort, path))
 		if err != nil {
 			return err
 		}
-
 		if res.StatusCode != http.StatusOK {
 			return fmt.Errorf("%s probe failed, %s", path, lo.Must(io.ReadAll(res.Body)))
 		}


### PR DESCRIPTION
Fixes aws/karpenter/issues/3867

**Description**
Webhook readiness was not considered by probes, leading to brief downtime of the webhook during rolling updates.

Knative hardcodes port 8080, so I moved the metrics port to container port 8000 in a buddy PR. Metrics are still scrapable at the karpenter service on port 8080.

**How was this change tested?**
* Update Provisioner during single pod rolling update


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
