### PR TITLE
fix: Fix `karpenter_nodes_termination_time_seconds` metric not firing

### DIFF
--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -38,13 +38,8 @@ import (
 	"github.com/aws/karpenter-core/pkg/controllers/termination"
 	"github.com/aws/karpenter-core/pkg/controllers/termination/terminator"
 	"github.com/aws/karpenter-core/pkg/events"
-	"github.com/aws/karpenter-core/pkg/metrics"
 	"github.com/aws/karpenter-core/pkg/operator/controller"
 )
-
-func init() {
-	metrics.MustRegister() // Registers cross-controller metrics
-}
 
 func NewControllers(
 	ctx context.Context,

--- a/pkg/controllers/termination/controller.go
+++ b/pkg/controllers/termination/controller.go
@@ -125,6 +125,10 @@ func (c *Controller) removeFinalizer(ctx context.Context, n *v1.Node) error {
 		metrics.NodesTerminatedCounter.With(prometheus.Labels{
 			metrics.ProvisionerLabel: n.Labels[v1alpha5.ProvisionerNameLabelKey],
 		}).Inc()
+		// We use stored.DeletionTimestamp since the api-server may give back a node after the patch without a deletionTimestamp
+		TerminationSummary.With(prometheus.Labels{
+			metrics.ProvisionerLabel: n.Labels[v1alpha5.ProvisionerNameLabelKey],
+		}).Observe(time.Since(stored.DeletionTimestamp.Time).Seconds())
 		logging.FromContext(ctx).Infof("deleted node")
 	}
 	return nil

--- a/pkg/controllers/termination/metrics.go
+++ b/pkg/controllers/termination/metrics.go
@@ -12,7 +12,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package terminator
+package termination
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
@@ -22,7 +22,7 @@ import (
 )
 
 var (
-	terminationSummary = prometheus.NewSummary(
+	TerminationSummary = prometheus.NewSummaryVec(
 		prometheus.SummaryOpts{
 			Namespace:  "karpenter",
 			Subsystem:  "nodes",
@@ -30,9 +30,10 @@ var (
 			Help:       "The time taken between a node's deletion request and the removal of its finalizer",
 			Objectives: metrics.SummaryObjectives(),
 		},
+		[]string{metrics.ProvisionerLabel},
 	)
 )
 
 func init() {
-	crmetrics.Registry.MustRegister(terminationSummary)
+	crmetrics.Registry.MustRegister(TerminationSummary)
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -106,7 +106,7 @@ var (
 	)
 )
 
-func MustRegister() {
+func init() {
 	crmetrics.Registry.MustRegister(MachinesCreatedCounter, MachinesTerminatedCounter, MachinesLaunchedCounter,
 		MachinesRegisteredCounter, MachinesInitializedCounter, NodesCreatedCounter, NodesTerminatedCounter)
 }


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

This metric was erroneously removed in [#176](https://github.com/aws/karpenter-core/pull/176/files#diff-64df72489417909f8ad9a7adac469bb50c6513e5f29ab7265e5ce6e859e02d12R106)

`karpenter_nodes_termination_time_seconds` metric was not firing when nodes were being terminated. This meant that we were not getting summary metrics on the amount of time that it takes to drain and delete nodes on average.

**How was this change tested?**

- `make presubmit`
- Manual Deploy and Viewing Prometheus

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
