### PR TITLE
Ignore `make toolchain` when hitting Cache

### DIFF
--- a/.github/actions/install-deps/action.yaml
+++ b/.github/actions/install-deps/action.yaml
@@ -1,0 +1,20 @@
+name: InstallDependencies
+description: 'Installs Go Downloads and installs Karpenter Dependencies'
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/setup-go@v4
+      with:
+        go-version-file: go.mod
+        check-latest: true
+        cache-dependency-path: "**/go.sum"
+    - uses: actions/cache@v3
+      id: cache-toolchain
+      with:
+        path: |
+          ~/.kubebuilder/bin
+          ~/go/bin
+        key: ${{ runner.os }}-toolchain-cache-${{ hashFiles('hack/toolchain.sh') }}
+    - if: ${{ steps.cache-toolchain.outputs.cache-hit != 'true' }}
+      shell: bash
+      run: make toolchain

--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -14,20 +14,7 @@ jobs:
       K8S_VERSION: ${{ matrix.k8sVersion }}
     steps:
     - uses: actions/checkout@v3
-    - run: sed -En 's/^go[[:space:]]+([[:digit:].]+)$/GO_VERSION=\1/p' go.mod >> $GITHUB_ENV
-    - uses: actions/setup-go@v3
-      with:
-        go-version: ${{ env.GO_VERSION }}
-        check-latest: true
-    - uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-          ~/go/bin/
-          ~/.kubebuilder/bin
-        key: ${{ runner.os }}-go-cache-${{ hashFiles('**/go.sum') }}
-    - run: make toolchain
+    - uses: ./.github/actions/install-deps
     - run: make presubmit
     - uses: shogo82148/actions-goveralls@v1
       with:


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

<!--
If your change is a BREAKING CHANGE, please create or append an entry to the upgrade guide for the next minor version release at `karpenter/website/content/en/preview/upgrade-guide/_index.md`
-->

Fixes # <!-- issue number -->

**Description**

This change leverages the cache used by `setup-go` in `v4` by default which automatically caches the go build cache the go mod package cache. It also checks for cache hits on `actions/cache` and ignores some steps if the cache is hit.

### Before Cache Action

<img width="1143" alt="Screenshot 2023-05-15 at 9 23 15 AM" src="https://github.com/aws/karpenter-core/assets/26334334/f4d2ea10-4c29-4b78-9252-7ab46ec01eeb">

### After Cache Action

<img width="1166" alt="Screenshot 2023-05-15 at 10 09 52 AM" src="https://github.com/aws/karpenter-core/assets/26334334/7259a046-e03b-45f5-933b-b8610f6f7f50">

**How was this change tested?**

* Running GHA and seeing speed-up from not running `make toolchain`

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
