### PR TITLE
chore: enable presubmit tests for k8s v1.25 and v1.26

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
         matrix:
-          k8sVersion: ["1.21.x", "1.22.x", "1.23.x", "1.24.x"]
+          k8sVersion: ["1.21.x", "1.22.x", "1.23.x", "1.24.x", "1.25.x", "1.26.x"]
     env:
       K8S_VERSION: ${{ matrix.k8sVersion }}
     steps:


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

This PR brings v1.25 and v1.26 presubmit tests into the PR CI flow.

**How was this change tested?**

We'll test it here!

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
