### PR TITLE
feat: add provisioner label to deprovisioning metrics

### DIFF
--- a/pkg/controllers/deprovisioning/drift.go
+++ b/pkg/controllers/deprovisioning/drift.go
@@ -64,7 +64,11 @@ func (d *Drift) ComputeCommand(ctx context.Context, nodes ...*Candidate) (Comman
 	if err != nil {
 		return Command{}, fmt.Errorf("filtering candidates, %w", err)
 	}
-	deprovisioningEligibleMachinesGauge.WithLabelValues(d.String()).Set(float64(len(candidates)))
+
+	groupedCandidates := GroupCandidatesByProvisioner(candidates)
+	for provisionerName, group := range groupedCandidates {
+		deprovisioningEligibleMachinesGauge.WithLabelValues(d.String(), provisionerName).Set(float64(len(group)))
+	}
 
 	// Deprovision all empty drifted nodes, as they require no scheduling simulations.
 	if empty := lo.Filter(candidates, func(c *Candidate, _ int) bool {

--- a/pkg/controllers/deprovisioning/emptiness.go
+++ b/pkg/controllers/deprovisioning/emptiness.go
@@ -66,8 +66,12 @@ func (e *Emptiness) ComputeCommand(_ context.Context, candidates ...*Candidate) 
 	emptyCandidates := lo.Filter(candidates, func(cn *Candidate, _ int) bool {
 		return cn.Machine.DeletionTimestamp.IsZero() && len(cn.pods) == 0
 	})
-	deprovisioningEligibleMachinesGauge.WithLabelValues(e.String()).Set(float64(len(candidates)))
 
+	groupedCandidates := GroupCandidatesByProvisioner(candidates)
+	for provisionerName, group := range groupedCandidates {
+		deprovisioningEligibleMachinesGauge.WithLabelValues(e.String(), provisionerName).Set(float64(len(group)))
+	}
+	
 	return Command{
 		candidates: emptyCandidates,
 	}, nil

--- a/pkg/controllers/deprovisioning/emptymachineconsolidation.go
+++ b/pkg/controllers/deprovisioning/emptymachineconsolidation.go
@@ -49,8 +49,11 @@ func (c *EmptyMachineConsolidation) ComputeCommand(ctx context.Context, candidat
 	if err != nil {
 		return Command{}, fmt.Errorf("sorting candidates, %w", err)
 	}
-	deprovisioningEligibleMachinesGauge.WithLabelValues(c.String()).Set(float64(len(candidates)))
-
+	
+	groupedCandidates := GroupCandidatesByProvisioner(candidates)
+	for provisionerName, group := range groupedCandidates {
+		deprovisioningEligibleMachinesGauge.WithLabelValues(c.String(), provisionerName).Set(float64(len(group)))
+	}
 	// select the entirely empty nodes
 	emptyCandidates := lo.Filter(candidates, func(n *Candidate, _ int) bool { return len(n.pods) == 0 })
 	if len(emptyCandidates) == 0 {

--- a/pkg/controllers/deprovisioning/metrics.go
+++ b/pkg/controllers/deprovisioning/metrics.go
@@ -32,6 +32,7 @@ const (
 	deprovisioningSubsystem = "deprovisioning"
 	deprovisionerLabel      = "deprovisioner"
 	actionLabel             = "action"
+	provisionerLabel				= "provisioner"
 )
 
 var (
@@ -57,17 +58,17 @@ var (
 			Namespace: metrics.Namespace,
 			Subsystem: deprovisioningSubsystem,
 			Name:      "actions_performed",
-			Help:      "Number of deprovisioning actions performed. Labeled by deprovisioner.",
+			Help:      "Number of deprovisioning actions performed. Labeled by deprovisioner and provisioner.",
 		},
-		[]string{actionLabel, deprovisionerLabel},
+		[]string{actionLabel, deprovisionerLabel, provisionerLabel},
 	)
 	deprovisioningEligibleMachinesGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: metrics.Namespace,
 			Subsystem: deprovisioningSubsystem,
 			Name:      "eligible_machines",
-			Help:      "Number of machines eligible for deprovisioning by Karpenter. Labeled by deprovisioner",
+			Help:      "Number of machines eligible for deprovisioning by Karpenter. Labeled by deprovisioner and provisioner.",
 		},
-		[]string{deprovisionerLabel},
+		[]string{deprovisionerLabel, provisionerLabel},
 	)
 )

--- a/pkg/controllers/deprovisioning/multimachineconsolidation.go
+++ b/pkg/controllers/deprovisioning/multimachineconsolidation.go
@@ -47,8 +47,11 @@ func (m *MultiMachineConsolidation) ComputeCommand(ctx context.Context, candidat
 	if err != nil {
 		return Command{}, fmt.Errorf("sorting candidates, %w", err)
 	}
-	deprovisioningEligibleMachinesGauge.WithLabelValues(m.String()).Set(float64(len(candidates)))
-
+	
+	groupedCandidates := GroupCandidatesByProvisioner(candidates)
+	for provisionerName, group := range groupedCandidates {
+		deprovisioningEligibleMachinesGauge.WithLabelValues(m.String(), provisionerName).Set(float64(len(group)))
+	}
 	// For now, we will consider up to every machine in the cluster, might be configurable in the future.
 	maxParallel := len(candidates)
 	cmd, err := m.firstNMachineConsolidationOption(ctx, candidates, maxParallel)

--- a/pkg/controllers/deprovisioning/types.go
+++ b/pkg/controllers/deprovisioning/types.go
@@ -136,6 +136,20 @@ func (c *Candidate) lifetimeRemaining(clock clock.Clock) float64 {
 	return remaining
 }
 
+// GroupCandidatesByProvisioner groups a list of candidates by provisioner name
+func GroupCandidatesByProvisioner(candidates []*Candidate) map[string][]*Candidate {
+	groupedCandidates := make(map[string][]*Candidate)
+
+	for _, candidate := range candidates {
+		provisionerName := candidate.provisioner.Name
+		groupedCandidates[provisionerName] = append(groupedCandidates[provisionerName], candidate)
+	}
+
+	return groupedCandidates
+}
+
+
+
 type Command struct {
 	candidates   []*Candidate
 	replacements []*scheduling.Machine


### PR DESCRIPTION
Fixes https://github.com/aws/karpenter/issues/3466

**Description**

Adds an additional `provisioner` label to the following metrics to allow grouping actions by provisioner:
karpenter_deprovisioning_actions_performed
karpenter_deprovisioning_eligible_machines

In addition to the linked issue, this fixes a bug where deprovisioning actions did not decrement the gauge of eligible machines after deprovisioning, leading to the gauge showing a count of already deprovisioned nodes as eligible to be deprovisioned until another cycle of deprovisioning came through, which would then set the gauge directly to the number of eligible machines. Fixed by decrementing the gauge after the wait for deletion was finished.

**How was this change tested?**

This change was tested both through the automated tests already in the repository, as well as multiple cycles of deploying to an EKS cluster with the inflating and deflating of pause images to simulate load, between zero capacity, full capacity, middle capacities, and cycling between combinations of the three.

**Does this change impact docs?**
- [ ] Yes, PR includes docs updates
- [ ] Yes, issue opened: # <!-- issue number -->
- [x] No

**Release Note**

```release-note
Adds a `provisioner` label to deprovisioning metrics, and fixes a bug where eligible machines were not decremented in metrics after deprovisioning.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
