### PR TITLE
fix: Gate nodes associated with a machine based on resolved `.status.providerID`

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -837,8 +837,6 @@ k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 h1:+70TFaan3hfJzs+7VK2o+O
 k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280/go.mod h1:+Axhij7bCpeqhklhUTe3xmOn6bWxolyZEeyaFpjGtl4=
 k8s.io/utils v0.0.0-20221108210102-8e77b1f39fe2 h1:GfD9OzL11kvZN5iArC6oTS7RTj7oJOIfnislxYlqTj8=
 k8s.io/utils v0.0.0-20221108210102-8e77b1f39fe2/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
-knative.dev/pkg v0.0.0-20221123154742-05b694ec4d3a h1:mTDxXL+zRBMz7BcdM3WOgw9FVbmkIN/3cvEj4MeS8zI=
-knative.dev/pkg v0.0.0-20221123154742-05b694ec4d3a/go.mod h1:fckNBPf9bu5/p1RbnOhEauX7r+kfN1zSQupEVtkaYBs=
 knative.dev/pkg v0.0.0-20230502134655-db8a35330281 h1:9mN8O5XO68DKlkzEhFAShUx+O/I+TQR71vmTvYt8oF4=
 knative.dev/pkg v0.0.0-20230502134655-db8a35330281/go.mod h1:2qWPP9Gjh9Q7ETti+WRHnBnGCSCq+6q7m3p/nmUQviE=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=

--- a/pkg/controllers/machine/termination/controller.go
+++ b/pkg/controllers/machine/termination/controller.go
@@ -86,7 +86,7 @@ func (c *Controller) Finalize(ctx context.Context, machine *v1alpha5.Machine) (r
 	if len(nodes) > 0 {
 		return reconcile.Result{}, nil
 	}
-	if machine.Status.ProviderID != "" {
+	if machine.Status.ProviderID != "" || machine.Annotations[v1alpha5.MachineLinkedAnnotationKey] != "" {
 		if err := c.cloudProvider.Delete(ctx, machine); cloudprovider.IgnoreMachineNotFoundError(err) != nil {
 			return reconcile.Result{}, fmt.Errorf("terminating cloudprovider instance, %w", err)
 		}

--- a/pkg/controllers/machine/termination/suite_test.go
+++ b/pkg/controllers/machine/termination/suite_test.go
@@ -21,6 +21,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -90,6 +91,9 @@ var _ = Describe("Termination", func() {
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
 				},
+				Finalizers: []string{
+					v1alpha5.TerminationFinalizer,
+				},
 			},
 			Spec: v1alpha5.MachineSpec{
 				Resources: v1alpha5.ResourceRequirements{
@@ -153,6 +157,26 @@ var _ = Describe("Termination", func() {
 		_, err = cloudProvider.Get(ctx, machine.Status.ProviderID)
 		Expect(cloudprovider.IsMachineNotFoundError(err)).To(BeTrue())
 	})
+	It("should delete the Node if the Machine is linked but doesn't have its providerID resolved yet", func() {
+		node := test.MachineLinkedNode(machine)
+
+		machine.Annotations = lo.Assign(machine.Annotations, map[string]string{v1alpha5.MachineLinkedAnnotationKey: machine.Status.ProviderID})
+		machine.Status.ProviderID = ""
+		ExpectApplied(ctx, env.Client, provisioner, machine, node)
+
+		// Expect the machine to be gone
+		Expect(env.Client.Delete(ctx, machine)).To(Succeed())
+		ExpectReconcileSucceeded(ctx, terminationController, client.ObjectKeyFromObject(machine)) // triggers the node deletion
+		ExpectFinalizersRemoved(ctx, env.Client, node)
+		ExpectNotFound(ctx, env.Client, node)
+
+		ExpectReconcileSucceeded(ctx, terminationController, client.ObjectKeyFromObject(machine)) // now all nodes are gone so machine deletion continues
+		ExpectNotFound(ctx, env.Client, machine, node)
+
+		// Expect the machine to be gone from the cloudprovider
+		_, err := cloudProvider.Get(ctx, machine.Annotations[v1alpha5.MachineLinkedAnnotationKey])
+		Expect(cloudprovider.IsMachineNotFoundError(err)).To(BeTrue())
+	})
 	It("should not delete the Machine until all the Nodes are removed", func() {
 		ExpectApplied(ctx, env.Client, provisioner, machine)
 		ExpectReconcileSucceeded(ctx, machineController, client.ObjectKeyFromObject(machine))
@@ -178,6 +202,7 @@ var _ = Describe("Termination", func() {
 		ExpectNotFound(ctx, env.Client, machine)
 	})
 	It("should not call Delete() on the CloudProvider if the machine hasn't been launched yet", func() {
+		machine.Status.ProviderID = ""
 		ExpectApplied(ctx, env.Client, provisioner, machine)
 
 		// Expect the machine to be gone
@@ -186,5 +211,24 @@ var _ = Describe("Termination", func() {
 
 		Expect(cloudProvider.DeleteCalls).To(HaveLen(0))
 		ExpectNotFound(ctx, env.Client, machine)
+	})
+	It("should not delete nodes without provider ids if the machine hasn't been launched yet", func() {
+		// Generate 10 nodes, none of which have a provider id
+		var nodes []*v1.Node
+		for i := 0; i < 10; i++ {
+			nodes = append(nodes, test.Node())
+		}
+		ExpectApplied(ctx, env.Client, lo.Map(nodes, func(n *v1.Node, _ int) client.Object { return n })...)
+
+		ExpectApplied(ctx, env.Client, provisioner, machine)
+
+		// Expect the machine to be gone
+		Expect(env.Client.Delete(ctx, machine)).To(Succeed())
+		ExpectReconcileSucceeded(ctx, terminationController, client.ObjectKeyFromObject(machine))
+
+		ExpectNotFound(ctx, env.Client, machine)
+		for _, node := range nodes {
+			ExpectExists(ctx, env.Client, node)
+		}
 	})
 })


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

Prior to this change, in the release `v0.28.0-rc.1`, if a Machine failed to launch, the `.status.providerID` of the machine could possibly not be resolved. If this was the case, the Machine would eventually get deleted due to a timeout on registration, causing any nodes associated with the machine to also be removed.

In this case, we were not guarding against the case where the providerID has never been resolved, meaning that we were deleting all nodes that had an empty providerID, meaning that Karpenter would delete nodes that weren't managed by it.

This change guards this case so that the next release `v0.28.0-rc.2` will not terminate these nodes when machines with empty provider ids are removed.

**How was this change tested?**

- `make presubmit`
- Manual Testing of Machine failure deletion

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
