### PR TITLE
fix: Edit the cache for `install-deps` to use K8s version

### DIFF
--- a/.github/actions/install-deps/action.yaml
+++ b/.github/actions/install-deps/action.yaml
@@ -1,5 +1,9 @@
 name: InstallDependencies
 description: 'Installs Go Downloads and installs Karpenter Dependencies'
+inputs:
+  k8sVersion:
+    description: Kubernetes version to use when installing the toolchain
+    default: "1.24.x"
 runs:
   using: "composite"
   steps:
@@ -14,7 +18,7 @@ runs:
         path: |
           ~/.kubebuilder/bin
           ~/go/bin
-        key: ${{ runner.os }}-toolchain-cache-${{ hashFiles('hack/toolchain.sh') }}
+        key: ${{ runner.os }}-${{ inputs.k8sVersion }}-toolchain-cache-${{ hashFiles('hack/toolchain.sh') }}
     - if: ${{ steps.cache-toolchain.outputs.cache-hit != 'true' }}
       shell: bash
-      run: make toolchain
+      run: K8S_VERSION=${{ inputs.k8sVersion }} make toolchain

--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -10,11 +10,11 @@ jobs:
     strategy:
         matrix:
           k8sVersion: ["1.22.x", "1.23.x", "1.24.x", "1.25.x", "1.26.x", "1.27.x"]
-    env:
-      K8S_VERSION: ${{ matrix.k8sVersion }}
     steps:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/install-deps
+      with:
+        k8sVersion: ${{ matrix.K8S_VERSION }}
     - run: make presubmit
     - uses: shogo82148/actions-goveralls@v1
       with:

--- a/pkg/controllers/provisioning/scheduling/topology_test.go
+++ b/pkg/controllers/provisioning/scheduling/topology_test.go
@@ -55,6 +55,9 @@ var _ = Describe("Topology", func() {
 	})
 
 	It("should not spread an invalid label selector", func() {
+		if env.Version.Minor() >= 24 {
+			Skip("Invalid label selector now is denied by admission in K8s >= 1.27.x")
+		}
 		topology := []v1.TopologySpreadConstraint{{
 			TopologyKey:       v1.LabelTopologyZone,
 			WhenUnsatisfiable: v1.DoNotSchedule,


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

- Fixes a caching issues on `.github/actions/install-deps` where the cache wouldn't be differentiated on the K8s Version, which meant that we would use a single K8s version for testing
- Fixes a compatibility issue with a K8s test on 1.27

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
