### PR TITLE
fix: Pass K8s version to make presubmit

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -14,8 +14,8 @@ jobs:
     - uses: actions/checkout@v3
     - uses: ./.github/actions/install-deps
       with:
-        k8sVersion: ${{ matrix.K8S_VERSION }}
-    - run: make presubmit
+        k8sVersion: ${{ matrix.k8sVersion }}
+    - run: K8S_VERSION=${{ matrix.k8sVersion }} make presubmit
     - uses: shogo82148/actions-goveralls@v1
       with:
         path-to-profile: coverage.out


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

- Pass K8s version to make presubmit in `.github/workflows/presubmit.yaml`

**How was this change tested?**


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
