### PR TITLE
perf: allow multi-machine consolidation fallback to single-machine consolidation when mutli-node consolidation validation fails

### DIFF
--- a/pkg/controllers/deprovisioning/multimachineconsolidation.go
+++ b/pkg/controllers/deprovisioning/multimachineconsolidation.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/util/sets"
 	"k8s.io/utils/clock"
+	"knative.dev/pkg/logging"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
@@ -66,7 +67,8 @@ func (m *MultiMachineConsolidation) ComputeCommand(ctx context.Context, candidat
 	}
 
 	if !isValid {
-		return Command{}, fmt.Errorf("command is no longer valid, %s", cmd)
+		logging.FromContext(ctx).Debugf("consolidation command is no longer valid, %s", cmd)
+		return Command{action: actionDoNothing}, nil
 	}
 	return cmd, nil
 }

--- a/pkg/controllers/deprovisioning/suite_test.go
+++ b/pkg/controllers/deprovisioning/suite_test.go
@@ -2224,6 +2224,90 @@ var _ = Describe("Multi-Node Consolidation", func() {
 		// and delete the two large ones
 		ExpectNotFound(ctx, env.Client, node1, node2)
 	})
+	It("should continue to single machine consolidation when multi-machine consolidation fails validation after the node ttl", func() {
+		labels := map[string]string{
+			"app": "test",
+		}
+		// create our RS so we can link a pod to it
+		rs := test.ReplicaSet()
+		ExpectApplied(ctx, env.Client, rs)
+		pods := test.Pods(3, test.PodOptions{
+			ObjectMeta: metav1.ObjectMeta{Labels: labels,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion:         "apps/v1",
+						Kind:               "ReplicaSet",
+						Name:               rs.Name,
+						UID:                rs.UID,
+						Controller:         ptr.Bool(true),
+						BlockOwnerDeletion: ptr.Bool(true),
+					},
+				}}})
+
+		ExpectApplied(ctx, env.Client, rs, pods[0], pods[1], pods[2], machine1, node1, machine2, node2, machine3, node3, prov)
+
+		// bind pods to nodes
+		ExpectManualBinding(ctx, env.Client, pods[0], node1)
+		ExpectManualBinding(ctx, env.Client, pods[1], node2)
+		ExpectManualBinding(ctx, env.Client, pods[2], node3)
+
+		// inform cluster state about nodes and machines
+		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node1, node2, node3}, []*v1alpha5.Machine{machine1, machine2, machine3})
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		finished := atomic.Bool{}
+		go func() {
+			defer GinkgoRecover()
+			defer wg.Done()
+			defer finished.Store(true)
+			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+		}()
+
+		// wait for the controller to block on the validation timeout
+		Eventually(fakeClock.HasWaiters, time.Second*5).Should(BeTrue())
+		// controller should be blocking during the timeout
+		Expect(finished.Load()).To(BeFalse())
+		// and the node should not be deleted yet
+		ExpectExists(ctx, env.Client, node1)
+		ExpectExists(ctx, env.Client, node2)
+		ExpectExists(ctx, env.Client, node3)
+
+		var extraPods []*v1.Pod
+		for i := 0; i < 2; i++ {
+			extraPods = append(extraPods, test.Pod(test.PodOptions{
+				ResourceRequirements: v1.ResourceRequirements{
+					Requests: v1.ResourceList{v1.ResourceCPU: *resource.NewQuantity(1, resource.DecimalSI)},
+				},
+			}))
+		}
+		ExpectApplied(ctx, env.Client, extraPods[0], extraPods[1])
+		// bind the extra pods to node1 and node 2 to make the consolidation decision invalid
+		// we bind to 2 nodes so we can deterministically expect that node3 is consolidated in
+		// single machine consolidation
+		ExpectManualBinding(ctx, env.Client, extraPods[0], node1)
+		ExpectManualBinding(ctx, env.Client, extraPods[1], node2)
+
+		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node1))
+		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node2))
+
+		// advance the clock so that the timeout expires for multi-machine consolidation
+		fakeClock.Step(31 * time.Second)
+
+		// wait for the controller to block on the validation timeout for single machine consolidation
+		Eventually(fakeClock.HasWaiters, time.Second*5).Should(BeTrue())
+		// advance the clock so that the timeout expires for single machine consolidation
+		fakeClock.Step(31 * time.Second)
+
+		// controller should finish
+		Eventually(finished.Load, 10*time.Second).Should(BeTrue())
+		wg.Wait()
+
+		// should have 2 nodes after single machine consolidation deletes one
+		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(2))
+		// and delete node3 in single machine consolidation
+		ExpectNotFound(ctx, env.Client, node3)
+	})
 })
 
 func leastExpensiveInstanceWithZone(zone string) *cloudprovider.InstanceType {


### PR DESCRIPTION
 * This is a cherry-pick of https://github.com/aws/karpenter-core/pull/367 to include in the v0.27.x release line

<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->
 
**Description**
 - Some very dynamic clusters can receive a lot of multi-machine consolidation aborts. This is because multi-machine consolidation computes a consolidation action and then validates that the option is still a valid consolidation plan after 15 seconds to ensure safe consolidation. In a dynamic cluster where pods are being scheduled that changes the consolidation action frequently, will result in multi-machine consolidation not being able to make safe progress. 
 - This change allows multi-machine consolidation to fallback to single machine consolidation if the validation fails on multi-machine consolidation. This will allow a small amount of progress to be made since the probability of a state change on one node is smaller than any some amount >1. 

**How was this change tested?**
 - Set an inflate deployment to 60k replicas w/ consolidation disabled. After a little bit of time, enabled consolidation and noticed, validation failures on multi-machine consolidation but falling back to single machine consolidation. 



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
