### PR TITLE
fix: Convert managed by label to annotation

### DIFF
--- a/pkg/apis/v1alpha5/labels.go
+++ b/pkg/apis/v1alpha5/labels.go
@@ -33,7 +33,6 @@ const (
 // Karpenter specific domains and labels
 const (
 	ProvisionerNameLabelKey = Group + "/provisioner-name"
-	ManagedByLabelKey       = Group + "/managed-by"
 	LabelNodeInitialized    = Group + "/initialized"
 	LabelCapacityType       = Group + "/capacity-type"
 )
@@ -45,6 +44,7 @@ const (
 	EmptinessTimestampAnnotationKey   = Group + "/emptiness-timestamp"
 	VoluntaryDisruptionAnnotationKey  = Group + "/voluntary-disruption"
 	MachineLinkedAnnotationKey        = Group + "/linked"
+	MachineManagedByAnnotationKey     = Group + "/managed-by"
 
 	ProviderCompatabilityAnnotationKey = CompatabilityGroup + "/provider"
 


### PR DESCRIPTION
<!--
Thanks for contributing to Karpenter Core! Before making major changes, please read karpenter.sh/docs/contributing/design-guide
-->

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
BREAKING CHANGE: <-- Include if your change includes a backwards incompatible change.
-->

Fixes # <!-- issue number -->

**Description**

Converts the `karpenter.sh/managed-by` label to be an annotation so that there are no value or length restriction to support longer cluster names and characters that aren't supported by label values (like `:`)

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
