### PR TITLE
fix: Ensure the ephemeral taints are removed before considering the Node Initialized

### DIFF
--- a/pkg/controllers/consistency/suite_test.go
+++ b/pkg/controllers/consistency/suite_test.go
@@ -145,7 +145,7 @@ var _ = Describe("Controller", func() {
 				v1.ResourcePods:   resource.MustParse("10"),
 			}
 			ExpectApplied(ctx, env.Client, provisioner, machine, node)
-			ExpectMakeMachinesReady(ctx, env.Client, machine)
+			ExpectMakeMachinesInitialized(ctx, env.Client, machine)
 			ExpectReconcileSucceeded(ctx, consistencyController, client.ObjectKeyFromObject(machine))
 			Expect(recorder.DetectedEvent("expected 128Gi of resource memory, but found 64Gi (50.0% of expected)")).To(BeTrue())
 		})

--- a/pkg/controllers/deprovisioning/drift_test.go
+++ b/pkg/controllers/deprovisioning/drift_test.go
@@ -69,7 +69,7 @@ var _ = Describe("Drift", func() {
 		ExpectApplied(ctx, env.Client, machine, node, prov)
 
 		// inform cluster state about nodes and machines
-		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
 
 		fakeClock.Step(10 * time.Minute)
 
@@ -89,7 +89,7 @@ var _ = Describe("Drift", func() {
 		ExpectApplied(ctx, env.Client, machine, node, prov)
 
 		// inform cluster state about nodes and machines
-		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
 
 		fakeClock.Step(10 * time.Minute)
 
@@ -107,7 +107,7 @@ var _ = Describe("Drift", func() {
 		ExpectApplied(ctx, env.Client, machine, node, prov)
 
 		// inform cluster state about nodes and machines
-		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
 
 		fakeClock.Step(10 * time.Minute)
 
@@ -124,7 +124,7 @@ var _ = Describe("Drift", func() {
 		ExpectApplied(ctx, env.Client, machine, node, prov)
 
 		// inform cluster state about nodes and machines
-		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
 
 		fakeClock.Step(10 * time.Minute)
 
@@ -170,7 +170,7 @@ var _ = Describe("Drift", func() {
 		ExpectApplied(ctx, env.Client, prov)
 
 		// inform cluster state about nodes and machines
-		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, nodes, machines)
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, nodes, machines)
 
 		var wg sync.WaitGroup
 		ExpectTriggerVerifyAction(&wg)
@@ -215,7 +215,7 @@ var _ = Describe("Drift", func() {
 		ExpectManualBinding(ctx, env.Client, pod, node)
 
 		// inform cluster state about nodes and machines
-		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
 
 		fakeClock.Step(10 * time.Minute)
 
@@ -319,7 +319,7 @@ var _ = Describe("Drift", func() {
 		ExpectManualBinding(ctx, env.Client, pods[2], node)
 
 		// inform cluster state about nodes and machines
-		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
 
 		fakeClock.Step(10 * time.Minute)
 
@@ -387,7 +387,7 @@ var _ = Describe("Drift", func() {
 		ExpectManualBinding(ctx, env.Client, pods[1], node2)
 
 		// inform cluster state about nodes and machines
-		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node, node2}, []*v1alpha5.Machine{machine, machine2})
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node, node2}, []*v1alpha5.Machine{machine, machine2})
 
 		// deprovisioning won't delete the old node until the new node is ready
 		var wg sync.WaitGroup

--- a/pkg/controllers/deprovisioning/expiration_test.go
+++ b/pkg/controllers/deprovisioning/expiration_test.go
@@ -72,7 +72,7 @@ var _ = Describe("Expiration", func() {
 		ExpectApplied(ctx, env.Client, machine, node, prov)
 
 		// inform cluster state about nodes and machines
-		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
 
 		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
 
@@ -85,7 +85,7 @@ var _ = Describe("Expiration", func() {
 		ExpectApplied(ctx, env.Client, machine, node, prov)
 
 		// inform cluster state about nodes and machines
-		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
 
 		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
 
@@ -98,7 +98,7 @@ var _ = Describe("Expiration", func() {
 		ExpectApplied(ctx, env.Client, machine, node, prov)
 
 		// inform cluster state about nodes and machines
-		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
 
 		var wg sync.WaitGroup
 		ExpectTriggerVerifyAction(&wg)
@@ -142,7 +142,7 @@ var _ = Describe("Expiration", func() {
 		ExpectApplied(ctx, env.Client, prov)
 
 		// inform cluster state about nodes and machines
-		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, nodes, machines)
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, nodes, machines)
 
 		var wg sync.WaitGroup
 		ExpectTriggerVerifyAction(&wg)
@@ -223,7 +223,7 @@ var _ = Describe("Expiration", func() {
 		ExpectManualBinding(ctx, env.Client, pods[1], nodeNotExpire)
 
 		// inform cluster state about nodes and machines
-		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{nodeToExpire, nodeNotExpire}, []*v1alpha5.Machine{machineToExpire, machineNotExpire})
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{nodeToExpire, nodeNotExpire}, []*v1alpha5.Machine{machineToExpire, machineNotExpire})
 
 		// deprovisioning won't delete the old node until the new node is ready
 		var wg sync.WaitGroup
@@ -269,7 +269,7 @@ var _ = Describe("Expiration", func() {
 		ExpectManualBinding(ctx, env.Client, pod, node)
 
 		// inform cluster state about nodes and machines
-		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
 
 		// deprovisioning won't delete the old node until the new node is ready
 		var wg sync.WaitGroup
@@ -321,7 +321,7 @@ var _ = Describe("Expiration", func() {
 		ExpectManualBinding(ctx, env.Client, pod, node)
 
 		// inform cluster state about nodes and machines
-		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
 
 		var wg sync.WaitGroup
 		ExpectTriggerVerifyAction(&wg)
@@ -413,7 +413,7 @@ var _ = Describe("Expiration", func() {
 		ExpectManualBinding(ctx, env.Client, pods[2], node)
 
 		// inform cluster state about nodes and machines
-		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
 
 		// deprovisioning won't delete the old machine until the new machine is ready
 		var wg sync.WaitGroup

--- a/pkg/controllers/deprovisioning/suite_test.go
+++ b/pkg/controllers/deprovisioning/suite_test.go
@@ -260,7 +260,7 @@ var _ = Describe("Replace Nodes", func() {
 		ExpectManualBinding(ctx, env.Client, pod, node)
 
 		// inform cluster state about nodes and machines
-		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
 
 		fakeClock.Step(10 * time.Minute)
 
@@ -352,7 +352,7 @@ var _ = Describe("Replace Nodes", func() {
 		ExpectManualBinding(ctx, env.Client, pods[2], node)
 
 		// inform cluster state about nodes and machines
-		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
 
 		fakeClock.Step(10 * time.Minute)
 
@@ -424,7 +424,7 @@ var _ = Describe("Replace Nodes", func() {
 		ExpectManualBinding(ctx, env.Client, pod, node)
 
 		// inform cluster state about nodes and machines
-		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
 
 		fakeClock.Step(10 * time.Minute)
 
@@ -516,7 +516,7 @@ var _ = Describe("Replace Nodes", func() {
 		ExpectManualBinding(ctx, env.Client, pods[2], annotatedNode)
 
 		// inform cluster state about nodes and machines
-		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{regularNode, annotatedNode}, []*v1alpha5.Machine{regularMachine, annotatedMachine})
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{regularNode, annotatedNode}, []*v1alpha5.Machine{regularMachine, annotatedMachine})
 
 		fakeClock.Step(10 * time.Minute)
 
@@ -618,7 +618,7 @@ var _ = Describe("Replace Nodes", func() {
 		ExpectManualBinding(ctx, env.Client, pod, node)
 
 		// inform cluster state about nodes and machines
-		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
 
 		fakeClock.Step(10 * time.Minute)
 		var wg sync.WaitGroup
@@ -733,7 +733,7 @@ var _ = Describe("Replace Nodes", func() {
 		ExpectManualBinding(ctx, env.Client, pod, node)
 
 		// inform cluster state about nodes and machines
-		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
 
 		fakeClock.Step(10 * time.Minute)
 		var wg sync.WaitGroup
@@ -795,7 +795,7 @@ var _ = Describe("Replace Nodes", func() {
 		ExpectManualBinding(ctx, env.Client, pod, node)
 
 		// inform cluster state about nodes and machines
-		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
 
 		fakeClock.Step(10 * time.Minute)
 
@@ -913,7 +913,7 @@ var _ = Describe("Delete Node", func() {
 		ExpectManualBinding(ctx, env.Client, pods[2], node2)
 
 		// inform cluster state about nodes and machines
-		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node1, node2}, []*v1alpha5.Machine{machine1, machine2})
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node1, node2}, []*v1alpha5.Machine{machine1, machine2})
 
 		fakeClock.Step(10 * time.Minute)
 
@@ -978,7 +978,7 @@ var _ = Describe("Delete Node", func() {
 		ExpectManualBinding(ctx, env.Client, pods[2], node2)
 
 		// inform cluster state about nodes and machines
-		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node1, node2}, []*v1alpha5.Machine{machine1, machine2})
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node1, node2}, []*v1alpha5.Machine{machine1, machine2})
 
 		fakeClock.Step(10 * time.Minute)
 
@@ -1029,7 +1029,7 @@ var _ = Describe("Delete Node", func() {
 		ExpectManualBinding(ctx, env.Client, pods[2], node2)
 
 		// inform cluster state about nodes and machines
-		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node1, node2}, []*v1alpha5.Machine{machine1, machine2})
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node1, node2}, []*v1alpha5.Machine{machine1, machine2})
 
 		fakeClock.Step(10 * time.Minute)
 
@@ -1077,7 +1077,7 @@ var _ = Describe("Delete Node", func() {
 		ExpectManualBinding(ctx, env.Client, pods[2], node2)
 
 		// inform cluster state about nodes and machines
-		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node1, node2}, []*v1alpha5.Machine{machine1, machine2})
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node1, node2}, []*v1alpha5.Machine{machine1, machine2})
 
 		fakeClock.Step(10 * time.Minute)
 
@@ -1125,7 +1125,7 @@ var _ = Describe("Delete Node", func() {
 		// inform cluster state about nodes and machines, intentionally leaving node1 as not ready
 		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node1))
 		ExpectReconcileSucceeded(ctx, machineStateController, client.ObjectKeyFromObject(machine1))
-		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node2}, []*v1alpha5.Machine{machine2})
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node2}, []*v1alpha5.Machine{machine2})
 
 		var wg sync.WaitGroup
 		ExpectTriggerVerifyAction(&wg)
@@ -1222,7 +1222,7 @@ var _ = Describe("Delete Node", func() {
 			ExpectManualBinding(ctx, env.Client, pods[i], n)
 
 			if i == elem {
-				ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{n}, []*v1alpha5.Machine{m})
+				ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{n}, []*v1alpha5.Machine{m})
 			} else {
 				ExpectReconcileSucceeded(ctx, machineStateController, client.ObjectKeyFromObject(m))
 				ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(n))
@@ -1274,7 +1274,7 @@ var _ = Describe("Delete Node", func() {
 		})
 		ExpectApplied(ctx, env.Client, consolidatableMachine, consolidatableNode, consolidatablePod)
 		ExpectManualBinding(ctx, env.Client, consolidatablePod, consolidatableNode)
-		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{consolidatableNode}, []*v1alpha5.Machine{consolidatableMachine})
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{consolidatableNode}, []*v1alpha5.Machine{consolidatableMachine})
 
 		var wg sync.WaitGroup
 		ExpectTriggerVerifyAction(&wg)
@@ -1377,7 +1377,7 @@ var _ = Describe("Node Lifetime Consideration", func() {
 		ExpectManualBinding(ctx, env.Client, pods[2], node2)
 
 		// inform cluster state about nodes and machines
-		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node1, node2}, []*v1alpha5.Machine{machine1, machine2})
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node1, node2}, []*v1alpha5.Machine{machine1, machine2})
 
 		fakeClock.SetTime(time.Now())
 
@@ -1493,7 +1493,7 @@ var _ = Describe("Topology Consideration", func() {
 		ExpectManualBinding(ctx, env.Client, pods[2], zone3Node)
 
 		// inform cluster state about nodes and machines
-		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{zone1Node, zone2Node, zone3Node}, []*v1alpha5.Machine{zone1Machine, zone2Machine, zone3Machine})
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{zone1Node, zone2Node, zone3Node}, []*v1alpha5.Machine{zone1Machine, zone2Machine, zone3Machine})
 
 		ExpectSkew(ctx, env.Client, "default", &tsc).To(ConsistOf(1, 1, 1))
 
@@ -1582,7 +1582,7 @@ var _ = Describe("Topology Consideration", func() {
 		ExpectManualBinding(ctx, env.Client, pods[2], zone3Node)
 
 		// inform cluster state about nodes and machines
-		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{zone1Node, zone2Node, zone3Node}, []*v1alpha5.Machine{zone1Machine, zone2Machine, zone3Machine})
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{zone1Node, zone2Node, zone3Node}, []*v1alpha5.Machine{zone1Machine, zone2Machine, zone3Machine})
 
 		fakeClock.Step(10 * time.Minute)
 
@@ -1647,7 +1647,7 @@ var _ = Describe("Empty Nodes", func() {
 		ExpectApplied(ctx, env.Client, machine1, node1, prov)
 
 		// inform cluster state about nodes and machines
-		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node1}, []*v1alpha5.Machine{machine1})
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node1}, []*v1alpha5.Machine{machine1})
 
 		fakeClock.Step(10 * time.Minute)
 
@@ -1668,7 +1668,7 @@ var _ = Describe("Empty Nodes", func() {
 		ExpectApplied(ctx, env.Client, machine1, node1, machine2, node2, prov)
 
 		// inform cluster state about nodes and machines
-		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node1, node2}, []*v1alpha5.Machine{machine1, machine2})
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node1, node2}, []*v1alpha5.Machine{machine1, machine2})
 
 		fakeClock.Step(10 * time.Minute)
 		wg := sync.WaitGroup{}
@@ -1701,7 +1701,7 @@ var _ = Describe("Empty Nodes", func() {
 		ExpectApplied(ctx, env.Client, prov, machine1, node1)
 
 		// inform cluster state about nodes and machines
-		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node1}, []*v1alpha5.Machine{machine1})
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node1}, []*v1alpha5.Machine{machine1})
 
 		fakeClock.Step(10 * time.Minute)
 		wg := sync.WaitGroup{}
@@ -1757,7 +1757,7 @@ var _ = Describe("Empty Nodes", func() {
 		ExpectManualBinding(ctx, env.Client, pod, node1)
 
 		// inform cluster state about nodes and machines
-		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node1}, []*v1alpha5.Machine{machine1})
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node1}, []*v1alpha5.Machine{machine1})
 
 		fakeClock.Step(10 * time.Minute)
 		var wg sync.WaitGroup
@@ -1865,7 +1865,7 @@ var _ = Describe("Consolidation TTL", func() {
 		ExpectManualBinding(ctx, env.Client, pod, node1)
 
 		// inform cluster state about nodes and machines
-		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node1}, []*v1alpha5.Machine{machine1})
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node1}, []*v1alpha5.Machine{machine1})
 
 		var wg sync.WaitGroup
 		wg.Add(1)
@@ -1903,7 +1903,7 @@ var _ = Describe("Consolidation TTL", func() {
 		ExpectApplied(ctx, env.Client, machine1, node1, prov)
 
 		// inform cluster state about nodes and machines
-		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node1}, []*v1alpha5.Machine{machine1})
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node1}, []*v1alpha5.Machine{machine1})
 
 		var wg sync.WaitGroup
 		wg.Add(1)
@@ -1988,7 +1988,7 @@ var _ = Describe("Consolidation TTL", func() {
 		ExpectManualBinding(ctx, env.Client, pods[2], node2)
 
 		// inform cluster state about nodes and machines
-		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node1, node2}, []*v1alpha5.Machine{machine1, machine2})
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node1, node2}, []*v1alpha5.Machine{machine1, machine2})
 
 		var wg sync.WaitGroup
 		wg.Add(1)
@@ -2026,7 +2026,7 @@ var _ = Describe("Consolidation TTL", func() {
 		ExpectApplied(ctx, env.Client, machine1, node1, prov, pod)
 
 		// inform cluster state about nodes and machines
-		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node1}, []*v1alpha5.Machine{machine1})
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node1}, []*v1alpha5.Machine{machine1})
 
 		var wg sync.WaitGroup
 		wg.Add(1)
@@ -2121,7 +2121,7 @@ var _ = Describe("Parallelization", func() {
 		ExpectManualBinding(ctx, env.Client, pod, node)
 
 		// inform cluster state about nodes and machines
-		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
 
 		fakeClock.Step(10 * time.Minute)
 
@@ -2202,7 +2202,7 @@ var _ = Describe("Parallelization", func() {
 		Expect(nodes).To(HaveLen(2))
 		newNode, _ := lo.Find(nodes, func(n *v1.Node) bool { return n.Name != oldNodeName })
 
-		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, nodes, nil)
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, nodes, nil)
 
 		// Wait for the nomination cache to expire
 		time.Sleep(time.Second * 11)
@@ -2305,7 +2305,7 @@ var _ = Describe("Multi-Node Consolidation", func() {
 				}}})
 
 		ExpectApplied(ctx, env.Client, rs, pods[0], pods[1], pods[2], machine1, node1, machine2, node2, machine3, node3, prov)
-		ExpectMakeNodesReady(ctx, env.Client, node1, node2, node3)
+		ExpectMakeNodesInitialized(ctx, env.Client, node1, node2, node3)
 
 		// bind pods to nodes
 		ExpectManualBinding(ctx, env.Client, pods[0], node1)
@@ -2313,7 +2313,7 @@ var _ = Describe("Multi-Node Consolidation", func() {
 		ExpectManualBinding(ctx, env.Client, pods[2], node3)
 
 		// inform cluster state about nodes and machines
-		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node1, node2, node3}, []*v1alpha5.Machine{machine1, machine2, machine3})
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node1, node2, node3}, []*v1alpha5.Machine{machine1, machine2, machine3})
 
 		fakeClock.Step(10 * time.Minute)
 
@@ -2373,7 +2373,7 @@ var _ = Describe("Multi-Node Consolidation", func() {
 			v1.LabelTopologyZone:       leastExpensiveOffering.Zone,
 		})
 		ExpectApplied(ctx, env.Client, rs, pods[0], pods[1], pods[2], machine1, node1, machine2, node2, prov)
-		ExpectMakeNodesReady(ctx, env.Client, node1, node2)
+		ExpectMakeNodesInitialized(ctx, env.Client, node1, node2)
 
 		// bind pods to nodes
 		ExpectManualBinding(ctx, env.Client, pods[0], node1)
@@ -2381,7 +2381,7 @@ var _ = Describe("Multi-Node Consolidation", func() {
 		ExpectManualBinding(ctx, env.Client, pods[2], node2)
 
 		// inform cluster state about nodes and machines
-		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node1, node2}, []*v1alpha5.Machine{machine1, machine2})
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node1, node2}, []*v1alpha5.Machine{machine1, machine2})
 
 		fakeClock.Step(10 * time.Minute)
 
@@ -2434,7 +2434,7 @@ var _ = Describe("Multi-Node Consolidation", func() {
 		ExpectManualBinding(ctx, env.Client, pods[2], node2)
 
 		// inform cluster state about nodes and machines
-		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node1, node2}, []*v1alpha5.Machine{machine1, machine2})
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node1, node2}, []*v1alpha5.Machine{machine1, machine2})
 
 		var wg sync.WaitGroup
 		ExpectMakeNewMachinesReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
@@ -2499,7 +2499,7 @@ var _ = Describe("Multi-Node Consolidation", func() {
 		ExpectManualBinding(ctx, env.Client, pods[2], node3)
 
 		// inform cluster state about nodes and machines
-		ExpectMakeReadyAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node1, node2, node3}, []*v1alpha5.Machine{machine1, machine2, machine3})
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node1, node2, node3}, []*v1alpha5.Machine{machine1, machine2, machine3})
 
 		var wg sync.WaitGroup
 		wg.Add(1)
@@ -2678,8 +2678,8 @@ func ExpectMakeNewMachinesReady(ctx context.Context, c client.Client, wg *sync.W
 						continue
 					}
 					m, n := ExpectMachineDeployedWithOffset(1, ctx, c, cluster, cloudProvider, m)
-					ExpectMakeMachinesReadyWithOffset(1, ctx, c, m)
-					ExpectMakeNodesReadyWithOffset(1, ctx, c, n)
+					ExpectMakeMachinesInitializedWithOffset(1, ctx, c, m)
+					ExpectMakeNodesInitializedWithOffset(1, ctx, c, n)
 
 					machinesMadeReady++
 					existingMachineNames.Insert(m.Name)
@@ -2695,9 +2695,9 @@ func ExpectMakeNewMachinesReady(ctx context.Context, c client.Client, wg *sync.W
 	}()
 }
 
-func ExpectMakeReadyAndStateUpdated(ctx context.Context, c client.Client, nodeStateController, machineStateController controller.Controller, nodes []*v1.Node, machines []*v1alpha5.Machine) {
-	ExpectMakeNodesReadyWithOffset(1, ctx, c, nodes...)
-	ExpectMakeMachinesReadyWithOffset(1, ctx, c, machines...)
+func ExpectMakeInitializedAndStateUpdated(ctx context.Context, c client.Client, nodeStateController, machineStateController controller.Controller, nodes []*v1.Node, machines []*v1alpha5.Machine) {
+	ExpectMakeNodesInitializedWithOffset(1, ctx, c, nodes...)
+	ExpectMakeMachinesInitializedWithOffset(1, ctx, c, machines...)
 
 	// Inform cluster state about node and machine readiness
 	for _, n := range nodes {

--- a/pkg/controllers/machine/lifecycle/initialization_test.go
+++ b/pkg/controllers/machine/lifecycle/initialization_test.go
@@ -18,6 +18,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	cloudproviderapi "k8s.io/cloud-provider/api"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
@@ -61,6 +62,8 @@ var _ = Describe("Initialization", func() {
 			ProviderID: machine.Status.ProviderID,
 		})
 		ExpectApplied(ctx, env.Client, node)
+		ExpectMakeNodesReady(ctx, env.Client, node) // Remove the not-ready taint
+
 		ExpectReconcileSucceeded(ctx, machineController, client.ObjectKeyFromObject(machine))
 
 		machine = ExpectExists(ctx, env.Client, machine)
@@ -120,6 +123,8 @@ var _ = Describe("Initialization", func() {
 			},
 		})
 		ExpectApplied(ctx, env.Client, node)
+		ExpectMakeNodesReady(ctx, env.Client, node) // Remove the not-ready taint
+
 		ExpectReconcileSucceeded(ctx, machineController, client.ObjectKeyFromObject(machine))
 
 		node = ExpectExists(ctx, env.Client, node)
@@ -209,6 +214,8 @@ var _ = Describe("Initialization", func() {
 			},
 		})
 		ExpectApplied(ctx, env.Client, node)
+		ExpectMakeNodesReady(ctx, env.Client, node) // Remove the not-ready taint
+
 		ExpectReconcileSucceeded(ctx, machineController, client.ObjectKeyFromObject(machine))
 
 		machine = ExpectExists(ctx, env.Client, machine)
@@ -257,6 +264,8 @@ var _ = Describe("Initialization", func() {
 			},
 		})
 		ExpectApplied(ctx, env.Client, node)
+		ExpectMakeNodesReady(ctx, env.Client, node) // Remove the not-ready taint
+
 		ExpectReconcileSucceeded(ctx, machineController, client.ObjectKeyFromObject(machine))
 
 		machine = ExpectExists(ctx, env.Client, machine)
@@ -322,6 +331,7 @@ var _ = Describe("Initialization", func() {
 			},
 		})
 		ExpectApplied(ctx, env.Client, node)
+		ExpectMakeNodesReady(ctx, env.Client, node) // Remove the not-ready taint
 
 		// Should add the startup taints to the node
 		ExpectReconcileSucceeded(ctx, machineController, client.ObjectKeyFromObject(machine))
@@ -345,7 +355,7 @@ var _ = Describe("Initialization", func() {
 		Expect(ExpectStatusConditionExists(machine, v1alpha5.MachineRegistered).Status).To(Equal(v1.ConditionTrue))
 		Expect(ExpectStatusConditionExists(machine, v1alpha5.MachineInitialized).Status).To(Equal(v1.ConditionFalse))
 	})
-	It("should consider the Node to be initialized once the startup taints are removed", func() {
+	It("should consider the Node to be initialized once the startupTaints are removed", func() {
 		machine := test.Machine(v1alpha5.Machine{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
@@ -392,8 +402,157 @@ var _ = Describe("Initialization", func() {
 			},
 		})
 		ExpectApplied(ctx, env.Client, node)
+		ExpectMakeNodesReady(ctx, env.Client, node) // Remove the not-ready taint
 
 		// Shouldn't consider the node ready since the startup taints still exist
+		ExpectReconcileSucceeded(ctx, machineController, client.ObjectKeyFromObject(machine))
+		machine = ExpectExists(ctx, env.Client, machine)
+		Expect(ExpectStatusConditionExists(machine, v1alpha5.MachineRegistered).Status).To(Equal(v1.ConditionTrue))
+		Expect(ExpectStatusConditionExists(machine, v1alpha5.MachineInitialized).Status).To(Equal(v1.ConditionFalse))
+
+		node = ExpectExists(ctx, env.Client, node)
+		node.Spec.Taints = []v1.Taint{}
+		ExpectApplied(ctx, env.Client, node)
+
+		// Machine should now be ready since all startup taints are removed
+		ExpectReconcileSucceeded(ctx, machineController, client.ObjectKeyFromObject(machine))
+		machine = ExpectExists(ctx, env.Client, machine)
+		Expect(ExpectStatusConditionExists(machine, v1alpha5.MachineRegistered).Status).To(Equal(v1.ConditionTrue))
+		Expect(ExpectStatusConditionExists(machine, v1alpha5.MachineInitialized).Status).To(Equal(v1.ConditionTrue))
+	})
+	It("should not consider the Node to be initialized when all ephemeralTaints aren't removed", func() {
+		machine := test.Machine(v1alpha5.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
+				},
+			},
+			Spec: v1alpha5.MachineSpec{
+				Resources: v1alpha5.ResourceRequirements{
+					Requests: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("2"),
+						v1.ResourceMemory: resource.MustParse("50Mi"),
+						v1.ResourcePods:   resource.MustParse("5"),
+					},
+				},
+				StartupTaints: []v1.Taint{
+					{
+						Key:    "custom-startup-taint",
+						Effect: v1.TaintEffectNoSchedule,
+						Value:  "custom-startup-value",
+					},
+					{
+						Key:    "other-custom-startup-taint",
+						Effect: v1.TaintEffectNoExecute,
+						Value:  "other-custom-startup-value",
+					},
+				},
+			},
+		})
+		ExpectApplied(ctx, env.Client, provisioner, machine)
+		ExpectReconcileSucceeded(ctx, machineController, client.ObjectKeyFromObject(machine))
+		machine = ExpectExists(ctx, env.Client, machine)
+
+		node := test.Node(test.NodeOptions{
+			ProviderID: machine.Status.ProviderID,
+			Capacity: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("10"),
+				v1.ResourceMemory: resource.MustParse("100Mi"),
+				v1.ResourcePods:   resource.MustParse("110"),
+			},
+			Allocatable: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("8"),
+				v1.ResourceMemory: resource.MustParse("80Mi"),
+				v1.ResourcePods:   resource.MustParse("110"),
+			},
+			Taints: []v1.Taint{
+				{
+					Key:    v1.TaintNodeNotReady,
+					Effect: v1.TaintEffectNoSchedule,
+				},
+				{
+					Key:    v1.TaintNodeUnreachable,
+					Effect: v1.TaintEffectNoSchedule,
+				},
+				{
+					Key:    cloudproviderapi.TaintExternalCloudProvider,
+					Effect: v1.TaintEffectNoSchedule,
+					Value:  "true",
+				},
+			},
+		})
+		ExpectApplied(ctx, env.Client, node)
+
+		// Shouldn't consider the node ready since the ephemeral taints still exist
+		ExpectReconcileSucceeded(ctx, machineController, client.ObjectKeyFromObject(machine))
+		machine = ExpectExists(ctx, env.Client, machine)
+		Expect(ExpectStatusConditionExists(machine, v1alpha5.MachineRegistered).Status).To(Equal(v1.ConditionTrue))
+		Expect(ExpectStatusConditionExists(machine, v1alpha5.MachineInitialized).Status).To(Equal(v1.ConditionFalse))
+	})
+	It("should consider the Node to be initialized once the ephemeralTaints are removed", func() {
+		machine := test.Machine(v1alpha5.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
+				},
+			},
+			Spec: v1alpha5.MachineSpec{
+				Resources: v1alpha5.ResourceRequirements{
+					Requests: v1.ResourceList{
+						v1.ResourceCPU:    resource.MustParse("2"),
+						v1.ResourceMemory: resource.MustParse("50Mi"),
+						v1.ResourcePods:   resource.MustParse("5"),
+					},
+				},
+				StartupTaints: []v1.Taint{
+					{
+						Key:    "custom-startup-taint",
+						Effect: v1.TaintEffectNoSchedule,
+						Value:  "custom-startup-value",
+					},
+					{
+						Key:    "other-custom-startup-taint",
+						Effect: v1.TaintEffectNoExecute,
+						Value:  "other-custom-startup-value",
+					},
+				},
+			},
+		})
+		ExpectApplied(ctx, env.Client, provisioner, machine)
+		ExpectReconcileSucceeded(ctx, machineController, client.ObjectKeyFromObject(machine))
+		machine = ExpectExists(ctx, env.Client, machine)
+
+		node := test.Node(test.NodeOptions{
+			ProviderID: machine.Status.ProviderID,
+			Capacity: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("10"),
+				v1.ResourceMemory: resource.MustParse("100Mi"),
+				v1.ResourcePods:   resource.MustParse("110"),
+			},
+			Allocatable: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("8"),
+				v1.ResourceMemory: resource.MustParse("80Mi"),
+				v1.ResourcePods:   resource.MustParse("110"),
+			},
+			Taints: []v1.Taint{
+				{
+					Key:    v1.TaintNodeNotReady,
+					Effect: v1.TaintEffectNoSchedule,
+				},
+				{
+					Key:    v1.TaintNodeUnreachable,
+					Effect: v1.TaintEffectNoSchedule,
+				},
+				{
+					Key:    cloudproviderapi.TaintExternalCloudProvider,
+					Effect: v1.TaintEffectNoSchedule,
+					Value:  "true",
+				},
+			},
+		})
+		ExpectApplied(ctx, env.Client, node)
+
+		// Shouldn't consider the node ready since the ephemeral taints still exist
 		ExpectReconcileSucceeded(ctx, machineController, client.ObjectKeyFromObject(machine))
 		machine = ExpectExists(ctx, env.Client, machine)
 		Expect(ExpectStatusConditionExists(machine, v1alpha5.MachineRegistered).Status).To(Equal(v1.ConditionTrue))

--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -1843,8 +1843,8 @@ var _ = Describe("In-Flight Nodes", func() {
 
 			// Make one of the nodes and machines initialized
 			elem := rand.Intn(100) //nolint:gosec
-			ExpectMakeMachinesReady(ctx, env.Client, machines[elem])
-			ExpectMakeNodesReady(ctx, env.Client, nodes[elem])
+			ExpectMakeMachinesInitialized(ctx, env.Client, machines[elem])
+			ExpectMakeNodesInitialized(ctx, env.Client, nodes[elem])
 			ExpectReconcileSucceeded(ctx, machineStateController, client.ObjectKeyFromObject(machines[elem]))
 			ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(nodes[elem]))
 
@@ -1881,8 +1881,8 @@ var _ = Describe("In-Flight Nodes", func() {
 			}
 
 			// Make one of the nodes and machines initialized
-			ExpectMakeMachinesReady(ctx, env.Client, machines[elem])
-			ExpectMakeNodesReady(ctx, env.Client, node)
+			ExpectMakeMachinesInitialized(ctx, env.Client, machines[elem])
+			ExpectMakeNodesInitialized(ctx, env.Client, node)
 			ExpectReconcileSucceeded(ctx, machineStateController, client.ObjectKeyFromObject(machines[elem]))
 			ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node))
 

--- a/pkg/scheduling/taints.go
+++ b/pkg/scheduling/taints.go
@@ -20,7 +20,14 @@ import (
 	"github.com/samber/lo"
 	"go.uber.org/multierr"
 	v1 "k8s.io/api/core/v1"
+	cloudproviderapi "k8s.io/cloud-provider/api"
 )
+
+var KnownEphemeralTaints = []v1.Taint{
+	{Key: v1.TaintNodeNotReady, Effect: v1.TaintEffectNoSchedule},
+	{Key: v1.TaintNodeUnreachable, Effect: v1.TaintEffectNoSchedule},
+	{Key: cloudproviderapi.TaintExternalCloudProvider, Effect: v1.TaintEffectNoSchedule, Value: "true"},
+}
 
 // Taints is a decorated alias type for []v1.Taint
 type Taints []v1.Taint


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

- This updates the initialization logic to ensure that all known ephemeral taints that become present on the Node when the Node first registers are removed before Karpenter begins to consider the Node for deprovisioning
- This is particularly critical for the `node.cloudprovider.kubernetes.io/uninitialized` taint which is added to the Node until the external cloudprovider removes its taint to mark it as registered

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
