### PR TITLE
test: Propagate discovery label to pods owned by deployment

### DIFF
--- a/pkg/test/deployment.go
+++ b/pkg/test/deployment.go
@@ -56,10 +56,8 @@ func Deployment(overrides ...DeploymentOptions) *appsv1.Deployment {
 			Replicas: ptr.Int32(options.Replicas),
 			Selector: &metav1.LabelSelector{MatchLabels: options.PodOptions.Labels},
 			Template: v1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: options.PodOptions.Labels,
-				},
-				Spec: pod.Spec,
+				ObjectMeta: ObjectMeta(options.PodOptions.ObjectMeta),
+				Spec:       pod.Spec,
 			},
 		},
 	}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

- Propagate `testing.karpenter.sh` discovery label to pods owned by deployment so that pods that are created through this method will be properly waited for during the cleanup phase.

**How was this change tested?**

`/karpenter snapshot`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
