### PR TITLE
chore: Use loopback address to call knative readiness/liveness internally

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -179,7 +179,7 @@ func (o *Operator) Start(ctx context.Context) {
 
 func knativeChecker(path string) healthz.Checker {
 	return func(req *http.Request) (err error) {
-		res, err := http.Get(fmt.Sprintf("http://:%d/%s", knativeinjection.HealthCheckDefaultPort, path))
+		res, err := http.Get(fmt.Sprintf("http://localhost:%d/%s", knativeinjection.HealthCheckDefaultPort, path))
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes: https://github.com/aws/karpenter/issues/4154

**Description**

Use loopback address to call knative readiness/liveness internally so that `no_proxy` can be properly enabled to not proxy the request outside the pod.

**How was this change tested?**

`/karpenter snapshot`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
