### PR TITLE
chore: Add `karpenter.sh/registered` label

### DIFF
--- a/pkg/apis/v1alpha5/labels.go
+++ b/pkg/apis/v1alpha5/labels.go
@@ -34,6 +34,7 @@ const (
 const (
 	ProvisionerNameLabelKey = Group + "/provisioner-name"
 	LabelNodeInitialized    = Group + "/initialized"
+	LabelNodeRegistered     = Group + "/registered"
 	LabelCapacityType       = Group + "/capacity-type"
 )
 

--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -1990,6 +1990,7 @@ var _ = Describe("In-Flight Nodes", func() {
 			machine1 := bindings.Get(initialPod).Machine
 			node1 := bindings.Get(initialPod).Node
 			machine1.StatusConditions().MarkTrue(v1alpha5.MachineInitialized)
+			node1.Labels = lo.Assign(node1.Labels, map[string]string{v1alpha5.LabelNodeInitialized: "true"})
 
 			// delete the pod so that the node is empty
 			ExpectDeleted(ctx, env.Client, initialPod)
@@ -2057,6 +2058,8 @@ var _ = Describe("In-Flight Nodes", func() {
 			machine1 := bindings.Get(initialPod).Machine
 			node1 := bindings.Get(initialPod).Node
 			machine1.StatusConditions().MarkTrue(v1alpha5.MachineInitialized)
+			node1.Labels = lo.Assign(node1.Labels, map[string]string{v1alpha5.LabelNodeInitialized: "true"})
+
 			node1.Spec.Taints = []v1.Taint{startupTaint}
 			node1.Status.Capacity = v1.ResourceList{v1.ResourcePods: resource.MustParse("10")}
 			ExpectApplied(ctx, env.Client, machine1, node1)

--- a/pkg/controllers/state/suite_test.go
+++ b/pkg/controllers/state/suite_test.go
@@ -534,7 +534,9 @@ var _ = Describe("Inflight Nodes", func() {
 		ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(node))
 
 		ExpectMakeMachinesInitialized(ctx, env.Client, machine)
+		ExpectMakeNodesInitialized(ctx, env.Client, node)
 		ExpectReconcileSucceeded(ctx, machineController, client.ObjectKeyFromObject(machine))
+		ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(node))
 
 		ExpectStateNodeCount("==", 1)
 		stateNode := ExpectStateNodeExists(node)

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -336,6 +336,7 @@ func ExpectMachineDeployedWithOffset(offset int, ctx context.Context, c client.C
 
 	// Mock the machine launch and node joining at the apiserver
 	node := test.MachineLinkedNode(m)
+	node.Labels = lo.Assign(node.Labels, map[string]string{v1alpha5.LabelNodeRegistered: "true"})
 	ExpectAppliedWithOffset(offset+1, ctx, c, m, node)
 	ExpectWithOffset(offset+1, cluster.UpdateNode(ctx, node)).To(Succeed())
 	cluster.UpdateMachine(m)
@@ -381,6 +382,7 @@ func ExpectMakeNodesInitializedWithOffset(offset int, ctx context.Context, c cli
 	ExpectMakeNodesReadyWithOffset(offset+1, ctx, c, nodes...)
 
 	for i := range nodes {
+		nodes[i].Labels[v1alpha5.LabelNodeRegistered] = "true"
 		nodes[i].Labels[v1alpha5.LabelNodeInitialized] = "true"
 		ExpectAppliedWithOffset(offset+1, ctx, c, nodes[i])
 	}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

- Adds the `karpenter.sh/registered` label to keep internal data consistency within the Node after all the labels, annotations, and taints have been properly propagated onto the Node after registration

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
