### PR TITLE
feat: Adding static drift hash annotation

### DIFF
--- a/pkg/apis/v1alpha5/labels.go
+++ b/pkg/apis/v1alpha5/labels.go
@@ -45,6 +45,7 @@ const (
 	EmptinessTimestampAnnotationKey   = Group + "/emptiness-timestamp"
 	MachineLinkedAnnotationKey        = Group + "/linked"
 	MachineManagedByAnnotationKey     = Group + "/managed-by"
+	ProvisionerHashAnnotationKey      = Group + "/provisioner-hash"
 
 	ProviderCompatabilityAnnotationKey = CompatabilityGroup + "/provider"
 )

--- a/pkg/controllers/provisioner/controller.go
+++ b/pkg/controllers/provisioner/controller.go
@@ -1,0 +1,71 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provisioner
+
+import (
+	"context"
+
+	"github.com/samber/lo"
+	"k8s.io/apimachinery/pkg/api/equality"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
+	corecontroller "github.com/aws/karpenter-core/pkg/operator/controller"
+)
+
+// Controller is provisioner hash controller that constructs a hash based on the felids that are considered for
+// static drift from the provisioner. The hash is placed in the provisioner.objectmeta.Annotation for increased observability.
+// The provisioner hash should be found on each machine that is owned that by the provisioner.
+type Controller struct {
+	kubeClient client.Client
+}
+
+func NewController(kubeClient client.Client) corecontroller.Controller {
+	return corecontroller.Typed[*v1alpha5.Provisioner](kubeClient, &Controller{
+		kubeClient: kubeClient,
+	})
+}
+
+func (c *Controller) Name() string {
+	return "provisioner.hash"
+}
+
+// Reconcile the resource
+func (c *Controller) Reconcile(ctx context.Context, p *v1alpha5.Provisioner) (reconcile.Result, error) {
+	stored := p.DeepCopy()
+
+	provisionerHash := p.Hash()
+	p.ObjectMeta.Annotations = lo.Assign(p.ObjectMeta.Annotations, map[string]string{v1alpha5.ProvisionerHashAnnotationKey: provisionerHash})
+
+	if !equality.Semantic.DeepEqual(stored, p) {
+		if err := c.kubeClient.Patch(ctx, p, client.MergeFrom(stored)); err != nil {
+			return reconcile.Result{}, client.IgnoreNotFound(err)
+		}
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (c *Controller) Builder(_ context.Context, m manager.Manager) corecontroller.Builder {
+	return corecontroller.Adapt(controllerruntime.
+		NewControllerManagedBy(m).
+		For(&v1alpha5.Provisioner{}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: 10}),
+	)
+}

--- a/pkg/controllers/provisioner/suite_test.go
+++ b/pkg/controllers/provisioner/suite_test.go
@@ -1,0 +1,125 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provisioner_test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	. "knative.dev/pkg/logging/testing"
+	"knative.dev/pkg/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/aws/karpenter-core/pkg/apis"
+	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
+	provcontroller "github.com/aws/karpenter-core/pkg/controllers/provisioner"
+	"github.com/aws/karpenter-core/pkg/operator/controller"
+	"github.com/aws/karpenter-core/pkg/operator/scheme"
+	"github.com/aws/karpenter-core/pkg/test"
+	. "github.com/aws/karpenter-core/pkg/test/expectations"
+)
+
+var provisionerController controller.Controller
+var provisioner *v1alpha5.Provisioner
+var ctx context.Context
+var env *test.Environment
+
+func TestAPIs(t *testing.T) {
+	ctx = TestContextWithLogger(t)
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Controllers/Provisioner")
+}
+
+var _ = BeforeSuite(func() {
+	env = test.NewEnvironment(scheme.Scheme, test.WithCRDs(apis.CRDs...))
+	provisionerController = provcontroller.NewController(env.Client)
+	provisioner = test.Provisioner(test.ProvisionerOptions{
+		Taints: []v1.Taint{
+			{
+				Key:    "key",
+				Effect: v1.TaintEffectNoExecute,
+			},
+		},
+		StartupTaints: []v1.Taint{
+			{
+				Key:    "key",
+				Effect: v1.TaintEffectNoExecute,
+			},
+		},
+		Labels: map[string]string{
+			"keyLabel": "valueLabel",
+		},
+		Kubelet: &v1alpha5.KubeletConfiguration{
+			MaxPods: ptr.Int32(10),
+		},
+		Annotations: map[string]string{
+			"keyAnnotation":  "valueAnnotation",
+			"keyAnnotation2": "valueAnnotation2",
+		},
+	})
+})
+
+var _ = AfterSuite(func() {
+	Expect(env.Stop()).To(Succeed(), "Failed to stop environment")
+})
+
+var _ = Describe("Provisioner Static Drift Hash", func() {
+	It("should update the static drift hash when provisioner static field is updated", func() {
+		ExpectApplied(ctx, env.Client, provisioner)
+		ExpectReconcileSucceeded(ctx, provisionerController, client.ObjectKeyFromObject(provisioner))
+		provisioner = ExpectExists(ctx, env.Client, provisioner)
+
+		expectedHash := provisioner.Hash()
+		Expect(provisioner.ObjectMeta.Annotations[v1alpha5.ProvisionerHashAnnotationKey]).To(Equal(expectedHash))
+
+		provisioner.Spec.Labels = map[string]string{"keyLabeltest": "valueLabeltest"}
+		provisioner.Spec.Annotations = map[string]string{"keyAnnotation2": "valueAnnotation2", "keyAnnotation": "valueAnnotation"}
+		ExpectReconcileSucceeded(ctx, provisionerController, client.ObjectKeyFromObject(provisioner))
+		provisioner = ExpectExists(ctx, env.Client, provisioner)
+
+		expectedHashTwo := provisioner.Hash()
+		Expect(provisioner.ObjectMeta.Annotations[v1alpha5.ProvisionerHashAnnotationKey]).To(Equal(expectedHashTwo))
+	})
+	It("should not update the static drift hash when provisioner behavior field is updated", func() {
+		ExpectApplied(ctx, env.Client, provisioner)
+		ExpectReconcileSucceeded(ctx, provisionerController, client.ObjectKeyFromObject(provisioner))
+		provisioner = ExpectExists(ctx, env.Client, provisioner)
+
+		expectedHash := provisioner.Hash()
+		Expect(provisioner.ObjectMeta.Annotations[v1alpha5.ProvisionerHashAnnotationKey]).To(Equal(expectedHash))
+
+		provisioner.Spec.Limits = &v1alpha5.Limits{Resources: v1.ResourceList{"cpu": resource.MustParse("16")}}
+		provisioner.Spec.Consolidation = &v1alpha5.Consolidation{Enabled: lo.ToPtr(true)}
+		provisioner.Spec.TTLSecondsAfterEmpty = lo.ToPtr(int64(30))
+		provisioner.Spec.TTLSecondsUntilExpired = lo.ToPtr(int64(50))
+		provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
+			{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test"}},
+			{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpGt, Values: []string{"1"}},
+			{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpLt, Values: []string{"1"}},
+		}
+		provisioner.Spec.Provider = &v1alpha5.Provider{}
+		provisioner.Spec.ProviderRef = &v1alpha5.MachineTemplateRef{Kind: "NodeTemplate", Name: "default"}
+		provisioner.Spec.Weight = lo.ToPtr(int32(80))
+		ExpectReconcileSucceeded(ctx, provisionerController, client.ObjectKeyFromObject(provisioner))
+		provisioner = ExpectExists(ctx, env.Client, provisioner)
+
+		Expect(provisioner.ObjectMeta.Annotations[v1alpha5.ProvisionerHashAnnotationKey]).To(Equal(expectedHash))
+	})
+})

--- a/pkg/controllers/provisioning/scheduling/machinetemplate.go
+++ b/pkg/controllers/provisioning/scheduling/machinetemplate.go
@@ -81,11 +81,16 @@ func (i *MachineTemplate) ToMachine(owner *v1alpha5.Provisioner) *v1alpha5.Machi
 	i.Requirements.Add(scheduling.NewRequirement(v1.LabelInstanceTypeStable, v1.NodeSelectorOpIn, lo.Map(instanceTypes, func(i *cloudprovider.InstanceType, _ int) string {
 		return i.Name
 	})...))
+	provisionerDriftHash := owner.Hash()
 	m := &v1alpha5.Machine{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: fmt.Sprintf("%s-", i.ProvisionerName),
-			Annotations:  lo.Assign(i.Annotations, v1alpha5.ProviderAnnotation(i.Provider)),
-			Labels:       i.Labels,
+			Annotations: lo.Assign(
+				i.Annotations,
+				v1alpha5.ProviderAnnotation(i.Provider),
+				map[string]string{v1alpha5.ProvisionerHashAnnotationKey: provisionerDriftHash},
+			),
+			Labels: i.Labels,
 			OwnerReferences: []metav1.OwnerReference{
 				{
 					APIVersion:         v1alpha5.SchemeGroupVersion.String(),


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
docs:            <-- Documentation change that does not impact code
chore:           <-- Metadata changes such as dependency update or configuration files
test:            <-- Test changes that do not impact behavior
perf:            <-- Code changes that improve performance but do not impact behavior
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Karpenter will create a provisioner hash of the fields that the team considers to be statically drifted 
- The will contain the values of each of those fields 

**How was this change tested?**
- `make battletest`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
