### PR TITLE
fix: Consider existing capacity for scheduling

### DIFF
--- a/pkg/controllers/deprovisioning/helpers.go
+++ b/pkg/controllers/deprovisioning/helpers.go
@@ -30,6 +30,7 @@ import (
 	"github.com/aws/karpenter-core/pkg/controllers/state"
 	"github.com/aws/karpenter-core/pkg/events"
 	"github.com/aws/karpenter-core/pkg/scheduling"
+	nodeutils "github.com/aws/karpenter-core/pkg/utils/node"
 	"github.com/aws/karpenter-core/pkg/utils/pod"
 
 	v1 "k8s.io/api/core/v1"
@@ -116,7 +117,7 @@ func simulateScheduling(ctx context.Context, kubeClient client.Client, cluster *
 	// to schedule since we want to assume that we can delete a node and its pods will immediately
 	// move to an existing node which won't occur if that node isn't ready.
 	for _, n := range results.ExistingNodes {
-		if !n.Initialized() {
+		if !n.Initialized() || nodeutils.GetCondition(n.Node, v1.NodeReady).Status != v1.ConditionTrue {
 			for _, p := range n.Pods {
 				results.PodErrors[p] = fmt.Errorf("would schedule against a non-initialized node %s", n.Name())
 			}

--- a/pkg/controllers/deprovisioning/suite_test.go
+++ b/pkg/controllers/deprovisioning/suite_test.go
@@ -931,6 +931,60 @@ var _ = Describe("Delete Node", func() {
 		// and delete the old one
 		ExpectNotFound(ctx, env.Client, machine2, node2)
 	})
+	It("can delete nodes, when non-Karpenter capacity can fit pods", func() {
+		labels := map[string]string{
+			"app": "test",
+		}
+		unmanagedNode := test.Node(test.NodeOptions{
+			ProviderID: test.RandomProviderID(),
+			Allocatable: map[v1.ResourceName]resource.Quantity{
+				v1.ResourceCPU:  resource.MustParse("32"),
+				v1.ResourcePods: resource.MustParse("100"),
+			},
+		})
+		// create our RS so we can link a pod to it
+		rs := test.ReplicaSet()
+		ExpectApplied(ctx, env.Client, rs)
+		pods := test.Pods(3, test.PodOptions{
+			ObjectMeta: metav1.ObjectMeta{Labels: labels,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion:         "apps/v1",
+						Kind:               "ReplicaSet",
+						Name:               rs.Name,
+						UID:                rs.UID,
+						Controller:         ptr.Bool(true),
+						BlockOwnerDeletion: ptr.Bool(true),
+					},
+				},
+			},
+		})
+		ExpectApplied(ctx, env.Client, rs, pods[0], pods[1], pods[2], machine1, node1, unmanagedNode, prov)
+
+		// bind pods to node
+		ExpectManualBinding(ctx, env.Client, pods[0], node1)
+		ExpectManualBinding(ctx, env.Client, pods[1], node1)
+		ExpectManualBinding(ctx, env.Client, pods[2], node1)
+
+		// inform cluster state about nodes and machines
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node1, unmanagedNode}, []*v1alpha5.Machine{machine1})
+
+		fakeClock.Step(10 * time.Minute)
+
+		var wg sync.WaitGroup
+		ExpectTriggerVerifyAction(&wg)
+		ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+		wg.Wait()
+
+		// Cascade any deletion of the machine to the node
+		ExpectMachinesCascadeDeletion(ctx, env.Client, machine1)
+
+		// we can fit all of our pod capacity on the unmanaged node
+		Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(0))
+		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
+		// and delete the old one
+		ExpectNotFound(ctx, env.Client, machine1, node1)
+	})
 	It("can delete nodes, considers PDB", func() {
 		var nl v1.NodeList
 		Expect(env.Client.List(ctx, &nl)).To(Succeed())

--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -265,12 +265,7 @@ func (s *Scheduler) add(ctx context.Context, pod *v1.Pod) error {
 }
 
 func (s *Scheduler) calculateExistingMachines(stateNodes []*state.StateNode, daemonSetPods []*v1.Pod) {
-	// create our existing nodes
 	for _, node := range stateNodes {
-		if !node.Owned() {
-			// ignoring this node as it wasn't launched by us
-			continue
-		}
 		// Calculate any daemonsets that should schedule to the inflight node
 		var daemons []*v1.Pod
 		for _, p := range daemonSetPods {

--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -1821,79 +1821,6 @@ var _ = Describe("In-Flight Nodes", func() {
 		node2 := ExpectScheduled(ctx, env.Client, secondPod)
 		Expect(node1.Name).ToNot(Equal(node2.Name))
 	})
-	Context("Ordering Existing Machines", func() {
-		It("should order initialized nodes for scheduling un-initialized nodes", func() {
-			ExpectApplied(ctx, env.Client, provisioner)
-
-			var machines []*v1alpha5.Machine
-			var nodes []*v1.Node
-			for i := 0; i < 100; i++ {
-				m := test.Machine(v1alpha5.Machine{
-					ObjectMeta: metav1.ObjectMeta{
-						Labels: map[string]string{
-							v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
-						},
-					},
-				})
-				ExpectApplied(ctx, env.Client, m)
-				m, n := ExpectMachineDeployed(ctx, env.Client, cluster, cloudProvider, m)
-				machines = append(machines, m)
-				nodes = append(nodes, n)
-			}
-
-			// Make one of the nodes and machines initialized
-			elem := rand.Intn(100) //nolint:gosec
-			ExpectMakeMachinesInitialized(ctx, env.Client, machines[elem])
-			ExpectMakeNodesInitialized(ctx, env.Client, nodes[elem])
-			ExpectReconcileSucceeded(ctx, machineStateController, client.ObjectKeyFromObject(machines[elem]))
-			ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(nodes[elem]))
-
-			pod := test.UnschedulablePod()
-			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
-			scheduledNode := ExpectScheduled(ctx, env.Client, pod)
-
-			// Expect that the scheduled node is equal to the ready node since it's initialized
-			Expect(scheduledNode.Name).To(Equal(nodes[elem].Name))
-		})
-		It("should order initialized nodes for scheduling un-initialized nodes when all other nodes are inflight", func() {
-			ExpectApplied(ctx, env.Client, provisioner)
-
-			var machines []*v1alpha5.Machine
-			var node *v1.Node
-			elem := rand.Intn(100) // The machine/node that will be marked as initialized
-			for i := 0; i < 100; i++ {
-				m := test.Machine(v1alpha5.Machine{
-					ObjectMeta: metav1.ObjectMeta{
-						Labels: map[string]string{
-							v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
-						},
-					},
-				})
-				ExpectApplied(ctx, env.Client, m)
-				if i == elem {
-					m, node = ExpectMachineDeployed(ctx, env.Client, cluster, cloudProvider, m)
-				} else {
-					var err error
-					m, err = ExpectMachineDeployedNoNode(ctx, env.Client, cluster, cloudProvider, m)
-					Expect(err).ToNot(HaveOccurred())
-				}
-				machines = append(machines, m)
-			}
-
-			// Make one of the nodes and machines initialized
-			ExpectMakeMachinesInitialized(ctx, env.Client, machines[elem])
-			ExpectMakeNodesInitialized(ctx, env.Client, node)
-			ExpectReconcileSucceeded(ctx, machineStateController, client.ObjectKeyFromObject(machines[elem]))
-			ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node))
-
-			pod := test.UnschedulablePod()
-			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
-			scheduledNode := ExpectScheduled(ctx, env.Client, pod)
-
-			// Expect that the scheduled node is equal to node3 since it's initialized
-			Expect(scheduledNode.Name).To(Equal(node.Name))
-		})
-	})
 	Context("Topology", func() {
 		It("should balance pods across zones with in-flight newNodes", func() {
 			labels := map[string]string{"foo": "bar"}
@@ -2337,6 +2264,131 @@ var _ = Describe("In-Flight Nodes", func() {
 		Expect(env.Client.List(ctx, &nodes)).To(Succeed())
 		// shouldn't create a second node
 		Expect(nodes.Items).To(HaveLen(1))
+	})
+	It("should order initialized nodes for scheduling un-initialized nodes when all other nodes are inflight", func() {
+		ExpectApplied(ctx, env.Client, provisioner)
+
+		var machines []*v1alpha5.Machine
+		var node *v1.Node
+		elem := rand.Intn(100) // The machine/node that will be marked as initialized
+		for i := 0; i < 100; i++ {
+			m := test.Machine(v1alpha5.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
+					},
+				},
+			})
+			ExpectApplied(ctx, env.Client, m)
+			if i == elem {
+				m, node = ExpectMachineDeployed(ctx, env.Client, cluster, cloudProvider, m)
+			} else {
+				var err error
+				m, err = ExpectMachineDeployedNoNode(ctx, env.Client, cluster, cloudProvider, m)
+				Expect(err).ToNot(HaveOccurred())
+			}
+			machines = append(machines, m)
+		}
+
+		// Make one of the nodes and machines initialized
+		ExpectMakeMachinesInitialized(ctx, env.Client, machines[elem])
+		ExpectMakeNodesInitialized(ctx, env.Client, node)
+		ExpectReconcileSucceeded(ctx, machineStateController, client.ObjectKeyFromObject(machines[elem]))
+		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node))
+
+		pod := test.UnschedulablePod()
+		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+		scheduledNode := ExpectScheduled(ctx, env.Client, pod)
+
+		// Expect that the scheduled node is equal to node3 since it's initialized
+		Expect(scheduledNode.Name).To(Equal(node.Name))
+	})
+})
+
+var _ = Describe("Existing Nodes", func() {
+	It("should schedule a pod to an existing node unowned by Karpenter", func() {
+		node := test.Node(test.NodeOptions{
+			Allocatable: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("10"),
+				v1.ResourceMemory: resource.MustParse("10Gi"),
+				v1.ResourcePods:   resource.MustParse("110"),
+			},
+		})
+		ExpectApplied(ctx, env.Client, node)
+		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node))
+		opts := test.PodOptions{ResourceRequirements: v1.ResourceRequirements{
+			Requests: map[v1.ResourceName]resource.Quantity{
+				v1.ResourceCPU: resource.MustParse("10m"),
+			},
+			Limits: map[v1.ResourceName]resource.Quantity{
+				v1.ResourceCPU: resource.MustParse("10m"),
+			},
+		}}
+		ExpectApplied(ctx, env.Client, provisioner)
+		pod := test.UnschedulablePod(opts)
+		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+		scheduledNode := ExpectScheduled(ctx, env.Client, pod)
+		Expect(node.Name).To(Equal(scheduledNode.Name))
+	})
+	It("should schedule multiple pods to an existing node unowned by Karpenter", func() {
+		node := test.Node(test.NodeOptions{
+			Allocatable: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse("10"),
+				v1.ResourceMemory: resource.MustParse("100Gi"),
+				v1.ResourcePods:   resource.MustParse("110"),
+			},
+		})
+		ExpectApplied(ctx, env.Client, node)
+		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node))
+		opts := test.PodOptions{ResourceRequirements: v1.ResourceRequirements{
+			Requests: map[v1.ResourceName]resource.Quantity{
+				v1.ResourceCPU: resource.MustParse("10m"),
+			},
+			Limits: map[v1.ResourceName]resource.Quantity{
+				v1.ResourceCPU: resource.MustParse("10m"),
+			},
+		}}
+		ExpectApplied(ctx, env.Client, provisioner)
+		pods := test.UnschedulablePods(opts, 100)
+		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pods...)
+
+		for _, pod := range pods {
+			scheduledNode := ExpectScheduled(ctx, env.Client, pod)
+			Expect(node.Name).To(Equal(scheduledNode.Name))
+		}
+	})
+	It("should order initialized nodes for scheduling un-initialized nodes", func() {
+		ExpectApplied(ctx, env.Client, provisioner)
+
+		var machines []*v1alpha5.Machine
+		var nodes []*v1.Node
+		for i := 0; i < 100; i++ {
+			m := test.Machine(v1alpha5.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
+					},
+				},
+			})
+			ExpectApplied(ctx, env.Client, m)
+			m, n := ExpectMachineDeployed(ctx, env.Client, cluster, cloudProvider, m)
+			machines = append(machines, m)
+			nodes = append(nodes, n)
+		}
+
+		// Make one of the nodes and machines initialized
+		elem := rand.Intn(100) //nolint:gosec
+		ExpectMakeMachinesInitialized(ctx, env.Client, machines[elem])
+		ExpectMakeNodesInitialized(ctx, env.Client, nodes[elem])
+		ExpectReconcileSucceeded(ctx, machineStateController, client.ObjectKeyFromObject(machines[elem]))
+		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(nodes[elem]))
+
+		pod := test.UnschedulablePod()
+		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+		scheduledNode := ExpectScheduled(ctx, env.Client, pod)
+
+		// Expect that the scheduled node is equal to the ready node since it's initialized
+		Expect(scheduledNode.Name).To(Equal(nodes[elem].Name))
 	})
 })
 

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -428,7 +428,7 @@ func (c *Cluster) cleanupNode(name string) {
 }
 
 func (c *Cluster) populateStartupTaints(ctx context.Context, n *StateNode) error {
-	if !n.Owned() {
+	if n.Labels()[v1alpha5.ProvisionerNameLabelKey] == "" {
 		return nil
 	}
 	provisioner := &v1alpha5.Provisioner{}
@@ -440,7 +440,7 @@ func (c *Cluster) populateStartupTaints(ctx context.Context, n *StateNode) error
 }
 
 func (c *Cluster) populateInflight(ctx context.Context, n *StateNode) error {
-	if !n.Owned() {
+	if n.Labels()[v1alpha5.ProvisionerNameLabelKey] == "" {
 		return nil
 	}
 	provisioner := &v1alpha5.Provisioner{}

--- a/pkg/controllers/state/statenode.go
+++ b/pkg/controllers/state/statenode.go
@@ -176,7 +176,7 @@ func (in *StateNode) Taints() []v1.Taint {
 	// re-appears on the node for a different reason (e.g. the node is cordoned) we will assume that pods can
 	// schedule against the node in the future incorrectly.
 	ephemeralTaints := scheduling.KnownEphemeralTaints
-	if !in.Initialized() && in.Owned() {
+	if !in.Initialized() && in.Managed() {
 		if in.Machine != nil {
 			ephemeralTaints = append(ephemeralTaints, in.Machine.Spec.StartupTaints...)
 		} else {
@@ -201,17 +201,21 @@ func (in *StateNode) Taints() []v1.Taint {
 }
 
 func (in *StateNode) Registered() bool {
-	if in.Node != nil {
-		return in.Node.Labels[v1alpha5.LabelNodeRegistered] == "true"
+	// Node is managed by Karpenter, so we can check for the Registered label
+	if in.Managed() {
+		return in.Node != nil && in.Node.Labels[v1alpha5.LabelNodeRegistered] == "true"
 	}
-	return false
+	// Nodes not managed by Karpenter are always considered Registered
+	return true
 }
 
 func (in *StateNode) Initialized() bool {
-	if in.Node != nil {
-		return in.Node.Labels[v1alpha5.LabelNodeInitialized] == "true"
+	// Node is managed by Karpenter, so we can check for the Initialized label
+	if in.Managed() {
+		return in.Node != nil && in.Node.Labels[v1alpha5.LabelNodeInitialized] == "true"
 	}
-	return false
+	// Nodes not managed by Karpenter are always considered Initialized
+	return true
 }
 
 func (in *StateNode) Capacity() v1.ResourceList {
@@ -229,7 +233,7 @@ func (in *StateNode) Capacity() v1.ResourceList {
 		return in.Machine.Status.Capacity
 	}
 	// TODO @joinnis: Remove this when machine migration is complete
-	if !in.Initialized() && in.Owned() {
+	if !in.Initialized() && in.Managed() {
 		// Override any zero quantity values in the node status
 		ret := lo.Assign(in.Node.Status.Capacity)
 		for resourceName, quantity := range in.inflightCapacity {
@@ -257,7 +261,7 @@ func (in *StateNode) Allocatable() v1.ResourceList {
 		return in.Machine.Status.Allocatable
 	}
 	// TODO @joinnis: Remove this when machine migration is complete
-	if !in.Initialized() && in.Owned() {
+	if !in.Initialized() && in.Managed() {
 		// Override any zero quantity values in the node status
 		ret := lo.Assign(in.Node.Status.Allocatable)
 		for resourceName, quantity := range in.inflightAllocatable {
@@ -321,8 +325,9 @@ func (in *StateNode) Nominated() bool {
 	return in.nominatedUntil.After(time.Now())
 }
 
-func (in *StateNode) Owned() bool {
-	return in.Labels()[v1alpha5.ProvisionerNameLabelKey] != ""
+func (in *StateNode) Managed() bool {
+	return in.Machine != nil ||
+		(in.Node != nil && in.Node.Labels[v1alpha5.ProvisionerNameLabelKey] != "")
 }
 
 func (in *StateNode) updateForPod(ctx context.Context, kubeClient client.Client, pod *v1.Pod) {

--- a/pkg/controllers/state/suite_test.go
+++ b/pkg/controllers/state/suite_test.go
@@ -239,7 +239,7 @@ var _ = Describe("Inflight Nodes", func() {
 		Expect(stateNode.HostName()).To(Equal("custom-host-name"))
 		Expect(stateNode.Annotations()).To(HaveKeyWithValue(v1alpha5.DoNotConsolidateNodeAnnotationKey, "true"))
 		Expect(stateNode.Initialized()).To(BeFalse())
-		Expect(stateNode.Owned()).To(BeTrue())
+		Expect(stateNode.Managed()).To(BeTrue())
 	})
 	It("should model the inflight capacity/allocatable as the machine capacity/allocatable", func() {
 		machine := test.Machine(v1alpha5.Machine{


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes https://github.com/aws/karpenter/issues/4266

**Description**

Prior to this change, Karpenter wouldn't consider capacity that wasn't owned by Karpenter for pod scheduling. This meant, paricularly in the case of consolidation, that Karpenter wouldn't scale-down Karpenter-managed nodes if there was other static capacity in the cluster that those pods could schedule to.

This change adds support for Karpenter discovering this capacity so that consolidation will scale-down these nodes.

**How was this change tested?**

- `make presubmit`
- Manual validation using MNG and Karpenter-managed nodes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
