### PR TITLE
fix: prevent consolidation from pausing for 5m

### DIFF
--- a/pkg/controllers/deprovisioning/controller.go
+++ b/pkg/controllers/deprovisioning/controller.go
@@ -123,7 +123,6 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 		return reconcile.Result{RequeueAfter: time.Second}, nil
 	}
 	// Attempt different deprovisioning methods. We'll only let one method perform an action
-	isConsolidated := c.cluster.Consolidated()
 	for _, d := range c.deprovisioners {
 		c.recordRun(fmt.Sprintf("%T", d))
 		success, err := c.deprovision(ctx, d)
@@ -135,10 +134,6 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 		}
 	}
 
-	if !isConsolidated {
-		// Mark cluster as consolidated, only if the deprovisioners ran and were not able to perform any work.
-		c.cluster.SetConsolidated(true)
-	}
 	// All deprovisioners did nothing, so return nothing to do
 	return reconcile.Result{RequeueAfter: pollingPeriod}, nil
 }

--- a/pkg/controllers/deprovisioning/emptymachineconsolidation.go
+++ b/pkg/controllers/deprovisioning/emptymachineconsolidation.go
@@ -42,7 +42,7 @@ func NewEmptyMachineConsolidation(clk clock.Clock, cluster *state.Cluster, kubeC
 
 // ComputeCommand generates a deprovisioning command given deprovisionable machines
 func (c *EmptyMachineConsolidation) ComputeCommand(ctx context.Context, candidates ...*Candidate) (Command, error) {
-	if c.cluster.Consolidated() {
+	if c.isConsolidated() {
 		return Command{}, nil
 	}
 	candidates, err := c.sortAndFilterCandidates(ctx, candidates)
@@ -54,6 +54,8 @@ func (c *EmptyMachineConsolidation) ComputeCommand(ctx context.Context, candidat
 	// select the entirely empty nodes
 	emptyCandidates := lo.Filter(candidates, func(n *Candidate, _ int) bool { return len(n.pods) == 0 })
 	if len(emptyCandidates) == 0 {
+		// none empty, so do nothing
+		c.markConsolidated()
 		return Command{}, nil
 	}
 

--- a/pkg/controllers/deprovisioning/multimachineconsolidation.go
+++ b/pkg/controllers/deprovisioning/multimachineconsolidation.go
@@ -41,7 +41,7 @@ func NewMultiMachineConsolidation(clk clock.Clock, cluster *state.Cluster, kubeC
 }
 
 func (m *MultiMachineConsolidation) ComputeCommand(ctx context.Context, candidates ...*Candidate) (Command, error) {
-	if m.cluster.Consolidated() {
+	if m.isConsolidated() {
 		return Command{}, nil
 	}
 	candidates, err := m.sortAndFilterCandidates(ctx, candidates)
@@ -56,7 +56,10 @@ func (m *MultiMachineConsolidation) ComputeCommand(ctx context.Context, candidat
 	if err != nil {
 		return Command{}, err
 	}
+
 	if cmd.Action() == NoOpAction {
+		// couldn't identify any candidates
+		m.markConsolidated()
 		return cmd, nil
 	}
 

--- a/pkg/controllers/deprovisioning/singlemachineconsolidation.go
+++ b/pkg/controllers/deprovisioning/singlemachineconsolidation.go
@@ -41,7 +41,7 @@ func NewSingleMachineConsolidation(clk clock.Clock, cluster *state.Cluster, kube
 // ComputeCommand generates a deprovisioning command given deprovisionable machines
 // nolint:gocyclo
 func (c *SingleMachineConsolidation) ComputeCommand(ctx context.Context, candidates ...*Candidate) (Command, error) {
-	if c.cluster.Consolidated() {
+	if c.isConsolidated() {
 		return Command{}, nil
 	}
 	candidates, err := c.sortAndFilterCandidates(ctx, candidates)
@@ -72,5 +72,7 @@ func (c *SingleMachineConsolidation) ComputeCommand(ctx context.Context, candida
 		}
 		return cmd, nil
 	}
+	// couldn't remove any candidate
+	c.markConsolidated()
 	return Command{}, nil
 }

--- a/pkg/controllers/state/informer/provisioner.go
+++ b/pkg/controllers/state/informer/provisioner.go
@@ -51,7 +51,7 @@ func (c *ProvisionerController) Name() string {
 
 func (c *ProvisionerController) Reconcile(_ context.Context, _ *v1alpha5.Provisioner) (reconcile.Result, error) {
 	// Something changed in the provisioner so we should re-consider consolidation
-	c.cluster.SetConsolidated(false)
+	c.cluster.MarkUnconsolidated()
 	return reconcile.Result{}, nil
 }
 


### PR DESCRIPTION
**Description**

There was a race with deprovisioning with steps 2 & 3 where we could: 

1) See the cluster as unconsolidated
2) Run the deprovisioners unsuccessfully
3) Something happens that makes consolidation possible (e.g. pod
   deletion)
4) We mark the cluster as unconsolidatable
5) On the next round, do nothing since cluster is unconsolidatable

The end result is that we mark the cluster as unconsolidatable which prevents us from trying again to save CPU time. Thankfully this was built with a 5 minute timeout to handle recovering from ICE situations automatically which limited the severity of the problem.

This change modifies the code to use a monotonically increasing timestamp.  If the cluster state changes (or nothing changes for five minutes), it increases.

The race above is now prevented:

1) See the cluster state as X
2) Run the deprovisioners unsuccessfully
3) Something happens that makes consolidation possible (e.g. pod
   deletion), this increases cluster state to X+1
4) We mark the cluster as unconsolidatable as of X 
5) On the next round, see the cluster state as X+1 and retry since
   we last tried at state X


**How was this change tested?**

Scaling up and down clusters many times and observing consolidation not hanging.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
