### PR TITLE
feat: Provisioner Static Drift

### DIFF
--- a/pkg/apis/v1alpha5/provisioner.go
+++ b/pkg/apis/v1alpha5/provisioner.go
@@ -43,13 +43,13 @@ type ProvisionerSpec struct {
 	// have matching tolerations. Additional taints will be created that match
 	// pod tolerations on a per-node basis.
 	// +optional
-	Taints []v1.Taint `json:"taints,omitempty" hash:"set"`
+	Taints []v1.Taint `json:"taints,omitempty"`
 	// StartupTaints are taints that are applied to nodes upon startup which are expected to be removed automatically
 	// within a short period of time, typically by a DaemonSet that tolerates the taint. These are commonly used by
 	// daemonsets to allow initialization and enforce startup ordering.  StartupTaints are ignored for provisioning
 	// purposes in that pods are not required to tolerate a StartupTaint in order to have nodes provisioned for them.
 	// +optional
-	StartupTaints []v1.Taint `json:"startupTaints,omitempty" hash:"set"`
+	StartupTaints []v1.Taint `json:"startupTaints,omitempty"`
 	// Requirements are layered with Labels and applied to every node.
 	Requirements []v1.NodeSelectorRequirement `json:"requirements,omitempty" hash:"ignore"`
 	// KubeletConfiguration are options passed to the kubelet when provisioning nodes
@@ -57,11 +57,11 @@ type ProvisionerSpec struct {
 	KubeletConfiguration *KubeletConfiguration `json:"kubeletConfiguration,omitempty"`
 	// Provider contains fields specific to your cloudprovider.
 	// +kubebuilder:pruning:PreserveUnknownFields
-	Provider *Provider `json:"provider,omitempty"`
+	Provider *Provider `json:"provider,omitempty" hash:"ignore"`
 	// ProviderRef is a reference to a dedicated CRD for the chosen provider, that holds
 	// additional configuration options
 	// +optional
-	ProviderRef *MachineTemplateRef `json:"providerRef,omitempty"`
+	ProviderRef *MachineTemplateRef `json:"providerRef,omitempty" hash:"ignore"`
 	// TTLSecondsAfterEmpty is the number of seconds the controller will wait
 	// before attempting to delete a node, measured from when the node is
 	// detected to be empty. A Node is considered to be empty when it does not

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -32,6 +32,7 @@ import (
 	metricspod "github.com/aws/karpenter-core/pkg/controllers/metrics/pod"
 	metricsprovisioner "github.com/aws/karpenter-core/pkg/controllers/metrics/provisioner"
 	metricsstate "github.com/aws/karpenter-core/pkg/controllers/metrics/state"
+	coreprovisioner "github.com/aws/karpenter-core/pkg/controllers/provisioner"
 	"github.com/aws/karpenter-core/pkg/controllers/provisioning"
 	"github.com/aws/karpenter-core/pkg/controllers/state"
 	"github.com/aws/karpenter-core/pkg/controllers/state/informer"
@@ -59,6 +60,7 @@ func NewControllers(
 		metricsstate.NewController(cluster),
 		deprovisioning.NewController(clock, kubeClient, provisioner, cloudProvider, recorder, cluster),
 		provisioning.NewController(kubeClient, provisioner, recorder),
+		coreprovisioner.NewController(kubeClient),
 		informer.NewDaemonSetController(kubeClient, cluster),
 		informer.NewNodeController(kubeClient, cluster),
 		informer.NewPodController(kubeClient, cluster),

--- a/pkg/controllers/machine/disruption/drift_test.go
+++ b/pkg/controllers/machine/disruption/drift_test.go
@@ -19,13 +19,16 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
+	"knative.dev/pkg/ptr"
 
+	"github.com/aws/karpenter-core/pkg/operator/controller"
 	. "github.com/aws/karpenter-core/pkg/test/expectations"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aws/karpenter-core/pkg/apis/settings"
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
+	controllerprov "github.com/aws/karpenter-core/pkg/controllers/provisioner"
 	"github.com/aws/karpenter-core/pkg/test"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -43,6 +46,9 @@ var _ = Describe("Drift", func() {
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
 					v1.LabelInstanceTypeStable:       test.RandomName(),
+				},
+				Annotations: map[string]string{
+					v1alpha5.ProvisionerHashAnnotationKey: provisioner.Hash(),
 				},
 			},
 		})
@@ -120,5 +126,79 @@ var _ = Describe("Drift", func() {
 
 		machine = ExpectExists(ctx, env.Client, machine)
 		Expect(machine.StatusConditions().GetCondition(v1alpha5.MachineDrifted)).To(BeNil())
+	})
+	Context("Static Drift", func() {
+		var testProvisionerOptions test.ProvisionerOptions
+		var provisionerController controller.Controller
+		BeforeEach(func() {
+			cp.Drifted = false
+			provisionerController = controllerprov.NewController(env.Client)
+			testProvisionerOptions = test.ProvisionerOptions{
+				ObjectMeta: provisioner.ObjectMeta,
+				Taints: []v1.Taint{
+					{
+						Key:    "keyValue1",
+						Effect: v1.TaintEffectNoExecute,
+					},
+				},
+				StartupTaints: []v1.Taint{
+					{
+						Key:    "startupKeyValue1",
+						Effect: v1.TaintEffectNoExecute,
+					},
+				},
+				Labels: map[string]string{
+					"keyLabel":  "valueLabel",
+					"keyLabel2": "valueLabel2",
+				},
+				Kubelet: &v1alpha5.KubeletConfiguration{
+					MaxPods: ptr.Int32(10),
+				},
+				Annotations: map[string]string{
+					"keyAnnotation":  "valueAnnotation",
+					"keyAnnotation2": "valueAnnotation2",
+				},
+			}
+			provisioner = test.Provisioner(testProvisionerOptions)
+			machine.ObjectMeta.Annotations[v1alpha5.ProvisionerHashAnnotationKey] = provisioner.Hash()
+		})
+		It("should detect drift on changes for all static fields", func() {
+			ExpectApplied(ctx, env.Client, provisioner, machine)
+			ExpectReconcileSucceeded(ctx, provisionerController, client.ObjectKeyFromObject(provisioner))
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKeyFromObject(machine))
+			machine = ExpectExists(ctx, env.Client, machine)
+			Expect(machine.StatusConditions().GetCondition(v1alpha5.MachineDrifted)).To(BeNil())
+
+			// Change one static field for the same provisioner
+			provisionerFieldToChange := []*v1alpha5.Provisioner{
+				test.Provisioner(testProvisionerOptions, test.ProvisionerOptions{ObjectMeta: provisioner.ObjectMeta, Annotations: map[string]string{"keyAnnotationTest": "valueAnnotationTest"}}),
+				test.Provisioner(testProvisionerOptions, test.ProvisionerOptions{ObjectMeta: provisioner.ObjectMeta, Labels: map[string]string{"keyLabelTest": "valueLabelTest"}}),
+				test.Provisioner(testProvisionerOptions, test.ProvisionerOptions{ObjectMeta: provisioner.ObjectMeta, Taints: []v1.Taint{{Key: "keytest2Taint", Effect: v1.TaintEffectNoExecute}}}),
+				test.Provisioner(testProvisionerOptions, test.ProvisionerOptions{ObjectMeta: provisioner.ObjectMeta, StartupTaints: []v1.Taint{{Key: "keytest2StartupTaint", Effect: v1.TaintEffectNoExecute}}}),
+				test.Provisioner(testProvisionerOptions, test.ProvisionerOptions{ObjectMeta: provisioner.ObjectMeta, Kubelet: &v1alpha5.KubeletConfiguration{MaxPods: ptr.Int32(30)}}),
+			}
+
+			for _, updatedProvisioner := range provisionerFieldToChange {
+				ExpectApplied(ctx, env.Client, updatedProvisioner)
+				ExpectReconcileSucceeded(ctx, provisionerController, client.ObjectKeyFromObject(updatedProvisioner))
+				ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKeyFromObject(machine))
+				machine = ExpectExists(ctx, env.Client, machine)
+				Expect(machine.StatusConditions().GetCondition(v1alpha5.MachineDrifted).IsTrue()).To(BeTrue())
+			}
+		})
+		It("should not return drifted if karpenter.sh/provisioner-hash annotation is not present on the provisioner", func() {
+			provisioner.ObjectMeta.Annotations = map[string]string{}
+			ExpectApplied(ctx, env.Client, provisioner, machine)
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKeyFromObject(machine))
+			machine = ExpectExists(ctx, env.Client, machine)
+			Expect(machine.StatusConditions().GetCondition(v1alpha5.MachineDrifted)).To(BeNil())
+		})
+		It("should not return drifted if karpenter.sh/provisioner-hash annotation is not present on the machine", func() {
+			machine.ObjectMeta.Annotations = map[string]string{}
+			ExpectApplied(ctx, env.Client, provisioner, machine)
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKeyFromObject(machine))
+			machine = ExpectExists(ctx, env.Client, machine)
+			Expect(machine.StatusConditions().GetCondition(v1alpha5.MachineDrifted)).To(BeNil())
+		})
 	})
 })

--- a/pkg/controllers/provisioner/controller.go
+++ b/pkg/controllers/provisioner/controller.go
@@ -23,6 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
@@ -65,6 +66,7 @@ func (c *Controller) Reconcile(ctx context.Context, p *v1alpha5.Provisioner) (re
 func (c *Controller) Builder(_ context.Context, m manager.Manager) corecontroller.Builder {
 	return corecontroller.Adapt(controllerruntime.
 		NewControllerManagedBy(m).
+		WithEventFilter(predicate.GenerationChangedPredicate{}).
 		For(&v1alpha5.Provisioner{}).
 		WithOptions(controller.Options{MaxConcurrentReconciles: 10}),
 	)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Adding static one-way drift for the provisioner.
- The fields that will statically drift:
     -  Taints
     -  Labels
     -  Annotations
     -  Kubelet Configuration 
     - Startup Taints
 - Drift will check the hash that is produced from the provisioner against all its machines to validate the machines have not drifted
 
**How was this change tested?**
- Unit tested 
- E2E testing will be in https://github.com/aws/karpenter/pull/4305

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
