### PR TITLE
perf: improve scheduling speed

### DIFF
--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -108,6 +108,7 @@ var _ = BeforeEach(func() {
 	newCP := fake.CloudProvider{}
 	cloudProvider.InstanceTypes, _ = newCP.GetInstanceTypes(context.Background(), nil)
 	cloudProvider.CreateCalls = nil
+	pscheduling.ResetDefaultStorageClass()
 })
 
 var _ = AfterEach(func() {

--- a/pkg/controllers/state/statenode.go
+++ b/pkg/controllers/state/statenode.go
@@ -296,7 +296,11 @@ func (in *StateNode) VolumeLimits() scheduling.VolumeCount {
 }
 
 func (in *StateNode) PodRequests() v1.ResourceList {
-	return resources.Merge(lo.Values(in.podRequests)...)
+	var totalRequests v1.ResourceList
+	for _, requests := range in.podRequests {
+		totalRequests = resources.MergeInto(totalRequests, requests)
+	}
+	return totalRequests
 }
 
 func (in *StateNode) PodLimits() v1.ResourceList {

--- a/pkg/scheduling/requirement.go
+++ b/pkg/scheduling/requirement.go
@@ -40,6 +40,20 @@ func NewRequirement(key string, operator v1.NodeSelectorOperator, values ...stri
 	if normalized, ok := v1alpha5.NormalizedLabels[key]; ok {
 		key = normalized
 	}
+
+	// This is a super-common case, so optimize for it an inline everything.
+	if operator == v1.NodeSelectorOpIn {
+		s := make(sets.Set[string], len(values))
+		for _, value := range values {
+			s[value] = sets.Empty{}
+		}
+		return &Requirement{
+			Key:        key,
+			values:     s,
+			complement: false,
+		}
+	}
+
 	r := &Requirement{
 		Key:        key,
 		values:     sets.New[string](),

--- a/pkg/utils/atomic/cachedvar.go
+++ b/pkg/utils/atomic/cachedvar.go
@@ -1,0 +1,61 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package atomic
+
+import (
+	"sync"
+	"time"
+)
+
+// CachedVariable is an atomic cached variable. It will store a value for the specified lifetime and allow
+// retrieval of the value.
+type CachedVariable[T any] struct {
+	mu       sync.Mutex
+	lifetime time.Duration
+	lastSet  time.Time
+	value    T
+}
+
+// NewCachedVariable creates a new cached variable with a given lifetime.
+func NewCachedVariable[T any](lifetime time.Duration) *CachedVariable[T] {
+	return &CachedVariable[T]{
+		lifetime: lifetime,
+	}
+}
+
+// Get returns the value if possible and a boolean indicating if the value was available.
+func (c *CachedVariable[T]) Get() (T, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if time.Since(c.lastSet) > c.lifetime {
+		return c.value, false
+	}
+	return c.value, true
+}
+
+// Set sets the value and resets the lifetime.
+func (c *CachedVariable[T]) Set(v T) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.lastSet = time.Now()
+	c.value = v
+}
+
+// Reset resets the cached variable so that it no longer stores a value.
+func (c *CachedVariable[T]) Reset() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.lastSet = time.Time{}
+}

--- a/pkg/utils/resources/resources.go
+++ b/pkg/utils/resources/resources.go
@@ -59,6 +59,25 @@ func Merge(resources ...v1.ResourceList) v1.ResourceList {
 	return result
 }
 
+// MergeInto sums the resources from src into dest, modifying dest. If you need to repeatedly sum
+// multiple resource lists, it allocates less to continually sum into an existing list as opposed to
+// constructing a new one for each sum like Merge
+func MergeInto(dest v1.ResourceList, src v1.ResourceList) v1.ResourceList {
+	if dest == nil {
+		sz := len(dest)
+		if len(src) > sz {
+			sz = len(src)
+		}
+		dest = make(v1.ResourceList, sz)
+	}
+	for resourceName, quantity := range src {
+		current := dest[resourceName]
+		current.Add(quantity)
+		dest[resourceName] = current
+	}
+	return dest
+}
+
 func Subtract(lhs, rhs v1.ResourceList) v1.ResourceList {
 	result := make(v1.ResourceList, len(lhs))
 	for k, v := range lhs {


### PR DESCRIPTION
Allocatable() is called a lot. Memoize this using a sync.Map so we can avoid the expensive calculation.

name               old time/op   new time/op   delta
Scheduling1-12       566µs ± 9%    382µs ± 5%  -32.54%  (p=0.004 n=5+6)
Scheduling50-12     26.2ms ± 4%   20.0ms ± 6%  -23.53%  (p=0.004 n=5+6)
Scheduling100-12    53.1ms ± 8%   39.4ms ± 6%  -25.70%  (p=0.004 n=5+6)
Scheduling500-12     272ms ± 5%    202ms ±10%  -25.68%  (p=0.004 n=5+6)
Scheduling1000-12    596ms ±11%    457ms ±12%  -23.38%  (p=0.004 n=5+6)
Scheduling2000-12    1.08s ± 4%    0.89s ±10%  -17.46%  (p=0.004 n=5+6)
Scheduling5000-12    2.83s ± 8%    2.21s ± 6%  -21.91%  (p=0.004 n=5+6)

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
