### PR TITLE
fix: Enable a controller to pass a `DisabledRateLimiter` to ignore backoff

### DIFF
--- a/pkg/controllers/deprovisioning/controller.go
+++ b/pkg/controllers/deprovisioning/controller.go
@@ -59,7 +59,6 @@ type Controller struct {
 
 // pollingPeriod that we inspect cluster to look for opportunities to deprovision
 const pollingPeriod = 10 * time.Second
-const immediately = time.Millisecond
 
 var errCandidateDeleting = fmt.Errorf("candidate is deleting")
 
@@ -130,7 +129,7 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 			return reconcile.Result{}, fmt.Errorf("deprovisioning via %q, %w", d, err)
 		}
 		if success {
-			return reconcile.Result{RequeueAfter: immediately}, nil
+			return reconcile.Result{}, nil
 		}
 	}
 

--- a/pkg/operator/controller/ratelimiter.go
+++ b/pkg/operator/controller/ratelimiter.go
@@ -1,0 +1,32 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import "time"
+
+// DisabledRateLimiter is a rate limiter that doesn't backoff when receiving an error
+// or Requeue: true from the reconcile loop. This is mainly useful with Singleton controllers
+// where we want the new loop to execute immediately without backoff
+type DisabledRateLimiter struct{}
+
+func NewDisabledRateLimiter() *DisabledRateLimiter {
+	return &DisabledRateLimiter{}
+}
+
+func (*DisabledRateLimiter) When(interface{}) time.Duration { return 0 }
+
+func (*DisabledRateLimiter) Forget(interface{}) {}
+
+func (*DisabledRateLimiter) NumRequeues(interface{}) int { return -1 }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Currently, the provisioner polling singleton controller employs the default rate limiter from [NewSingletonManagedBy](). This means that when the provisioner controller experiences an error, it will backoff that error in an exponential manner. If we get especially unlucky or the batching window is sufficiently large, it may not forget the backoff value, causing the backoff to grow larger and larger until it gets to max backoff (~16 minutes).

Since this singleton controller is already reliant on a batching mechanism, we can disable the backoff mechanism for the provisioner and allow it to react as quickly as possible when it is provisioning Machines for pods.

This PR adds the following concepts to the `controller` package:
- `WithRateLimter` allows you to pass a rate limiter into the singleton controller in the same way that you can currently pass one through to controller runtime
- `DisabledRateLimiter` is a rate limiter that does not have any backoff

**How was this change tested?**

`make apply` manually tested on a cluster, validating that other controllers have the correct rate limiter while the provisioner requeues at a faster interval

### Before Change (see the timestamps, increasing backoff over time)

```console
2023-07-20T01:46:13.976Z        ERROR   controller.provisioner  creating scheduler, no provisioners found       {"commit": "98cd3f6"}
2023-07-20T01:46:23.988Z        ERROR   controller.provisioner  creating scheduler, no provisioners found       {"commit": "98cd3f6"}
2023-07-20T01:46:34.016Z        ERROR   controller.provisioner  creating scheduler, no provisioners found       {"commit": "98cd3f6"}
2023-07-20T01:46:44.025Z        ERROR   controller.provisioner  creating scheduler, no provisioners found       {"commit": "98cd3f6"}
2023-07-20T01:46:54.061Z        ERROR   controller.provisioner  creating scheduler, no provisioners found       {"commit": "98cd3f6"}
2023-07-20T01:47:04.082Z        ERROR   controller.provisioner  creating scheduler, no provisioners found       {"commit": "98cd3f6"}
2023-07-20T01:47:14.149Z        ERROR   controller.provisioner  creating scheduler, no provisioners found       {"commit": "98cd3f6"}
2023-07-20T01:47:24.218Z        ERROR   controller.provisioner  creating scheduler, no provisioners found       {"commit": "98cd3f6"}
2023-07-20T01:47:34.510Z        ERROR   controller.provisioner  creating scheduler, no provisioners found       {"commit": "98cd3f6"}
2023-07-20T01:47:44.771Z        ERROR   controller.provisioner  creating scheduler, no provisioners found       {"commit": "98cd3f6"}
2023-07-20T01:47:55.288Z        ERROR   controller.provisioner  creating scheduler, no provisioners found       {"commit": "98cd3f6"}
2023-07-20T01:48:06.320Z        ERROR   controller.provisioner  creating scheduler, no provisioners found       {"commit": "98cd3f6"}
2023-07-20T01:48:18.372Z        ERROR   controller.provisioner  creating scheduler, no provisioners found       {"commit": "98cd3f6"}
2023-07-20T01:48:32.499Z        ERROR   controller.provisioner  creating scheduler, no provisioners found       {"commit": "98cd3f6"}
2023-07-20T01:48:50.724Z        ERROR   controller.provisioner  creating scheduler, no provisioners found       {"commit": "98cd3f6"}
2023-07-20T01:49:17.114Z        ERROR   controller.provisioner  creating scheduler, no provisioners found       {"commit": "98cd3f6"}
2023-07-20T01:49:59.887Z        ERROR   controller.provisioner  creating scheduler, no provisioners found       {"commit": "98cd3f6"}
2023-07-20T01:51:15.428Z        ERROR   controller.provisioner  creating scheduler, no provisioners found       {"commit": "98cd3f6"}
```

### After Change (see the timestamps, no backoff)

```console
2023-07-20T01:52:32.296Z        ERROR   controller.provisioner  creating scheduler, no provisioners found       {"commit": "98cd3f6"}
2023-07-20T01:52:42.302Z        ERROR   controller.provisioner  creating scheduler, no provisioners found       {"commit": "98cd3f6"}
2023-07-20T01:52:52.333Z        ERROR   controller.provisioner  creating scheduler, no provisioners found       {"commit": "98cd3f6"}
2023-07-20T01:53:02.340Z        ERROR   controller.provisioner  creating scheduler, no provisioners found       {"commit": "98cd3f6"}
2023-07-20T01:53:12.346Z        ERROR   controller.provisioner  creating scheduler, no provisioners found       {"commit": "98cd3f6"}
2023-07-20T01:53:22.353Z        ERROR   controller.provisioner  creating scheduler, no provisioners found       {"commit": "98cd3f6"}
2023-07-20T01:53:32.365Z        ERROR   controller.provisioner  creating scheduler, no provisioners found       {"commit": "98cd3f6"}
2023-07-20T01:53:42.389Z        ERROR   controller.provisioner  creating scheduler, no provisioners found       {"commit": "98cd3f6"}
2023-07-20T01:53:52.403Z        ERROR   controller.provisioner  creating scheduler, no provisioners found       {"commit": "98cd3f6"}
2023-07-20T01:54:02.414Z        ERROR   controller.provisioner  creating scheduler, no provisioners found       {"commit": "98cd3f6"}
2023-07-20T01:54:12.427Z        ERROR   controller.provisioner  creating scheduler, no provisioners found       {"commit": "98cd3f6"}
2023-07-20T01:54:22.439Z        ERROR   controller.provisioner  creating scheduler, no provisioners found       {"commit": "98cd3f6"}
2023-07-20T01:54:32.451Z        ERROR   controller.provisioner  creating scheduler, no provisioners found       {"commit": "98cd3f6"}
2023-07-20T01:54:42.464Z        ERROR   controller.provisioner  creating scheduler, no provisioners found       {"commit": "98cd3f6"}
2023-07-20T01:54:52.475Z        ERROR   controller.provisioner  creating scheduler, no provisioners found       {"commit": "98cd3f6"}
2023-07-20T01:55:02.487Z        ERROR   controller.provisioner  creating scheduler, no provisioners found       {"commit": "98cd3f6"}
2023-07-20T01:55:12.499Z        ERROR   controller.provisioner  creating scheduler, no provisioners found       {"commit": "98cd3f6"}
2023-07-20T01:55:22.511Z        ERROR   controller.provisioner  creating scheduler, no provisioners found       {"commit": "98cd3f6"}
2023-07-20T01:55:32.521Z        ERROR   controller.provisioner  creating scheduler, no provisioners found       {"commit": "98cd3f6"}
2023-07-20T01:55:42.545Z        ERROR   controller.provisioner  creating scheduler, no provisioners found       {"commit": "98cd3f6"}
2023-07-20T01:55:52.556Z        ERROR   controller.provisioner  creating scheduler, no provisioners found       {"commit": "98cd3f6"}
2023-07-20T01:56:02.566Z        ERROR   controller.provisioner  creating scheduler, no provisioners found       {"commit": "98cd3f6"}
2023-07-20T01:56:12.579Z        ERROR   controller.provisioner  creating scheduler, no provisioners found       {"commit": "98cd3f6"}
2023-07-20T01:56:22.593Z        ERROR   controller.provisioner  creating scheduler, no provisioners found       {"commit": "98cd3f6"}
2023-07-20T01:56:32.606Z        ERROR   controller.provisioner  creating scheduler, no provisioners found       {"commit": "98cd3f6"}
2023-07-20T01:56:42.630Z        ERROR   controller.provisioner  creating scheduler, no provisioners found       {"commit": "98cd3f6"}
2023-07-20T01:56:52.670Z        ERROR   controller.provisioner  creating scheduler, no provisioners found       {"commit": "98cd3f6"}
2023-07-20T01:57:02.675Z        ERROR   controller.provisioner  creating scheduler, no provisioners found       {"commit": "98cd3f6"}
2023-07-20T01:57:12.710Z        ERROR   controller.provisioner  creating scheduler, no provisioners found       {"commit": "98cd3f6"}
2023-07-20T01:57:22.715Z        ERROR   controller.provisioner  creating scheduler, no provisioners found       {"commit": "98cd3f6"}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
