### PR TITLE
[fix] Adding LeaderElectionNamespace to init of controllerruntime Manager

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -110,6 +110,7 @@ func NewOperator() (context.Context, *Operator) {
 		LeaderElection:             opts.EnableLeaderElection,
 		LeaderElectionID:           "karpenter-leader-election",
 		LeaderElectionResourceLock: resourcelock.LeasesResourceLock,
+		LeaderElectionNamespace:    system.Namespace(),
 		Scheme:                     scheme.Scheme,
 		MetricsBindAddress:         fmt.Sprintf(":%d", opts.MetricsPort),
 		HealthProbeBindAddress:     fmt.Sprintf(":%d", opts.HealthProbePort),


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes - https://github.com/aws/karpenter/issues/4216

**Description**

Add leader election namespace during initialization so that Kubernetes clusters where default service account tokens are not automatically mounted can run Karpenter with leader election. Issue -  https://github.com/aws/karpenter/issues/4216

**How was this change tested?**

Tested in our setup where we don't mount default namespace service account.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
