### PR TITLE
fix: Don't treat consolidation validation failures as errors, and emit a debug log instead

### DIFF
--- a/pkg/controllers/deprovisioning/emptymachineconsolidation.go
+++ b/pkg/controllers/deprovisioning/emptymachineconsolidation.go
@@ -82,7 +82,8 @@ func (c *EmptyMachineConsolidation) ComputeCommand(ctx context.Context, candidat
 	// the machine isn't a target of a recent scheduling simulation
 	for _, n := range candidatesToDelete {
 		if len(n.pods) != 0 || c.cluster.IsNodeNominated(n.Name()) {
-			return Command{}, fmt.Errorf("command is no longer valid, %s", cmd)
+			logging.FromContext(ctx).Debugf("abandoning empty machine consolidation attempt due to pod churn, command is no longer valid, %s", cmd)
+			return Command{}, nil
 		}
 	}
 	return cmd, nil

--- a/pkg/controllers/deprovisioning/multimachineconsolidation.go
+++ b/pkg/controllers/deprovisioning/multimachineconsolidation.go
@@ -70,7 +70,7 @@ func (m *MultiMachineConsolidation) ComputeCommand(ctx context.Context, candidat
 	}
 
 	if !isValid {
-		logging.FromContext(ctx).Debugf("consolidation command is no longer valid, %s", cmd)
+		logging.FromContext(ctx).Debugf("abandoning multi machine consolidation attempt due to pod churn, command is no longer valid, %s", cmd)
 		return Command{}, nil
 	}
 	return cmd, nil

--- a/pkg/controllers/deprovisioning/singlemachineconsolidation.go
+++ b/pkg/controllers/deprovisioning/singlemachineconsolidation.go
@@ -64,11 +64,11 @@ func (c *SingleMachineConsolidation) ComputeCommand(ctx context.Context, candida
 
 		isValid, err := v.IsValid(ctx, cmd)
 		if err != nil {
-			logging.FromContext(ctx).Errorf("validating consolidation %s", err)
-			continue
+			return Command{}, fmt.Errorf("validating consolidation, %w", err)
 		}
 		if !isValid {
-			return Command{}, fmt.Errorf("command is no longer valid, %s", cmd)
+			logging.FromContext(ctx).Debugf("abandoning single machine consolidation attempt due to pod churn, command is no longer valid, %s", cmd)
+			return Command{}, nil
 		}
 		return cmd, nil
 	}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #https://github.com/aws/karpenter/issues/4364

**Description**

Currently, different consolidation methods have different behavior.

* emptiness: returns an error, bailing from consolidation entirely and starting back at the beginning
* single machine: return an error, bailing from consolidation entirely and starting back at the beginning
* multi machine: log a DEBUG, moving to the next consolidation method

This change aligns all behavior to log and continue. e.g., if pod churn has invalidated an empty consolidation, we'll try multi. If multi has become invalidated, we'll try single. 

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
