### PR TITLE
fix: Wait for Karpenter-managed node to populate provider id

### DIFF
--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -339,7 +339,7 @@ func (p *Provisioner) Launch(ctx context.Context, m *scheduler.Machine, opts ...
 		return "", err
 	}
 	instanceTypeRequirement, _ := lo.Find(machine.Spec.Requirements, func(req v1.NodeSelectorRequirement) bool { return req.Key == v1.LabelInstanceTypeStable })
-	logging.FromContext(ctx).With("requests", machine.Spec.Resources.Requests, "instance-types", instanceTypeList(instanceTypeRequirement.Values)).Infof("created machine")
+	logging.FromContext(ctx).With("machine", machine.Name, "requests", machine.Spec.Resources.Requests, "instance-types", instanceTypeList(instanceTypeRequirement.Values)).Infof("created machine")
 	p.cluster.NominateNodeForPod(ctx, machine.Name)
 	metrics.MachinesCreatedCounter.With(prometheus.Labels{
 		metrics.ReasonLabel:      options.Reason,

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -228,6 +228,10 @@ func (c *Cluster) UpdateNode(ctx context.Context, node *v1.Node) error {
 	defer c.mu.Unlock()
 
 	if node.Spec.ProviderID == "" {
+		// If we know that we own this node, we shouldn't allow the providerID to be empty
+		if node.Labels[v1alpha5.ProvisionerNameLabelKey] != "" {
+			return nil
+		}
 		node.Spec.ProviderID = node.Name
 	}
 	n, err := c.newStateFromNode(ctx, node, c.nodes[node.Spec.ProviderID])

--- a/pkg/controllers/state/suite_test.go
+++ b/pkg/controllers/state/suite_test.go
@@ -101,6 +101,7 @@ var _ = Describe("Inflight Nodes", func() {
 				v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
 				v1.LabelInstanceTypeStable:       instanceType.Name,
 			}},
+			ProviderID: test.RandomProviderID(),
 		})
 		ExpectApplied(ctx, env.Client, node)
 		ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(node))
@@ -122,6 +123,7 @@ var _ = Describe("Inflight Nodes", func() {
 			Capacity: v1.ResourceList{
 				v1.ResourceEphemeralStorage: resource.MustParse("100Gi"),
 			},
+			ProviderID: test.RandomProviderID(),
 		})
 		ExpectApplied(ctx, env.Client, node)
 		ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(node))
@@ -756,7 +758,9 @@ var _ = Describe("Node Resource Level", func() {
 			}},
 			Allocatable: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU: resource.MustParse("4"),
-			}})
+			},
+			ProviderID: test.RandomProviderID(),
+		})
 		ExpectApplied(ctx, env.Client, pod1, pod2)
 		ExpectApplied(ctx, env.Client, node)
 
@@ -787,7 +791,9 @@ var _ = Describe("Node Resource Level", func() {
 			}},
 			Allocatable: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU: resource.MustParse("4"),
-			}})
+			},
+			ProviderID: test.RandomProviderID(),
+		})
 		ExpectApplied(ctx, env.Client, pod1, pod2)
 		ExpectApplied(ctx, env.Client, node)
 
@@ -825,7 +831,9 @@ var _ = Describe("Node Resource Level", func() {
 			}},
 			Allocatable: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU: resource.MustParse("4"),
-			}})
+			},
+			ProviderID: test.RandomProviderID(),
+		})
 
 		// simulate a node that already exists in our cluster
 		ExpectApplied(ctx, env.Client, pod1, pod2)
@@ -857,7 +865,9 @@ var _ = Describe("Node Resource Level", func() {
 			}},
 			Allocatable: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU: resource.MustParse("4"),
-			}})
+			},
+			ProviderID: test.RandomProviderID(),
+		})
 		ExpectApplied(ctx, env.Client, pod1, pod2)
 		ExpectApplied(ctx, env.Client, node)
 
@@ -904,6 +914,7 @@ var _ = Describe("Node Resource Level", func() {
 			Allocatable: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU: resource.MustParse("4"),
 			},
+			ProviderID: test.RandomProviderID(),
 		})
 		ExpectApplied(ctx, env.Client, pod1, pod2)
 		ExpectApplied(ctx, env.Client, node)
@@ -933,7 +944,9 @@ var _ = Describe("Node Resource Level", func() {
 			}},
 			Allocatable: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU: resource.MustParse("4"),
-			}})
+			},
+			ProviderID: test.RandomProviderID(),
+		})
 		ExpectApplied(ctx, env.Client, pod1)
 		ExpectApplied(ctx, env.Client, node)
 
@@ -973,7 +986,9 @@ var _ = Describe("Node Resource Level", func() {
 			}},
 			Allocatable: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU: resource.MustParse("4"),
-			}})
+			},
+			ProviderID: test.RandomProviderID(),
+		})
 		ExpectApplied(ctx, env.Client, pod1, node1)
 		ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(node1))
 		ExpectReconcileSucceeded(ctx, podController, client.ObjectKeyFromObject(pod1))
@@ -997,7 +1012,9 @@ var _ = Describe("Node Resource Level", func() {
 			}},
 			Allocatable: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU: resource.MustParse("8"),
-			}})
+			},
+			ProviderID: test.RandomProviderID(),
+		})
 
 		// and the pod can only bind to node2 due to the resource request
 		pod2 := test.UnschedulablePod(test.PodOptions{
@@ -1047,7 +1064,9 @@ var _ = Describe("Node Resource Level", func() {
 			Allocatable: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU:  resource.MustParse("200"),
 				v1.ResourcePods: resource.MustParse("500"),
-			}})
+			},
+			ProviderID: test.RandomProviderID(),
+		})
 		ExpectApplied(ctx, env.Client, node)
 		ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(node))
 		ExpectResources(v1.ResourceList{
@@ -1136,7 +1155,9 @@ var _ = Describe("Node Resource Level", func() {
 			Allocatable: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU:    resource.MustParse("4"),
 				v1.ResourceMemory: resource.MustParse("8Gi"),
-			}})
+			},
+			ProviderID: test.RandomProviderID(),
+		})
 		ExpectApplied(ctx, env.Client, pod1, node)
 		ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(node))
 
@@ -1180,8 +1201,9 @@ var _ = Describe("Node Resource Level", func() {
 			},
 			Allocatable: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU: resource.MustParse("4"),
-			}},
-		)
+			},
+			ProviderID: test.RandomProviderID(),
+		})
 		ExpectApplied(ctx, env.Client, node)
 
 		ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(node))
@@ -1262,8 +1284,9 @@ var _ = Describe("Node Resource Level", func() {
 			},
 			Allocatable: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU: resource.MustParse("4"),
-			}},
-		)
+			},
+			ProviderID: test.RandomProviderID(),
+		})
 		ExpectApplied(ctx, env.Client, node)
 		ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(node))
 
@@ -1318,7 +1341,9 @@ var _ = Describe("Pod Anti-Affinity", func() {
 			}},
 			Allocatable: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU: resource.MustParse("4"),
-			}})
+			},
+			ProviderID: test.RandomProviderID(),
+		})
 
 		ExpectApplied(ctx, env.Client, pod)
 		ExpectApplied(ctx, env.Client, node)
@@ -1360,7 +1385,9 @@ var _ = Describe("Pod Anti-Affinity", func() {
 			}},
 			Allocatable: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU: resource.MustParse("4"),
-			}})
+			},
+			ProviderID: test.RandomProviderID(),
+		})
 
 		ExpectApplied(ctx, env.Client, pod)
 		ExpectApplied(ctx, env.Client, node)
@@ -1399,7 +1426,9 @@ var _ = Describe("Pod Anti-Affinity", func() {
 			}},
 			Allocatable: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU: resource.MustParse("4"),
-			}})
+			},
+			ProviderID: test.RandomProviderID(),
+		})
 
 		ExpectApplied(ctx, env.Client, pod)
 		ExpectApplied(ctx, env.Client, node)
@@ -1448,7 +1477,9 @@ var _ = Describe("Pod Anti-Affinity", func() {
 			}},
 			Allocatable: map[v1.ResourceName]resource.Quantity{
 				v1.ResourceCPU: resource.MustParse("4"),
-			}})
+			},
+			ProviderID: test.RandomProviderID(),
+		})
 
 		ExpectApplied(ctx, env.Client, pod)
 		ExpectApplied(ctx, env.Client, node)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Updates cluster state to wait for a Node that is Karpenter-managed to propagate its providerID before adding it into cluster state. This prevents us having expectations about the state of this node (including having the instance type label which was causing spurious errors to be thrown) and ensures that we don't treat the node capacity as separate capacity from the tracked Machine while the mapping hasn't been established.

**How was this change tested?**

`make presubmit`
`/karpenter snapshot`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
