### PR TITLE
fix: Handle ephemeral volume topology

### DIFF
--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -2392,96 +2392,6 @@ var _ = Describe("Existing Nodes", func() {
 		// Expect that the scheduled node is equal to the ready node since it's initialized
 		Expect(scheduledNode.Name).To(Equal(nodes[elem].Name))
 	})
-	It("should consider a pod incompatible with an existing node but compatible with Provisioner", func() {
-		machine, node := test.MachineAndNode(v1alpha5.Machine{
-			Status: v1alpha5.MachineStatus{
-				Allocatable: v1.ResourceList{
-					v1.ResourceCPU:    resource.MustParse("10"),
-					v1.ResourceMemory: resource.MustParse("10Gi"),
-					v1.ResourcePods:   resource.MustParse("110"),
-				},
-			},
-		})
-		ExpectApplied(ctx, env.Client, machine, node)
-		ExpectMakeMachinesInitialized(ctx, env.Client, machine)
-		ExpectMakeNodesInitialized(ctx, env.Client, node)
-
-		ExpectReconcileSucceeded(ctx, machineStateController, client.ObjectKeyFromObject(machine))
-		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node))
-
-		pod := test.UnschedulablePod(test.PodOptions{
-			NodeRequirements: []v1.NodeSelectorRequirement{
-				{
-					Key:      v1.LabelTopologyZone,
-					Operator: v1.NodeSelectorOpIn,
-					Values:   []string{"test-zone-1"},
-				},
-			},
-		})
-		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
-		ExpectNotScheduled(ctx, env.Client, pod)
-
-		ExpectApplied(ctx, env.Client, provisioner)
-		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
-		ExpectScheduled(ctx, env.Client, pod)
-	})
-	Context("Daemonsets", func() {
-		It("should not subtract daemonset overhead that is not strictly compatible with an existing node", func() {
-			machine, node := test.MachineAndNode(v1alpha5.Machine{
-				Status: v1alpha5.MachineStatus{
-					Allocatable: v1.ResourceList{
-						v1.ResourceCPU:    resource.MustParse("1"),
-						v1.ResourceMemory: resource.MustParse("1Gi"),
-						v1.ResourcePods:   resource.MustParse("110"),
-					},
-				},
-			})
-			// This DaemonSet is not compatible with the existing Machine/Node
-			ds := test.DaemonSet(
-				test.DaemonSetOptions{PodOptions: test.PodOptions{
-					ResourceRequirements: v1.ResourceRequirements{Requests: v1.ResourceList{
-						v1.ResourceCPU:    resource.MustParse("100"),
-						v1.ResourceMemory: resource.MustParse("100Gi")},
-					},
-					NodeRequirements: []v1.NodeSelectorRequirement{
-						{
-							Key:      v1.LabelTopologyZone,
-							Operator: v1.NodeSelectorOpIn,
-							Values:   []string{"test-zone-1"},
-						},
-					},
-				}},
-			)
-			ExpectApplied(ctx, env.Client, provisioner, machine, node, ds)
-			ExpectMakeMachinesInitialized(ctx, env.Client, machine)
-			ExpectMakeNodesInitialized(ctx, env.Client, node)
-
-			ExpectReconcileSucceeded(ctx, machineStateController, client.ObjectKeyFromObject(machine))
-			ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node))
-
-			pod := test.UnschedulablePod(test.PodOptions{
-				ResourceRequirements: v1.ResourceRequirements{Requests: v1.ResourceList{
-					v1.ResourceCPU:    resource.MustParse("1"),
-					v1.ResourceMemory: resource.MustParse("1Gi")},
-				},
-			})
-			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
-			scheduledNode := ExpectScheduled(ctx, env.Client, pod)
-			Expect(scheduledNode.Name).To(Equal(node.Name))
-
-			// Add another pod and expect that pod not to schedule against a Provisioner since we will model the DS against the Provisioner
-			// In this case, the DS overhead will take over the entire capacity for every "theoretical node" so we can't schedule a new pod to any new Node
-			pod2 := test.UnschedulablePod(test.PodOptions{
-				ResourceRequirements: v1.ResourceRequirements{Requests: v1.ResourceList{
-					v1.ResourceCPU:    resource.MustParse("1"),
-					v1.ResourceMemory: resource.MustParse("1Gi")},
-				},
-			})
-			ExpectApplied(ctx, env.Client, provisioner)
-			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod2)
-			ExpectNotScheduled(ctx, env.Client, pod2)
-		})
-	})
 })
 
 var _ = Describe("No Pre-Binding", func() {
@@ -2875,7 +2785,12 @@ var _ = Describe("VolumeUsage", func() {
 				},
 			},
 		})
-		ExpectApplied(ctx, env.Client, provisioner, sc, initialPod)
+		pvc := test.PersistentVolumeClaim(test.PersistentVolumeClaimOptions{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: fmt.Sprintf("%s-%s", initialPod.Name, initialPod.Spec.Volumes[0].Name),
+			},
+		})
+		ExpectApplied(ctx, env.Client, provisioner, sc, pvc, initialPod)
 		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, initialPod)
 		node := ExpectScheduled(ctx, env.Client, initialPod)
 		csiNode := &storagev1.CSINode{

--- a/pkg/controllers/provisioning/scheduling/topology_test.go
+++ b/pkg/controllers/provisioning/scheduling/topology_test.go
@@ -1097,7 +1097,7 @@ var _ = Describe("Topology", func() {
 	})
 
 	// https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#interaction-with-node-affinity-and-node-selectors
-	Context("Combined Zonal Topology and Machine Affinity", func() {
+	Context("Combined Zonal Topology and Node Affinity", func() {
 		It("should limit spread options by nodeSelector", func() {
 			topology := []v1.TopologySpreadConstraint{{
 				TopologyKey:       v1.LabelTopologyZone,
@@ -1193,7 +1193,7 @@ var _ = Describe("Topology", func() {
 	})
 
 	// https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/#interaction-with-node-affinity-and-node-selectors
-	Context("Combined Capacity Type Topology and Machine Affinity", func() {
+	Context("Combined Capacity Type Topology and Node Affinity", func() {
 		It("should limit spread options by nodeSelector", func() {
 			topology := []v1.TopologySpreadConstraint{{
 				TopologyKey:       v1alpha5.LabelCapacityType,

--- a/pkg/scheduling/storageclass.go
+++ b/pkg/scheduling/storageclass.go
@@ -1,0 +1,62 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduling
+
+import (
+	"context"
+	"sort"
+	"time"
+
+	"github.com/samber/lo"
+	storagev1 "k8s.io/api/storage/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/aws/karpenter-core/pkg/utils/atomic"
+)
+
+const IsDefaultStorageClassAnnotation = "storageclass.kubernetes.io/is-default-class"
+
+// Cache the lookup of our default storage class, global atomic cache since the volume usage is per node
+var defaultStorageClass = atomic.NewCachedVariable[string](1 * time.Minute)
+
+// ResetDefaultStorageClass is intended to be called from unit tests to reset the default storage class
+func ResetDefaultStorageClass() {
+	defaultStorageClass.Reset()
+}
+
+func DiscoverDefaultStorageClassName(ctx context.Context, kubeClient client.Client) (string, error) {
+	if name, ok := defaultStorageClass.Get(); ok {
+		return name, nil
+	}
+
+	storageClassList := &storagev1.StorageClassList{}
+	if err := kubeClient.List(ctx, storageClassList); err != nil {
+		return "", err
+	}
+	// Find all StorageClasses that have the default annotation
+	defaults := lo.Filter(storageClassList.Items, func(sc storagev1.StorageClass, _ int) bool {
+		return sc.Annotations[IsDefaultStorageClassAnnotation] == "true"
+	})
+	if len(defaults) == 0 {
+		return "", nil
+	}
+	// Sort the default StorageClasses by timestamp and take the newest one
+	// https://github.com/kubernetes/kubernetes/pull/110559
+	sort.Slice(defaults, func(i, j int) bool {
+		return defaults[i].CreationTimestamp.After(defaults[j].CreationTimestamp.Time)
+	})
+	defaultStorageClass.Set(defaults[0].Name)
+	return defaults[0].Name, nil
+}

--- a/pkg/scheduling/volumeusage.go
+++ b/pkg/scheduling/volumeusage.go
@@ -17,8 +17,6 @@ package scheduling
 import (
 	"context"
 	"fmt"
-	"sort"
-	"time"
 
 	"github.com/samber/lo"
 	csitranslation "k8s.io/csi-translation-lib"
@@ -30,12 +28,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	"github.com/aws/karpenter-core/pkg/utils/atomic"
-)
-
-const (
-	IsDefaultStorageClassAnnotation = "storageclass.kubernetes.io/is-default-class"
 )
 
 // translator is a CSI Translator that translates in-tree plugin names to their out-of-tree CSI driver names
@@ -47,14 +39,6 @@ var translator = csitranslation.New()
 type VolumeUsage struct {
 	volumes    volumes
 	podVolumes map[types.NamespacedName]volumes
-}
-
-// Cache the lookup of our default storage class, global atomic cache since the volume usage is per node
-var defaultStorageClass = atomic.NewCachedVariable[string](1 * time.Minute)
-
-// ResetDefaultStorageClass is intended to be called from unit tests to reset the default storage class
-func ResetDefaultStorageClass() {
-	defaultStorageClass.Reset()
 }
 
 func NewVolumeUsage() *VolumeUsage {
@@ -168,7 +152,7 @@ func (v *VolumeUsage) Validate(ctx context.Context, kubeClient client.Client, po
 func (v *VolumeUsage) validate(ctx context.Context, kubeClient client.Client, pod *v1.Pod) (volumes, error) {
 	ctx = logging.WithLogger(ctx, logging.FromContext(ctx).With("pod", pod.Name))
 	podPVCs := volumes{}
-	defaultStorageClassName, err := v.discoverDefaultStorageClassName(ctx, kubeClient)
+	defaultStorageClassName, err := DiscoverDefaultStorageClassName(ctx, kubeClient)
 	if err != nil {
 		return nil, fmt.Errorf("discovering default storage class, %w", err)
 	}
@@ -204,31 +188,6 @@ func (v *VolumeUsage) validate(ctx context.Context, kubeClient client.Client, po
 		}
 	}
 	return podPVCs, nil
-}
-
-func (v *VolumeUsage) discoverDefaultStorageClassName(ctx context.Context, kubeClient client.Client) (string, error) {
-	if name, ok := defaultStorageClass.Get(); ok {
-		return name, nil
-	}
-
-	storageClassList := &storagev1.StorageClassList{}
-	if err := kubeClient.List(ctx, storageClassList); err != nil {
-		return "", err
-	}
-	// Find all StorageClasses that have the default annotation
-	defaults := lo.Filter(storageClassList.Items, func(sc storagev1.StorageClass, _ int) bool {
-		return sc.Annotations[IsDefaultStorageClassAnnotation] == "true"
-	})
-	if len(defaults) == 0 {
-		return "", nil
-	}
-	// Sort the default StorageClasses by timestamp and take the newest one
-	// https://github.com/kubernetes/kubernetes/pull/110559
-	sort.Slice(defaults, func(i, j int) bool {
-		return defaults[i].CreationTimestamp.After(defaults[j].CreationTimestamp.Time)
-	})
-	defaultStorageClass.Set(defaults[0].Name)
-	return defaults[0].Name, nil
 }
 
 // resolveDriver resolves the storage driver name in the following order:


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Prior to this change, Karpenter would only handle volume topology for PVCs that were directly reference by pods through the `.spec.volumes[*].persistentVolumeClaim` field; however, pods can also reference [dynamically-generated generic ephemeral volumes](https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/#generic-ephemeral-volumes), referenced through `.spec.volumes[*].ephemeral`. We did not respect PVCs that were bound to pods with volume topology. This change allows us to handle ephemeral volumes and scale-out if the current nodes do not satisfy the volume topology.

**How was this change tested?**

- `make presubmit`
- Deploying bound PVC/PV to cluster, removing nodes and expecting Karpenter to assign volume topologies correctly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
