### PR TITLE
fix: Add volume limit to StateNode from Machine

### DIFF
--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -358,16 +358,20 @@ func (c *Cluster) newStateFromMachine(machine *v1alpha5.Machine, oldNode *StateN
 		oldNode = NewNode()
 	}
 	n := &StateNode{
-		Node:              oldNode.Node,
-		Machine:           machine,
-		hostPortUsage:     oldNode.hostPortUsage,
-		volumeUsage:       oldNode.volumeUsage,
-		daemonSetRequests: oldNode.daemonSetRequests,
-		daemonSetLimits:   oldNode.daemonSetLimits,
-		podRequests:       oldNode.podRequests,
-		podLimits:         oldNode.podLimits,
-		markedForDeletion: oldNode.markedForDeletion,
-		nominatedUntil:    oldNode.nominatedUntil,
+		Node:                oldNode.Node,
+		Machine:             machine,
+		inflightAllocatable: oldNode.inflightAllocatable,
+		inflightCapacity:    oldNode.inflightCapacity,
+		startupTaints:       oldNode.startupTaints,
+		hostPortUsage:       oldNode.hostPortUsage,
+		volumeUsage:         oldNode.volumeUsage,
+		volumeLimits:        oldNode.volumeLimits,
+		daemonSetRequests:   oldNode.daemonSetRequests,
+		daemonSetLimits:     oldNode.daemonSetLimits,
+		podRequests:         oldNode.podRequests,
+		podLimits:           oldNode.podLimits,
+		markedForDeletion:   oldNode.markedForDeletion,
+		nominatedUntil:      oldNode.nominatedUntil,
 	}
 	// Cleanup the old machine with its old providerID if its providerID changes
 	// This can happen since nodes don't get created with providerIDs. Rather, CCM picks up the


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes https://github.com/aws/karpenter/issues/4254

**Description**
- Currently karpenter is not taking into account the node volume limit when recoiling machines into the state node. 
- This results in consolidation not being able to determine volume limits that can block nodes from running on other pods.

**How was this change tested?**
- `make presubmit`
- Deployed a stateful into a cluster and scaled to a 100 replicas to find consolidation 
- karpenter e2e tests 
- Need to include more integration testing https://github.com/aws/karpenter/issues/4382

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
