### PR TITLE
chore: Update cloud provider interface to provide drifted reason

### DIFF
--- a/pkg/cloudprovider/fake/cloudprovider.go
+++ b/pkg/cloudprovider/fake/cloudprovider.go
@@ -48,7 +48,7 @@ type CloudProvider struct {
 	DeleteCalls        []*v1alpha5.Machine
 
 	CreatedMachines map[string]*v1alpha5.Machine
-	Drifted         bool
+	Drifted         cloudprovider.DriftReason
 }
 
 func NewCloudProvider() *CloudProvider {
@@ -67,7 +67,7 @@ func (c *CloudProvider) Reset() {
 	c.AllowedCreateCalls = math.MaxInt
 	c.NextCreateErr = nil
 	c.DeleteCalls = []*v1alpha5.Machine{}
-	c.Drifted = false
+	c.Drifted = "drifted"
 }
 
 func (c *CloudProvider) Create(ctx context.Context, machine *v1alpha5.Machine) (*v1alpha5.Machine, error) {
@@ -207,7 +207,7 @@ func (c *CloudProvider) Delete(_ context.Context, m *v1alpha5.Machine) error {
 	return cloudprovider.NewMachineNotFoundError(fmt.Errorf("no machine exists with provider id '%s'", m.Status.ProviderID))
 }
 
-func (c *CloudProvider) IsMachineDrifted(context.Context, *v1alpha5.Machine) (bool, error) {
+func (c *CloudProvider) IsMachineDrifted(context.Context, *v1alpha5.Machine) (cloudprovider.DriftReason, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 

--- a/pkg/cloudprovider/metrics/cloudprovider.go
+++ b/pkg/cloudprovider/metrics/cloudprovider.go
@@ -142,7 +142,7 @@ func (d *decorator) GetInstanceTypes(ctx context.Context, provisioner *v1alpha5.
 	return instanceType, err
 }
 
-func (d *decorator) IsMachineDrifted(ctx context.Context, machine *v1alpha5.Machine) (bool, error) {
+func (d *decorator) IsMachineDrifted(ctx context.Context, machine *v1alpha5.Machine) (cloudprovider.DriftReason, error) {
 	method := "IsMachineDrifted"
 	defer metrics.Measure(methodDurationHistogramVec.With(getLabelsMapForDuration(ctx, d, method)))()
 	isDrifted, err := d.CloudProvider.IsMachineDrifted(ctx, machine)

--- a/pkg/cloudprovider/types.go
+++ b/pkg/cloudprovider/types.go
@@ -30,6 +30,8 @@ import (
 	"github.com/aws/karpenter-core/pkg/utils/resources"
 )
 
+type DriftReason string
+
 // CloudProvider interface is implemented by cloud providers to support provisioning.
 type CloudProvider interface {
 	// Create launches a machine with the given resource requests and requirements and returns a hydrated
@@ -48,7 +50,7 @@ type CloudProvider interface {
 	GetInstanceTypes(context.Context, *v1alpha5.Provisioner) ([]*InstanceType, error)
 	// IsMachineDrifted returns whether a machine has drifted from the provisioning requirements
 	// it is tied to.
-	IsMachineDrifted(context.Context, *v1alpha5.Machine) (bool, error)
+	IsMachineDrifted(context.Context, *v1alpha5.Machine) (DriftReason, error)
 	// Name returns the CloudProvider implementation name.
 	Name() string
 }

--- a/pkg/controllers/machine/disruption/drift_test.go
+++ b/pkg/controllers/machine/disruption/drift_test.go
@@ -56,7 +56,7 @@ var _ = Describe("Drift", func() {
 		machine.StatusConditions().MarkTrue(v1alpha5.MachineLaunched)
 	})
 	It("should detect drift", func() {
-		cp.Drifted = true
+		cp.Drifted = "drifted"
 		ExpectApplied(ctx, env.Client, provisioner, machine)
 		ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKeyFromObject(machine))
 
@@ -64,7 +64,7 @@ var _ = Describe("Drift", func() {
 		Expect(machine.StatusConditions().GetCondition(v1alpha5.MachineDrifted).IsTrue()).To(BeTrue())
 	})
 	It("should not detect drift if the feature flag is disabled", func() {
-		cp.Drifted = true
+		cp.Drifted = "drifted"
 		ctx = settings.ToContext(ctx, test.Settings(settings.Settings{DriftEnabled: false}))
 		ExpectApplied(ctx, env.Client, provisioner, machine)
 		ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKeyFromObject(machine))
@@ -73,7 +73,7 @@ var _ = Describe("Drift", func() {
 		Expect(machine.StatusConditions().GetCondition(v1alpha5.MachineDrifted)).To(BeNil())
 	})
 	It("should remove the status condition from the machine if the feature flag is disabled", func() {
-		cp.Drifted = true
+		cp.Drifted = "drifted"
 		ctx = settings.ToContext(ctx, test.Settings(settings.Settings{DriftEnabled: false}))
 		machine.StatusConditions().MarkTrue(v1alpha5.MachineDrifted)
 		ExpectApplied(ctx, env.Client, provisioner, machine)
@@ -84,7 +84,7 @@ var _ = Describe("Drift", func() {
 		Expect(machine.StatusConditions().GetCondition(v1alpha5.MachineDrifted)).To(BeNil())
 	})
 	It("should remove the status condition from the machine when the machine launch condition is false", func() {
-		cp.Drifted = true
+		cp.Drifted = "drifted"
 		machine.StatusConditions().MarkTrue(v1alpha5.MachineDrifted)
 		ExpectApplied(ctx, env.Client, provisioner, machine, node)
 		machine.StatusConditions().MarkFalse(v1alpha5.MachineLaunched, "", "")
@@ -96,7 +96,7 @@ var _ = Describe("Drift", func() {
 		Expect(machine.StatusConditions().GetCondition(v1alpha5.MachineDrifted)).To(BeNil())
 	})
 	It("should remove the status condition from the machine when the machine launch condition doesn't exist", func() {
-		cp.Drifted = true
+		cp.Drifted = "drifted"
 		machine.StatusConditions().MarkTrue(v1alpha5.MachineDrifted)
 		ExpectApplied(ctx, env.Client, provisioner, machine, node)
 		machine.Status.Conditions = lo.Reject(machine.Status.Conditions, func(s apis.Condition, _ int) bool {
@@ -110,7 +110,7 @@ var _ = Describe("Drift", func() {
 		Expect(machine.StatusConditions().GetCondition(v1alpha5.MachineDrifted)).To(BeNil())
 	})
 	It("should not detect drift if the provisioner does not exist", func() {
-		cp.Drifted = true
+		cp.Drifted = "drifted"
 		ExpectApplied(ctx, env.Client, machine)
 		ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKeyFromObject(machine))
 
@@ -118,7 +118,7 @@ var _ = Describe("Drift", func() {
 		Expect(machine.StatusConditions().GetCondition(v1alpha5.MachineDrifted)).To(BeNil())
 	})
 	It("should remove the status condition from the machine if the machine is no longer drifted", func() {
-		cp.Drifted = false
+		cp.Drifted = ""
 		machine.StatusConditions().MarkTrue(v1alpha5.MachineDrifted)
 		ExpectApplied(ctx, env.Client, provisioner, machine)
 
@@ -130,7 +130,7 @@ var _ = Describe("Drift", func() {
 	Context("NodeRequirement Drift", func() {
 		DescribeTable("",
 			func(oldProvisionerReq []v1.NodeSelectorRequirement, newProvisionerReq []v1.NodeSelectorRequirement, machineLabels map[string]string, drifted bool) {
-				cp.Drifted = false
+				cp.Drifted = ""
 				provisioner.Spec.Requirements = oldProvisionerReq
 				machine.Labels = lo.Assign(machine.Labels, machineLabels)
 
@@ -280,7 +280,7 @@ var _ = Describe("Drift", func() {
 			),
 		)
 		It("should return drifted only on machines that are drifted from an updated provisioner", func() {
-			cp.Drifted = false
+			cp.Drifted = ""
 			provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
 				{Key: v1alpha5.LabelCapacityType, Operator: v1.NodeSelectorOpIn, Values: []string{v1alpha5.CapacityTypeOnDemand}},
 				{Key: v1.LabelOSStable, Operator: v1.NodeSelectorOpIn, Values: []string{string(v1.Linux), string(v1.Windows)}},
@@ -336,7 +336,7 @@ var _ = Describe("Drift", func() {
 		var testProvisionerOptions test.ProvisionerOptions
 		var provisionerController controller.Controller
 		BeforeEach(func() {
-			cp.Drifted = false
+			cp.Drifted = ""
 			provisionerController = controllerprov.NewController(env.Client)
 			testProvisionerOptions = test.ProvisionerOptions{
 				ObjectMeta: provisioner.ObjectMeta,

--- a/pkg/controllers/machine/disruption/suite_test.go
+++ b/pkg/controllers/machine/disruption/suite_test.go
@@ -98,7 +98,7 @@ var _ = Describe("Disruption", func() {
 		})
 	})
 	It("should set multiple disruption conditions simultaneously", func() {
-		cp.Drifted = true
+		cp.Drifted = "drifted"
 		provisioner.Spec.TTLSecondsAfterEmpty = ptr.Int64(30)
 		provisioner.Spec.TTLSecondsUntilExpired = ptr.Int64(30)
 		node.Annotations = lo.Assign(node.Annotations, map[string]string{

--- a/pkg/controllers/machine/disruption/types.go
+++ b/pkg/controllers/machine/disruption/types.go
@@ -1,0 +1,25 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disruption
+
+import (
+	"github.com/aws/karpenter-core/pkg/cloudprovider"
+)
+
+const (
+	StaticDrift          cloudprovider.DriftReason = "StaticDrift"
+	NodeRequirementDrift cloudprovider.DriftReason = "NodeRequirementDrift"
+	NotDrifted           cloudprovider.DriftReason = ""
+)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
- To pass metric the cloud provider should pass back the field that is considered for logging and metrics 

**How was this change tested?**
- `make test`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
