### PR TITLE
chore: Enable `v1beta1/NodeClaim` conversion in consistency controller

### DIFF
--- a/pkg/controllers/consistency/suite_test.go
+++ b/pkg/controllers/consistency/suite_test.go
@@ -65,7 +65,7 @@ var _ = BeforeSuite(func() {
 	ctx = settings.ToContext(ctx, test.Settings())
 	cp = &fake.CloudProvider{}
 	recorder = test.NewEventRecorder()
-	consistencyController = consistency.NewController(fakeClock, env.Client, recorder, cp)
+	consistencyController = consistency.NewMachineController(fakeClock, env.Client, recorder, cp)
 })
 
 var _ = AfterSuite(func() {

--- a/pkg/controllers/consistency/termination.go
+++ b/pkg/controllers/consistency/termination.go
@@ -21,7 +21,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
+	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-core/pkg/controllers/deprovisioning"
 	nodeutils "github.com/aws/karpenter-core/pkg/utils/node"
 )
@@ -37,9 +37,9 @@ func NewTermination(kubeClient client.Client) Check {
 	}
 }
 
-func (t *Termination) Check(ctx context.Context, node *v1.Node, machine *v1alpha5.Machine) ([]Issue, error) {
+func (t *Termination) Check(ctx context.Context, node *v1.Node, nodeClaim *v1beta1.NodeClaim) ([]Issue, error) {
 	// we are only looking at nodes that are hung deleting
-	if machine.DeletionTimestamp.IsZero() {
+	if nodeClaim.DeletionTimestamp.IsZero() {
 		return nil, nil
 	}
 	pdbs, err := deprovisioning.NewPDBLimits(ctx, t.kubeClient)

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -70,7 +70,7 @@ func NewControllers(
 		metricspod.NewController(kubeClient),
 		metricsprovisioner.NewController(kubeClient),
 		counter.NewProvisionerController(kubeClient, cluster),
-		consistency.NewController(clock, kubeClient, recorder, cloudProvider),
+		consistency.NewMachineController(clock, kubeClient, recorder, cloudProvider),
 		nodeclaimlifecycle.NewMachineController(clock, kubeClient, cloudProvider, recorder),
 		nodeclaimgarbagecollection.NewController(clock, kubeClient, cloudProvider),
 		nodeclaimtermination.NewMachineController(kubeClient, cloudProvider),


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR starts staging out the changes for `v1beta1` to be supported across all controllers. It adds conversion for `v1alpha5.Machine`s into `v1beta1.NodeClaim`s so that all Machines and NodeClaims are treated the same in-memory for the Consistency Controller to update the status for the `NodeClaim` and the `Machine`

**How was this change tested?**

`make presubmit`
`make apply`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
