### PR TITLE
chore: Enable `v1beta1/NodePool` conversion in counter controller

### DIFF
--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -69,7 +69,7 @@ func NewControllers(
 		termination.NewController(kubeClient, cloudProvider, terminator, recorder),
 		metricspod.NewController(kubeClient),
 		metricsprovisioner.NewController(kubeClient),
-		counter.NewController(kubeClient, cluster),
+		counter.NewProvisionerController(kubeClient, cluster),
 		consistency.NewController(clock, kubeClient, recorder, cloudProvider),
 		nodeclaimlifecycle.NewMachineController(clock, kubeClient, cloudProvider, recorder),
 		nodeclaimgarbagecollection.NewController(clock, kubeClient, cloudProvider),


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR starts staging out the changes for `v1beta1` to be supported across all controllers. It adds conversion for `v1alpha5.Provisioner`s into `v1beta1.NodePool`s so that all Provisioners and NodePools are treated the same in-memory for the Counter controller to update the status for the `NodePool` and the `Provisioner`.

**How was this change tested?**

`make presubmit`
`make apply`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
