### PR TITLE
fix: continue for expiration/drift when pods cannot reschedule

### DIFF
--- a/pkg/controllers/deprovisioning/drift.go
+++ b/pkg/controllers/deprovisioning/drift.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/aws/karpenter-core/pkg/apis/settings"
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
+	deprovisioningevents "github.com/aws/karpenter-core/pkg/controllers/deprovisioning/events"
 	"github.com/aws/karpenter-core/pkg/controllers/provisioning"
 	"github.com/aws/karpenter-core/pkg/controllers/state"
 	"github.com/aws/karpenter-core/pkg/events"
@@ -85,7 +86,9 @@ func (d *Drift) ComputeCommand(ctx context.Context, nodes ...*Candidate) (Comman
 		}
 		// Log when all pods can't schedule, as the command will get executed immediately.
 		if !results.AllPodsScheduled() {
-			logging.FromContext(ctx).With("machine", candidate.Machine.Name, "node", candidate.Node.Name).Debug("Continuing to terminate drifted machine after scheduling simulation failed to schedule all pods %s", results.PodSchedulingErrors())
+			logging.FromContext(ctx).With("machine", candidate.Machine.Name, "node", candidate.Node.Name).Debugf("cannot terminate drifted machine since scheduling simulation failed to schedule all pods %s", results.PodSchedulingErrors())
+			d.recorder.Publish(deprovisioningevents.Blocked(candidate.Node, candidate.Machine, "scheduling simulation failed to schedule all pods")...)
+			continue
 		}
 		if len(results.NewMachines) == 0 {
 			return Command{

--- a/pkg/controllers/deprovisioning/expiration_test.go
+++ b/pkg/controllers/deprovisioning/expiration_test.go
@@ -126,11 +126,19 @@ var _ = Describe("Expiration", func() {
 		// inform cluster state about nodes and machines
 		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node2}, []*v1alpha5.Machine{machine2})
 
+		// deprovisioning won't delete the old node until the new node is ready
+		var wg sync.WaitGroup
+		ExpectTriggerVerifyAction(&wg)
+		ExpectMakeNewMachinesReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
 		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		wg.Wait()
 
-		Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(1))
-		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
+		ExpectMachinesCascadeDeletion(ctx, env.Client, machine, machine2)
+
+		Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(2))
+		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(2))
 		ExpectExists(ctx, env.Client, machine)
+		ExpectNotFound(ctx, env.Client, machine2)
 	})
 	It("should ignore nodes with the expired status condition set to false", func() {
 		machine.StatusConditions().MarkFalse(v1alpha5.MachineExpired, "", "")

--- a/pkg/controllers/deprovisioning/expiration_test.go
+++ b/pkg/controllers/deprovisioning/expiration_test.go
@@ -44,6 +44,9 @@ var _ = Describe("Expiration", func() {
 	BeforeEach(func() {
 		prov = test.Provisioner(test.ProvisionerOptions{
 			TTLSecondsUntilExpired: ptr.Int64(30),
+			Limits: v1.ResourceList{
+				v1.ResourceCPU: resource.MustParse("100"),
+			},
 		})
 		machine, node = test.MachineAndNode(v1alpha5.Machine{
 			ObjectMeta: metav1.ObjectMeta{
@@ -74,6 +77,57 @@ var _ = Describe("Expiration", func() {
 		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
 
 		// Expect to not create or delete more machines
+		Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(1))
+		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
+		ExpectExists(ctx, env.Client, machine)
+	})
+	It("should continue to the next expired node if the first cannot reschedule all pods", func() {
+		pod := test.Pod(test.PodOptions{
+			ResourceRequirements: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU: resource.MustParse("150"),
+				},
+			},
+		})
+		podToExpire := test.Pod(test.PodOptions{
+			ResourceRequirements: v1.ResourceRequirements{
+				Requests: v1.ResourceList{
+					v1.ResourceCPU: resource.MustParse("1"),
+				},
+			},
+		})
+		ExpectApplied(ctx, env.Client, machine, node, prov, pod)
+		ExpectManualBinding(ctx, env.Client, pod, node)
+
+		// inform cluster state about nodes and machines
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
+
+		machine2, node2 := test.MachineAndNode(v1alpha5.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					v1alpha5.ProvisionerNameLabelKey: prov.Name,
+					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name,
+					v1alpha5.LabelCapacityType:       mostExpensiveOffering.CapacityType,
+					v1.LabelTopologyZone:             mostExpensiveOffering.Zone,
+				},
+			},
+			Status: v1alpha5.MachineStatus{
+				ProviderID: test.RandomProviderID(),
+				Allocatable: map[v1.ResourceName]resource.Quantity{
+					v1.ResourceCPU:  resource.MustParse("1"),
+					v1.ResourcePods: resource.MustParse("100"),
+				},
+			},
+		})
+		machine2.StatusConditions().MarkTrue(v1alpha5.MachineExpired)
+		ExpectApplied(ctx, env.Client, machine2, node2, podToExpire)
+		ExpectManualBinding(ctx, env.Client, podToExpire, node2)
+
+		// inform cluster state about nodes and machines
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node2}, []*v1alpha5.Machine{machine2})
+
+		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+
 		Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(1))
 		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
 		ExpectExists(ctx, env.Client, machine)

--- a/pkg/utils/machine/machine.go
+++ b/pkg/utils/machine/machine.go
@@ -319,8 +319,7 @@ func GetExpirationTime(obj client.Object, provisioner *v1alpha5.Provisioner) tim
 	return obj.GetCreationTimestamp().Add(expirationTTL)
 }
 func GetDriftedTime(nodeClaim *v1alpha5.Machine) time.Time {
-	if nodeClaim.StatusConditions().GetCondition(v1alpha5.MachineDrifted) != nil &&
-		nodeClaim.StatusConditions().GetCondition(v1alpha5.MachineDrifted).IsTrue() {
+	if nodeClaim.StatusConditions().GetCondition(v1alpha5.MachineDrifted).IsTrue() {
 		return nodeClaim.StatusConditions().GetCondition(v1alpha5.MachineDrifted).LastTransitionTime.Inner.Time
 	}
 	return time.Date(5000, 0, 0, 0, 0, 0, 0, time.UTC)

--- a/pkg/utils/machine/machine.go
+++ b/pkg/utils/machine/machine.go
@@ -318,6 +318,13 @@ func GetExpirationTime(obj client.Object, provisioner *v1alpha5.Provisioner) tim
 	expirationTTL := time.Duration(ptr.Int64Value(provisioner.Spec.TTLSecondsUntilExpired)) * time.Second
 	return obj.GetCreationTimestamp().Add(expirationTTL)
 }
+func GetDriftedTime(nodeClaim *v1alpha5.Machine) time.Time {
+	if nodeClaim.StatusConditions().GetCondition(v1alpha5.MachineDrifted) != nil &&
+		nodeClaim.StatusConditions().GetCondition(v1alpha5.MachineDrifted).IsTrue() {
+		return nodeClaim.StatusConditions().GetCondition(v1alpha5.MachineDrifted).LastTransitionTime.Inner.Time
+	}
+	return time.Date(5000, 0, 0, 0, 0, 0, 0, time.UTC)
+}
 
 func IsPastEmptinessTTL(nodeClaim *v1alpha5.Machine, clock clock.Clock, provisioner *v1alpha5.Provisioner) bool {
 	return nodeClaim.StatusConditions().GetCondition(v1alpha5.MachineEmpty) != nil &&


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
When pods could not all schedule, expiration and drift would continue. This asserted that nodes that were expired or drifted would eventually be cleaned up. Yet, in the case where all replacement types were exhausted, this would just result in a delete action, which if the Provisioner has no correct configuration, could result in a scale to 0 situation. 

**How was this change tested?**
`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
