### PR TITLE
chore: debug log when we add requirements due to volumes

### DIFF
--- a/pkg/controllers/provisioning/scheduling/volumetopology.go
+++ b/pkg/controllers/provisioning/scheduling/volumetopology.go
@@ -22,6 +22,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"knative.dev/pkg/logging"
 	"knative.dev/pkg/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -67,6 +68,10 @@ func (v *VolumeTopology) Inject(ctx context.Context, pod *v1.Pod) error {
 		pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[i].MatchExpressions = append(
 			pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[i].MatchExpressions, requirements...)
 	}
+
+	logging.FromContext(ctx).
+		With("pod", client.ObjectKeyFromObject(pod)).
+		Debugf("adding requirements derived from pod volumes, %s", requirements)
 	return nil
 }
 


### PR DESCRIPTION
Fixes #N/A <!-- issue number -->

**Description**

These can affect scheduling decisions and make it difficult to debug why pods aren't scheduling.  With this change, the new requirements are logged and it should become easier to diagnose incompatibility between volumes and pod requirements. Currently this creates an empty set requirement and the pod just fails to schedule.

**How was this change tested?**
Unit testing and observed the new log.

```
DEBUG	scheduling/volumetopology.go:74	adding requirements derived from pod volumes, [{topology.kubernetes.io/zone In [test-zone-2 test-zone-3]}]	{"pod": "default/facegarnet-49-9jvxmqcv0v"}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
