### PR TITLE
fix: ignore permanently pending pods during consolidation

### DIFF
--- a/pkg/controllers/deprovisioning/consolidation.go
+++ b/pkg/controllers/deprovisioning/consolidation.go
@@ -124,7 +124,7 @@ func (c *consolidation) computeConsolidation(ctx context.Context, candidates ...
 	}
 
 	// if not all of the pods were scheduled, we can't do anything
-	if !results.AllPodsScheduled() {
+	if !results.AllNonPendingPodsScheduled() {
 		// This method is used by multi-node consolidation as well, so we'll only report in the single node case
 		if len(candidates) == 1 {
 			c.recorder.Publish(deprovisioningevents.Unconsolidatable(candidates[0].Node, candidates[0].Machine, results.PodSchedulingErrors())...)

--- a/pkg/controllers/deprovisioning/drift.go
+++ b/pkg/controllers/deprovisioning/drift.go
@@ -99,7 +99,7 @@ func (d *Drift) ComputeCommand(ctx context.Context, nodes ...*Candidate) (Comman
 			return Command{}, err
 		}
 		// Log when all pods can't schedule, as the command will get executed immediately.
-		if !results.AllPodsScheduled() {
+		if !results.AllNonPendingPodsScheduled() {
 			logging.FromContext(ctx).With("machine", candidate.Machine.Name, "node", candidate.Node.Name).Debugf("cannot terminate drifted machine since scheduling simulation failed to schedule all pods %s", results.PodSchedulingErrors())
 			d.recorder.Publish(deprovisioningevents.Blocked(candidate.Node, candidate.Machine, "scheduling simulation failed to schedule all pods")...)
 			continue

--- a/pkg/controllers/deprovisioning/expiration.go
+++ b/pkg/controllers/deprovisioning/expiration.go
@@ -105,7 +105,7 @@ func (e *Expiration) ComputeCommand(ctx context.Context, nodes ...*Candidate) (C
 			return Command{}, err
 		}
 		// Log when all pods can't schedule, as the command will get executed immediately.
-		if !results.AllPodsScheduled() {
+		if !results.AllNonPendingPodsScheduled() {
 			logging.FromContext(ctx).With("machine", candidate.Machine.Name, "node", candidate.Node.Name).Debugf("cannot terminate expired machine since scheduling simulation failed to schedule all pods, %s", results.PodSchedulingErrors())
 			e.recorder.Publish(deprovisioningevents.Blocked(candidate.Node, candidate.Machine, "scheduling simulation failed to schedule all pods")...)
 			continue

--- a/pkg/controllers/deprovisioning/validation.go
+++ b/pkg/controllers/deprovisioning/validation.go
@@ -128,7 +128,7 @@ func (v *Validation) ValidateCommand(ctx context.Context, cmd Command, candidate
 	if err != nil {
 		return false, fmt.Errorf("simluating scheduling, %w", err)
 	}
-	if !results.AllPodsScheduled() {
+	if !results.AllNonPendingPodsScheduled() {
 		return false, nil
 	}
 


### PR DESCRIPTION
Fixes #457

**Description**

We still consider pending pods for scheduling calculation purposes, but if a pod was pending before scheduling, we don't let the fact that we can't schedule it prevent consolidation. This ensures that permanently pending pods won't block consolidation.

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
