### PR TITLE
fix: ignore permanently pending pods for deprovisioning

### DIFF
--- a/pkg/controllers/deprovisioning/helpers.go
+++ b/pkg/controllers/deprovisioning/helpers.go
@@ -90,7 +90,7 @@ func simulateScheduling(ctx context.Context, kubeClient client.Client, cluster *
 	if err != nil {
 		return nil, fmt.Errorf("failed to get pods from deleting nodes, %w", err)
 	}
-	// start by getting all pending pendingPods
+	// start by getting all pending pods
 	pendingPods, err := provisioner.GetPendingPods(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("determining pending pods, %w", err)

--- a/pkg/controllers/deprovisioning/suite_test.go
+++ b/pkg/controllers/deprovisioning/suite_test.go
@@ -264,7 +264,6 @@ var _ = Describe("Replace Nodes", func() {
 		Expect(machines[0].Name).ToNot(Equal(machine.Name))
 		Expect(scheduling.NewNodeSelectorRequirements(machines[0].Spec.Requirements...).Has(v1.LabelInstanceTypeStable)).To(BeTrue())
 		Expect(scheduling.NewNodeSelectorRequirements(machines[0].Spec.Requirements...).Get(v1.LabelInstanceTypeStable).Has(mostExpensiveInstance.Name)).To(BeFalse())
-
 		// and delete the old one
 		ExpectNotFound(ctx, env.Client, machine, node)
 	})
@@ -1429,6 +1428,108 @@ var _ = Describe("Delete Node", func() {
 		Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(100))
 		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(100))
 		ExpectNotFound(ctx, env.Client, consolidatableMachine, consolidatableNode)
+	})
+	It("can delete nodes with a permanently pending pod", func() {
+		labels := map[string]string{
+			"app": "test",
+		}
+		// create our RS so we can link a pod to it
+		rs := test.ReplicaSet()
+		ExpectApplied(ctx, env.Client, rs)
+		pods := test.Pods(3, test.PodOptions{
+			ObjectMeta: metav1.ObjectMeta{Labels: labels,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion:         "apps/v1",
+						Kind:               "ReplicaSet",
+						Name:               rs.Name,
+						UID:                rs.UID,
+						Controller:         ptr.Bool(true),
+						BlockOwnerDeletion: ptr.Bool(true),
+					},
+				}}})
+
+		pending := test.UnschedulablePod(test.PodOptions{
+			NodeSelector: map[string]string{
+				"non-existent": "node-label",
+			},
+		})
+
+		ExpectApplied(ctx, env.Client, rs, pods[0], pods[1], pods[2], machine1, node1, machine2, node2, prov, pending)
+
+		// bind pods to node
+		ExpectManualBinding(ctx, env.Client, pods[0], node1)
+		ExpectManualBinding(ctx, env.Client, pods[1], node1)
+		ExpectManualBinding(ctx, env.Client, pods[2], node2)
+
+		// inform cluster state about nodes and machines
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node1, node2}, []*v1alpha5.Machine{machine1, machine2})
+
+		fakeClock.Step(10 * time.Minute)
+
+		var wg sync.WaitGroup
+		ExpectTriggerVerifyAction(&wg)
+		ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+		wg.Wait()
+
+		// Cascade any deletion of the machine to the node
+		ExpectMachinesCascadeDeletion(ctx, env.Client, machine2)
+
+		// we don't need a new node, but we should evict everything off one of node2 which only has a single pod
+		Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(1))
+		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
+		// and delete the old one
+		ExpectNotFound(ctx, env.Client, machine2, node2)
+
+		// pending pod is still here and hasn't been scheduled anywayre
+		pending = ExpectPodExists(ctx, env.Client, pending.Name, pending.Namespace)
+		Expect(pending.Spec.NodeName).To(BeEmpty())
+	})
+	It("won't delete nodes if it would make a non-pending pod go pending", func() {
+		labels := map[string]string{
+			"app": "test",
+		}
+		// create our RS so we can link a pod to it
+		rs := test.ReplicaSet()
+		ExpectApplied(ctx, env.Client, rs)
+		pods := test.Pods(3, test.PodOptions{
+			ObjectMeta: metav1.ObjectMeta{Labels: labels,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion:         "apps/v1",
+						Kind:               "ReplicaSet",
+						Name:               rs.Name,
+						UID:                rs.UID,
+						Controller:         ptr.Bool(true),
+						BlockOwnerDeletion: ptr.Bool(true),
+					},
+				}}})
+
+		// setup labels and node selectors so we force the pods onto the nodes we want
+		node1.Labels["foo"] = "1"
+		node2.Labels["foo"] = "2"
+
+		pods[0].Spec.NodeSelector = map[string]string{"foo": "1"}
+		pods[1].Spec.NodeSelector = map[string]string{"foo": "1"}
+		pods[2].Spec.NodeSelector = map[string]string{"foo": "2"}
+
+		ExpectApplied(ctx, env.Client, rs, pods[0], pods[1], pods[2], machine1, node1, machine2, node2, prov)
+
+		// bind pods to node
+		ExpectManualBinding(ctx, env.Client, pods[0], node1)
+		ExpectManualBinding(ctx, env.Client, pods[1], node1)
+		ExpectManualBinding(ctx, env.Client, pods[2], node2)
+
+		// inform cluster state about nodes and machines
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node1, node2}, []*v1alpha5.Machine{machine1, machine2})
+
+		fakeClock.Step(10 * time.Minute)
+
+		ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+
+		// No node can be deleted as it would cause one of the three pods to go pending
+		Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(2))
+		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(2))
 	})
 })
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #457 <!-- issue number -->

**Description**
When Karpenter deprovisions nodes, it pulls in any pending pods and pods on deleting nodes for its scheduling simulation. If there is a permanently pending pod or a deleting node that cannot reschedule, Karpenter will block deprovisioning for the candidate, even if the pods on the candidate could have been rescheduled.

This re-orders the initial logic so that candidate Pods are considered first, rather than pending pods first.

**How was this change tested?**
- make presubmit

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
