### PR TITLE
test: Deflake tests that validate deprovisioning ordering

### DIFF
--- a/pkg/controllers/deprovisioning/drift.go
+++ b/pkg/controllers/deprovisioning/drift.go
@@ -32,7 +32,6 @@ import (
 	"github.com/aws/karpenter-core/pkg/controllers/state"
 	"github.com/aws/karpenter-core/pkg/events"
 	"github.com/aws/karpenter-core/pkg/metrics"
-	machineutil "github.com/aws/karpenter-core/pkg/utils/machine"
 )
 
 // Drift is a subreconciler that deletes drifted machines.
@@ -66,7 +65,8 @@ func (d *Drift) filterAndSortCandidates(ctx context.Context, nodes []*Candidate)
 		return nil, fmt.Errorf("filtering candidates, %w", err)
 	}
 	sort.Slice(candidates, func(i int, j int) bool {
-		return machineutil.GetDriftedTime(candidates[i].Machine).Before(machineutil.GetDriftedTime(candidates[j].Machine))
+		return candidates[i].Machine.StatusConditions().GetCondition(v1alpha5.MachineDrifted).LastTransitionTime.Inner.Time.Before(
+			candidates[j].Machine.StatusConditions().GetCondition(v1alpha5.MachineDrifted).LastTransitionTime.Inner.Time)
 	})
 	return candidates, nil
 }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR deflakes two test cases that deal with the ordering of nodes by specifically setting a status condition to a later time rather than relying on the `.StatusConditions().MarkTrue()` mechanism which relies on `time.Now()` and was prone to race conditions.

**How was this change tested?**

`make deflake`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
