### PR TITLE
chore: Reduce event spam by replacing `command.String()`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/samber/lo v1.38.1
 	go.uber.org/multierr v1.11.0
 	go.uber.org/zap v1.24.0
+	golang.org/x/text v0.11.0
 	golang.org/x/time v0.3.0
 	k8s.io/api v0.26.6
 	k8s.io/apiextensions-apiserver v0.26.6
@@ -84,7 +85,6 @@ require (
 	golang.org/x/sync v0.2.0 // indirect
 	golang.org/x/sys v0.10.0 // indirect
 	golang.org/x/term v0.10.0 // indirect
-	golang.org/x/text v0.11.0 // indirect
 	golang.org/x/tools v0.9.3 // indirect
 	gomodules.xyz/jsonpatch/v2 v2.2.0 // indirect
 	google.golang.org/api v0.124.0 // indirect

--- a/pkg/controllers/deprovisioning/events/events.go
+++ b/pkg/controllers/deprovisioning/events/events.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"time"
 
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 	v1 "k8s.io/api/core/v1"
 
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
@@ -29,7 +31,7 @@ func Launching(machine *v1alpha5.Machine, reason string) events.Event {
 		InvolvedObject: machine,
 		Type:           v1.EventTypeNormal,
 		Reason:         "DeprovisioningLaunching",
-		Message:        fmt.Sprintf("Launching machine for %s", reason),
+		Message:        fmt.Sprintf("Launching machine: %s", cases.Title(language.Und, cases.NoLower).String(reason)),
 		DedupeValues:   []string{machine.Name, reason},
 	}
 }
@@ -60,14 +62,14 @@ func Terminating(node *v1.Node, machine *v1alpha5.Machine, reason string) []even
 			InvolvedObject: node,
 			Type:           v1.EventTypeNormal,
 			Reason:         "DeprovisioningTerminating",
-			Message:        fmt.Sprintf("Deprovisioning node via %s", reason),
+			Message:        fmt.Sprintf("Deprovisioning node: %s", cases.Title(language.Und, cases.NoLower).String(reason)),
 			DedupeValues:   []string{node.Name, reason},
 		},
 		{
 			InvolvedObject: machine,
 			Type:           v1.EventTypeNormal,
 			Reason:         "DeprovisioningTerminating",
-			Message:        fmt.Sprintf("Deprovisioning machine via %s", reason),
+			Message:        fmt.Sprintf("Deprovisioning machine: %s", cases.Title(language.Und, cases.NoLower).String(reason)),
 			DedupeValues:   []string{machine.Name, reason},
 		},
 	}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Deprovisioning events were spamming event messages by providing the entire command reason log output in the event for _each_ Node and _each_ Machine. This meant that when there was a deprovisioning action that was taken that affected multiple nodes, it would provide the full command output for each event, which wasn't useful and was quite spammy.

### Before PR

```console
10s         Normal    DeprovisioningTerminating       node/ip-192-168-97-252.us-west-2.compute.internal    Deprovisioning node via delete, terminating 100 machines ip-192-168-12-92.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-8-101.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-113-135.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-124-231.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-41-99.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-122-108.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-184-155.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-160-76.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-2-140.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-11-185.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-18-148.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-113-70.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-63-193.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-110-50.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-165-197.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-179-9.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-8-169.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-170-123.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-162-139.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-58-149.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-61-176.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-111-46.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-110-202.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-187-90.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-173-66.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-182-209.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-190-64.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-27-122.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-9-206.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-22-12.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-35-246.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-32-98.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-127-239.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-168-219.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-20-95.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-33-159.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-164-228.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-188-46.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-185-91.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-176-155.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-7-138.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-5-170.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-110-36.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-126-13.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-189-123.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-182-70.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-162-235.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-174-71.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-19-196.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-114-30.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-62-167.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-42-53.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-97-252.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-188-91.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-50-231.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-100-117.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-110-82.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-117-8.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-108-2.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-8-55.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-190-179.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-178-223.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-38-25.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-115-42.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-46-254.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-163-174.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-183-199.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-182-123.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-36-138.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-107-156.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-113-231.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-177-110.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-60-70.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-52-185.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-107-67.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-168-27.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-10-16.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-59-71.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-39-164.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-126-88.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-176-11.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-104-30.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-96-72.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-48-0.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-171-215.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-12-8.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-8-23.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-112-126.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-179-204.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-172-142.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-27-42.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-20-208.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-164-158.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-1-61.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-40-25.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-37-120.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-101-249.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-108-91.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-162-97.us-west-2.compute.internal/t3a.small/on-demand, ip-192-168-170-160.us-west-2.compute.internal/t3a.small/on-demand
```

### After PR 

```console
➜  karpenter git:(main) k get events --sort-by=.metadata.creationTimestamp | grep DeprovisioningTerminating | tail
66s         Normal    DeprovisioningTerminating       node/ip-192-168-170-178.us-west-2.compute.internal   Deprovisioning node via: Consolidation/Delete
66s         Normal    DeprovisioningTerminating       machine/default-wvngx                                Deprovisioning machine via: Consolidation/Delete
65s         Normal    DeprovisioningTerminating       machine/default-dds7t                                Deprovisioning machine via: Consolidation/Delete
66s         Normal    DeprovisioningTerminating       machine/default-dhrcv                                Deprovisioning machine via: Consolidation/Delete
66s         Normal    DeprovisioningTerminating       machine/default-rl5nw                                Deprovisioning machine via: Consolidation/Delete
66s         Normal    DeprovisioningTerminating       node/ip-192-168-47-44.us-west-2.compute.internal     Deprovisioning node via: Consolidation/Delete
66s         Normal    DeprovisioningTerminating       node/ip-192-168-114-120.us-west-2.compute.internal   Deprovisioning node via: Consolidation/Delete
66s         Normal    DeprovisioningTerminating       machine/default-f49cf                                Deprovisioning machine via: Consolidation/Delete
66s         Normal    DeprovisioningTerminating       node/ip-192-168-167-248.us-west-2.compute.internal   Deprovisioning node via: Consolidation/Delete
66s         Normal    DeprovisioningTerminating       node/ip-192-168-167-99.us-west-2.compute.internal    Deprovisioning node via: Consolidation/Delete
```

**How was this change tested?**

`make presubmit`
`make apply`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
