### PR TITLE
chore: Garbage Collect Leaked Node Lease

### DIFF
--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -25,6 +25,7 @@ import (
 	"github.com/aws/karpenter-core/pkg/controllers/consistency"
 	"github.com/aws/karpenter-core/pkg/controllers/counter"
 	"github.com/aws/karpenter-core/pkg/controllers/deprovisioning"
+	"github.com/aws/karpenter-core/pkg/controllers/leasegarbagecollection"
 	nodeclaimdisruption "github.com/aws/karpenter-core/pkg/controllers/machine/disruption"
 	nodeclaimgarbagecollection "github.com/aws/karpenter-core/pkg/controllers/machine/garbagecollection"
 	nodeclaimlifecycle "github.com/aws/karpenter-core/pkg/controllers/machine/lifecycle"
@@ -75,5 +76,6 @@ func NewControllers(
 		nodeclaimgarbagecollection.NewController(clock, kubeClient, cloudProvider),
 		nodeclaimtermination.NewMachineController(kubeClient, cloudProvider),
 		nodeclaimdisruption.NewMachineController(clock, kubeClient, cluster, cloudProvider),
+		leasegarbagecollection.NewController(kubeClient),
 	}
 }

--- a/pkg/controllers/leasegarbagecollection/controller.go
+++ b/pkg/controllers/leasegarbagecollection/controller.go
@@ -1,0 +1,69 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package leasegarbagecollection
+
+import (
+	"context"
+
+	v1 "k8s.io/api/coordination/v1"
+	"knative.dev/pkg/logging"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	corecontroller "github.com/aws/karpenter-core/pkg/operator/controller"
+)
+
+// Controller for the resource
+type Controller struct {
+	kubeClient client.Client
+}
+
+// NewController is a constructor
+func NewController(kubeClient client.Client) corecontroller.Controller {
+	return corecontroller.Typed[*v1.Lease](kubeClient, &Controller{
+		kubeClient: kubeClient,
+	})
+}
+
+func (c *Controller) Name() string {
+	return "lease.garbagecollection"
+}
+
+// Reconcile the resource
+func (c *Controller) Reconcile(ctx context.Context, l *v1.Lease) (reconcile.Result, error) {
+	if l.OwnerReferences != nil || l.Namespace != "kube-node-lease" {
+		return reconcile.Result{}, nil
+	}
+	err := c.kubeClient.Delete(ctx, l)
+	if err == nil {
+		logging.FromContext(ctx).Debug("found and delete leaked lease")
+		NodeLeaseDeletedCounter.Inc()
+	}
+
+	return reconcile.Result{}, client.IgnoreNotFound(err)
+}
+
+func (c *Controller) Builder(_ context.Context, m manager.Manager) corecontroller.Builder {
+	return corecontroller.Adapt(controllerruntime.
+		NewControllerManagedBy(m).
+		WithEventFilter(predicate.GenerationChangedPredicate{}).
+		For(&v1.Lease{}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: 10}),
+	)
+}

--- a/pkg/controllers/leasegarbagecollection/metrics.go
+++ b/pkg/controllers/leasegarbagecollection/metrics.go
@@ -1,0 +1,37 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package leasegarbagecollection
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	crmetrics "sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	"github.com/aws/karpenter-core/pkg/metrics"
+)
+
+var (
+	NodeLeaseDeletedCounter = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: "karpenter",
+			Subsystem: metrics.NodeSubsystem,
+			Name:      "leases_deleted",
+			Help:      "Number of deleted leaked leases.",
+		},
+	)
+)
+
+func init() {
+	crmetrics.Registry.MustRegister(NodeLeaseDeletedCounter)
+}

--- a/pkg/controllers/leasegarbagecollection/suite_test.go
+++ b/pkg/controllers/leasegarbagecollection/suite_test.go
@@ -1,0 +1,127 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package leasegarbagecollection_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	coordinationsv1 "k8s.io/api/coordination/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/samber/lo"
+
+	"github.com/aws/karpenter-core/pkg/apis"
+	"github.com/aws/karpenter-core/pkg/apis/settings"
+	"github.com/aws/karpenter-core/pkg/controllers/leasegarbagecollection"
+	"github.com/aws/karpenter-core/pkg/operator/controller"
+	"github.com/aws/karpenter-core/pkg/operator/scheme"
+	"github.com/aws/karpenter-core/pkg/test"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "knative.dev/pkg/logging/testing"
+
+	. "github.com/aws/karpenter-core/pkg/test/expectations"
+)
+
+var ctx context.Context
+var env *test.Environment
+var garbageCollectionController controller.Controller
+
+func TestAPIs(t *testing.T) {
+	ctx = TestContextWithLogger(t)
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "LeaseGarbageCollection")
+}
+
+var _ = BeforeSuite(func() {
+	env = test.NewEnvironment(scheme.Scheme, test.WithCRDs(apis.CRDs...))
+	ctx = settings.ToContext(ctx, test.Settings())
+
+	garbageCollectionController = leasegarbagecollection.NewController(env.Client)
+})
+
+var _ = AfterSuite(func() {
+	Expect(env.Stop()).To(Succeed(), "Failed to stop environment")
+})
+
+var _ = AfterEach(func() {
+	ExpectCleanedUp(ctx, env.Client)
+})
+
+var _ = Describe("GarbageCollection", func() {
+	var goodLease *coordinationsv1.Lease
+	var badLease *coordinationsv1.Lease
+	BeforeEach(func() {
+		node := test.Node(test.NodeOptions{})
+		ExpectApplied(ctx, env.Client, node)
+		node = ExpectExists(ctx, env.Client, node)
+		goodLease = &coordinationsv1.Lease{
+			ObjectMeta: v1.ObjectMeta{
+				CreationTimestamp: v1.Time{Time: time.Now().Add(-time.Hour * 2)},
+				Name:              "new-lease",
+				Namespace:         "kube-node-lease",
+				Labels:            map[string]string{test.DiscoveryLabel: "unspecified"},
+				OwnerReferences: []v1.OwnerReference{
+					{
+						APIVersion: "v1",
+						Name:       "owner-node",
+						Kind:       "Node",
+						UID:        node.UID,
+					},
+				},
+			},
+		}
+		badLease = &coordinationsv1.Lease{
+			ObjectMeta: v1.ObjectMeta{
+				CreationTimestamp: v1.Time{Time: time.Now().Add(-time.Hour * 2)},
+				Name:              "new-lease",
+				Namespace:         "kube-node-lease",
+				Labels:            map[string]string{test.DiscoveryLabel: "unspecified"},
+			},
+		}
+	})
+	Context("Metrics", func() {
+		It("should fire the leaseDeletedCounter metric when deleting leases", func() {
+			ExpectApplied(ctx, env.Client, badLease)
+			ExpectReconcileSucceeded(ctx, garbageCollectionController, client.ObjectKeyFromObject(badLease))
+			ExpectNotFound(ctx, env.Client, badLease)
+
+			m, ok := FindMetricWithLabelValues("karpenter_nodes_leases_deleted", map[string]string{})
+			Expect(ok).To(BeTrue())
+			Expect(lo.FromPtr(m.GetCounter().Value)).To(BeNumerically("==", 1.0))
+
+		})
+	})
+	It("should not delete node lease that contains an OwnerReference", func() {
+		ExpectApplied(ctx, env.Client, goodLease)
+		ExpectReconcileSucceeded(ctx, garbageCollectionController, client.ObjectKeyFromObject(goodLease))
+		ExpectExists(ctx, env.Client, goodLease)
+	})
+	It("should delete node lease that does not contain an OwnerReference", func() {
+		ExpectApplied(ctx, env.Client, badLease)
+		ExpectReconcileSucceeded(ctx, garbageCollectionController, client.ObjectKeyFromObject(badLease))
+		ExpectNotFound(ctx, env.Client, badLease)
+	})
+	It("should not delete node lease that does not contain OwnerReference in a outside of kube-node-lease namespace", func() {
+		badLease.Namespace = "kube-system"
+		ExpectApplied(ctx, env.Client, badLease)
+		ExpectReconcileSucceeded(ctx, garbageCollectionController, client.ObjectKeyFromObject(badLease))
+		ExpectExists(ctx, env.Client, badLease)
+	})
+})

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	nodeSubsystem      = "nodes"
+	NodeSubsystem      = "nodes"
 	machineSubsystem   = "machines"
 	nodeClaimSubsystem = "nodeclaims"
 )
@@ -110,7 +110,7 @@ var (
 	NodesCreatedCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: Namespace,
-			Subsystem: nodeSubsystem,
+			Subsystem: NodeSubsystem,
 			Name:      "created",
 			Help:      "Number of nodes created in total by Karpenter. Labeled by owning provisioner.",
 		},
@@ -122,7 +122,7 @@ var (
 	NodesTerminatedCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: Namespace,
-			Subsystem: nodeSubsystem,
+			Subsystem: NodeSubsystem,
 			Name:      "terminated",
 			Help:      "Number of nodes terminated in total by Karpenter. Labeled by owning provisioner.",
 		},


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
- As part of our mitigation strategy for https://github.com/aws/karpenter/issues/4363, we are implementing a controller to delete node leases that do not contain any OwnerReference. 
- This controller should be removed once https://github.com/kubernetes/kubernetes/issues/109777 is fixed upstream

**How was this change tested?**
- Manually tested

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
