### PR TITLE
chore: Enable `v1beta1/NodePool` provisioner hash controller

### DIFF
--- a/pkg/apis/v1beta1/labels.go
+++ b/pkg/apis/v1beta1/labels.go
@@ -43,6 +43,7 @@ const (
 	DoNotDisruptAnnotationKey          = Group + "/do-not-disrupt"
 	ProviderCompatabilityAnnotationKey = CompatabilityGroup + "/provider"
 	ManagedByAnnotationKey             = Group + "/managed-by"
+	NodePoolHashAnnotationKey          = Group + "/nodepool-hash"
 )
 
 // Karpenter specific finalizers

--- a/pkg/apis/v1beta1/nodeclaim.go
+++ b/pkg/apis/v1beta1/nodeclaim.go
@@ -33,10 +33,10 @@ type NodeClaimSpec struct {
 	StartupTaints []v1.Taint `json:"startupTaints,omitempty"`
 	// Requirements are layered with GetLabels and applied to every node.
 	// +optional
-	Requirements []v1.NodeSelectorRequirement `json:"requirements,omitempty"`
+	Requirements []v1.NodeSelectorRequirement `json:"requirements,omitempty" hash:"ignore"`
 	// Resources models the resource requirements for the NodeClaim to launch
 	// +optional
-	Resources ResourceRequirements `json:"resources,omitempty"`
+	Resources ResourceRequirements `json:"resources,omitempty" hash:"ignore"`
 	// KubeletConfiguration are options passed to the kubelet when provisioning nodes
 	// +optional
 	KubeletConfiguration *KubeletConfiguration `json:"kubeletConfiguration,omitempty"`

--- a/pkg/apis/v1beta1/nodepool.go
+++ b/pkg/apis/v1beta1/nodepool.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/mitchellh/hashstructure/v2"
+	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/ptr"
@@ -121,6 +123,14 @@ type NodePool struct {
 	// is actually referring to a Provisioner object. This value is not actually part of the v1beta1 public-facing API
 	// TODO @joinnis: Remove this field when v1alpha5 is unsupported in a future version of Karpenter
 	IsProvisioner bool `json:"-"`
+}
+
+func (in *NodePool) Hash() string {
+	return fmt.Sprint(lo.Must(hashstructure.Hash(in.Spec.Template, hashstructure.FormatV2, &hashstructure.HashOptions{
+		SlicesAsSets:    true,
+		IgnoreZeroValue: true,
+		ZeroNil:         true,
+	})))
 }
 
 // NodePoolList contains a list of NodePool

--- a/pkg/apis/v1beta1/nodepool_validation.go
+++ b/pkg/apis/v1beta1/nodepool_validation.go
@@ -45,6 +45,9 @@ func (in *NodePoolSpec) validate() (errs *apis.FieldError) {
 }
 
 func (in *NodeClaimTemplate) validate() (errs *apis.FieldError) {
+	if len(in.Spec.Resources.Requests) > 0 {
+		errs = errs.Also(apis.ErrDisallowedFields("resources.requests"))
+	}
 	return errs.Also(
 		in.validateLabels().ViaField("metadata"),
 		in.Spec.validate().ViaField("spec"),

--- a/pkg/apis/v1beta1/nodepool_validation_test.go
+++ b/pkg/apis/v1beta1/nodepool_validation_test.go
@@ -87,6 +87,12 @@ var _ = Describe("Validation", func() {
 		})
 	})
 	Context("Template", func() {
+		It("should fail if resource requests are set", func() {
+			nodePool.Spec.Template.Spec.Resources.Requests = v1.ResourceList{
+				v1.ResourceCPU: resource.MustParse("5"),
+			}
+			Expect(nodePool.Validate(ctx)).ToNot(Succeed())
+		})
 		Context("Labels", func() {
 			It("should allow unrecognized labels", func() {
 				nodePool.Spec.Template.Labels = map[string]string{"foo": randomdata.SillyName()}

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -32,7 +32,7 @@ import (
 	metricspod "github.com/aws/karpenter-core/pkg/controllers/metrics/pod"
 	metricsprovisioner "github.com/aws/karpenter-core/pkg/controllers/metrics/provisioner"
 	metricsstate "github.com/aws/karpenter-core/pkg/controllers/metrics/state"
-	coreprovisioner "github.com/aws/karpenter-core/pkg/controllers/provisioner"
+	"github.com/aws/karpenter-core/pkg/controllers/provisioner"
 	"github.com/aws/karpenter-core/pkg/controllers/provisioning"
 	"github.com/aws/karpenter-core/pkg/controllers/state"
 	"github.com/aws/karpenter-core/pkg/controllers/state/informer"
@@ -52,15 +52,15 @@ func NewControllers(
 	cloudProvider cloudprovider.CloudProvider,
 ) []controller.Controller {
 
-	provisioner := provisioning.NewProvisioner(kubeClient, kubernetesInterface.CoreV1(), recorder, cloudProvider, cluster)
+	p := provisioning.NewProvisioner(kubeClient, kubernetesInterface.CoreV1(), recorder, cloudProvider, cluster)
 	terminator := terminator.NewTerminator(clock, kubeClient, terminator.NewEvictionQueue(ctx, kubernetesInterface.CoreV1(), recorder))
 
 	return []controller.Controller{
-		provisioner,
+		p,
 		metricsstate.NewController(cluster),
-		deprovisioning.NewController(clock, kubeClient, provisioner, cloudProvider, recorder, cluster),
-		provisioning.NewController(kubeClient, provisioner, recorder),
-		coreprovisioner.NewController(kubeClient),
+		deprovisioning.NewController(clock, kubeClient, p, cloudProvider, recorder, cluster),
+		provisioning.NewController(kubeClient, p, recorder),
+		provisioner.NewProvisionerController(kubeClient),
 		informer.NewDaemonSetController(kubeClient, cluster),
 		informer.NewNodeController(kubeClient, cluster),
 		informer.NewPodController(kubeClient, cluster),

--- a/pkg/controllers/machine/disruption/drift_test.go
+++ b/pkg/controllers/machine/disruption/drift_test.go
@@ -365,7 +365,7 @@ var _ = Describe("Drift", func() {
 		var provisionerController controller.Controller
 		BeforeEach(func() {
 			cp.Drifted = ""
-			provisionerController = controllerprov.NewController(env.Client)
+			provisionerController = controllerprov.NewProvisionerController(env.Client)
 			testProvisionerOptions = test.ProvisionerOptions{
 				ObjectMeta: provisioner.ObjectMeta,
 				Taints: []v1.Taint{


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR starts staging out the changes for `v1beta1` to be supported across all controllers. It adds support for reconciling the NodePool hash in the same way that we reconcile the Provisioner hash in the current Provisioner hash controller.

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
