### PR TITLE
feat: move blocked conditions to the machine status conditions

### DIFF
--- a/pkg/apis/v1beta1/nodeclaim_status.go
+++ b/pkg/apis/v1beta1/nodeclaim_status.go
@@ -60,6 +60,7 @@ var (
 	NodeDrifted       apis.ConditionType = "NodeDrifted"
 	NodeExpired       apis.ConditionType = "NodeExpired"
 	NodeUnderutilized apis.ConditionType = "NodeUnderutilized"
+	NodeDeprovisioningBlocked apis.ConditionType = "NodeDeprovisioningBlocked"
 )
 
 func (in *NodeClaim) GetConditions() apis.Conditions {

--- a/pkg/apis/v1beta1/nodeclaim_status.go
+++ b/pkg/apis/v1beta1/nodeclaim_status.go
@@ -53,13 +53,13 @@ var LivingConditions = []apis.ConditionType{
 }
 
 var (
-	NodeLaunched      apis.ConditionType = "NodeLaunched"
-	NodeRegistered    apis.ConditionType = "NodeRegistered"
-	NodeInitialized   apis.ConditionType = "NodeInitialized"
-	NodeEmpty         apis.ConditionType = "NodeEmpty"
-	NodeDrifted       apis.ConditionType = "NodeDrifted"
-	NodeExpired       apis.ConditionType = "NodeExpired"
-	NodeUnderutilized apis.ConditionType = "NodeUnderutilized"
+	NodeLaunched              apis.ConditionType = "NodeLaunched"
+	NodeRegistered            apis.ConditionType = "NodeRegistered"
+	NodeInitialized           apis.ConditionType = "NodeInitialized"
+	NodeEmpty                 apis.ConditionType = "NodeEmpty"
+	NodeDrifted               apis.ConditionType = "NodeDrifted"
+	NodeExpired               apis.ConditionType = "NodeExpired"
+	NodeUnderutilized         apis.ConditionType = "NodeUnderutilized"
 	NodeDeprovisioningBlocked apis.ConditionType = "NodeDeprovisioningBlocked"
 )
 

--- a/pkg/controllers/deprovisioning/helpers.go
+++ b/pkg/controllers/deprovisioning/helpers.go
@@ -58,7 +58,7 @@ func filterCandidates(ctx context.Context, kubeClient client.Client, recorder ev
 			recorder.Publish(deprovisioningevents.Blocked(cn.Node, cn.NodeClaim, fmt.Sprintf("PDB %q prevents pod evictions", pdb))...)
 			return false
 		}
-		if p, ok := HasDoNotEvictPod(cn); ok {
+		if p, ok := HasDoNotEvictPod(cn.pods); ok {
 			recorder.Publish(deprovisioningevents.Blocked(cn.Node, cn.NodeClaim, fmt.Sprintf("Pod %q has do not evict annotation", client.ObjectKeyFromObject(p)))...)
 			return false
 		}
@@ -253,7 +253,7 @@ func worstLaunchPrice(ofs []cloudprovider.Offering, reqs scheduling.Requirements
 	return math.MaxFloat64
 }
 
-func hasDoNotEvictPod(pods []*v1.Pod) (*v1.Pod, bool) {
+func HasDoNotEvictPod(pods []*v1.Pod) (*v1.Pod, bool) {
 	return lo.Find(pods, func(p *v1.Pod) bool {
 		if pod.IsTerminating(p) || pod.IsTerminal(p) || pod.IsOwnedByNode(p) {
 			return false

--- a/pkg/controllers/deprovisioning/suite_test.go
+++ b/pkg/controllers/deprovisioning/suite_test.go
@@ -3019,19 +3019,6 @@ func ExpectMakeNewMachinesReady(ctx context.Context, c client.Client, wg *sync.W
 	}()
 }
 
-func ExpectMakeInitializedAndStateUpdated(ctx context.Context, c client.Client, nodeStateController, machineStateController controller.Controller, nodes []*v1.Node, machines []*v1alpha5.Machine) {
-	ExpectMakeNodesInitializedWithOffset(1, ctx, c, nodes...)
-	ExpectMakeMachinesInitializedWithOffset(1, ctx, c, machines...)
-
-	// Inform cluster state about node and machine readiness
-	for _, n := range nodes {
-		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(n))
-	}
-	for _, m := range machines {
-		ExpectReconcileSucceeded(ctx, machineStateController, client.ObjectKeyFromObject(m))
-	}
-}
-
 // cheapestOffering grabs the cheapest offering from the passed offerings
 func cheapestOffering(ofs []cloudprovider.Offering) cloudprovider.Offering {
 	offering := cloudprovider.Offering{Price: math.MaxFloat64}

--- a/pkg/controllers/deprovisioning/types.go
+++ b/pkg/controllers/deprovisioning/types.go
@@ -34,7 +34,6 @@ import (
 	"github.com/aws/karpenter-core/pkg/controllers/provisioning/scheduling"
 	"github.com/aws/karpenter-core/pkg/controllers/state"
 	"github.com/aws/karpenter-core/pkg/events"
-	nodeclaimutil "github.com/aws/karpenter-core/pkg/utils/nodeclaim"
 	nodepoolutil "github.com/aws/karpenter-core/pkg/utils/nodepool"
 )
 
@@ -62,52 +61,18 @@ type Candidate struct {
 func NewCandidate(ctx context.Context, kubeClient client.Client, recorder events.Recorder, clk clock.Clock, node *state.StateNode,
 	nodePoolMap map[nodepoolutil.Key]*v1beta1.NodePool, nodePoolToInstanceTypesMap map[nodepoolutil.Key]map[string]*cloudprovider.InstanceType) (*Candidate, error) {
 
-	if node.Node == nil || node.NodeClaim == nil {
-		return nil, fmt.Errorf("state node doesn't contain both a node and a machine")
-	}
-	// skip any nodes that are already marked for deletion and being handled
-	if node.MarkedForDeletion() {
-		return nil, fmt.Errorf("state node is marked for deletion")
-	}
-	// skip nodes that aren't initialized
-	if !node.Initialized() {
-		return nil, fmt.Errorf("state node isn't initialized")
-	}
-	if _, ok := node.Annotations()[v1beta1.DoNotDisruptAnnotationKey]; ok {
-		recorder.Publish(deprovisioningevents.Blocked(node.Node, node.NodeClaim, fmt.Sprintf("Disruption is blocked with the %q annotation", v1beta1.DoNotDisruptAnnotationKey))...)
-		return nil, fmt.Errorf("disruption is blocked through the %q annotation", v1beta1.DoNotDisruptAnnotationKey)
-	}
-	// check whether the node has all the labels we need
-	for _, label := range []string{
-		v1beta1.CapacityTypeLabelKey,
-		v1.LabelTopologyZone,
-	} {
-		if _, ok := node.Labels()[label]; !ok {
-			recorder.Publish(deprovisioningevents.Blocked(node.Node, node.NodeClaim, fmt.Sprintf("Required label %q doesn't exist", label))...)
-			return nil, fmt.Errorf("state node doesn't have required label %q", label)
-		}
-	}
-	ownerKey := nodeclaimutil.OwnerKey(node)
-	if ownerKey.Name == "" {
-		return nil, fmt.Errorf("state node doesn't have the Karpenter owner label")
-	}
-	nodePool := nodePoolMap[ownerKey]
-	instanceTypeMap := nodePoolToInstanceTypesMap[ownerKey]
-	// skip any nodes where we can't determine the nodePool
-	if nodePool == nil || instanceTypeMap == nil {
-		recorder.Publish(deprovisioningevents.Blocked(node.Node, node.NodeClaim, fmt.Sprintf("Owning %s %q not found", lo.Ternary(ownerKey.IsProvisioner, "provisioner", "nodepool"), ownerKey.Name))...)
-		return nil, fmt.Errorf("%s %q can't be resolved for state node", lo.Ternary(ownerKey.IsProvisioner, "provisioner", "nodepool"), ownerKey.Name)
+	provisioner := provisionerMap[node.Labels()[v1alpha5.ProvisionerNameLabelKey]]
+	instanceTypeMap := provisionerToInstanceTypes[node.Labels()[v1alpha5.ProvisionerNameLabelKey]]
+	// skip any nodes where we can't determine the provisioner
+	if provisioner == nil || instanceTypeMap == nil {
+		recorder.Publish(deprovisioningevents.Blocked(node.Node, node.Machine, fmt.Sprintf("Owning provisioner %q not found", node.Labels()[v1alpha5.ProvisionerNameLabelKey]))...)
+		return nil, fmt.Errorf("provisioner '%s' can't be resolved for state node", node.Labels()[v1alpha5.ProvisionerNameLabelKey])
 	}
 	instanceType := instanceTypeMap[node.Labels()[v1.LabelInstanceTypeStable]]
 	// skip any nodes that we can't determine the instance of
 	if instanceType == nil {
 		recorder.Publish(deprovisioningevents.Blocked(node.Node, node.NodeClaim, fmt.Sprintf("Instance type %q not found", node.Labels()[v1.LabelInstanceTypeStable]))...)
 		return nil, fmt.Errorf("instance type '%s' can't be resolved", node.Labels()[v1.LabelInstanceTypeStable])
-	}
-	// skip the node if it is nominated by a recent provisioning pass to be the target of a pending pod.
-	if node.Nominated() {
-		recorder.Publish(deprovisioningevents.Blocked(node.Node, node.NodeClaim, "Nominated for a pending pod")...)
-		return nil, fmt.Errorf("state node is nominated for a pending pod")
 	}
 	pods, err := node.Pods(ctx, kubeClient)
 	if err != nil {

--- a/pkg/controllers/deprovisioning/types.go
+++ b/pkg/controllers/deprovisioning/types.go
@@ -25,6 +25,8 @@ import (
 	"knative.dev/pkg/logging"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/samber/lo"
+
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-core/pkg/cloudprovider"

--- a/pkg/controllers/deprovisioning/types.go
+++ b/pkg/controllers/deprovisioning/types.go
@@ -133,7 +133,7 @@ func (c *Candidate) lifetimeRemaining(clock clock.Clock) float64 {
 		ageInSeconds := clock.Since(c.Node.CreationTimestamp.Time).Seconds()
 		totalLifetimeSeconds := c.nodePool.Spec.Deprovisioning.ExpirationTTL.Duration.Seconds()
 		lifetimeRemainingSeconds := totalLifetimeSeconds - ageInSeconds
-		remaining = clamp(0.0, lifetimeRemainingSeconds/totalLifetimeSeconds, 1.0)
+		remaining = lo.Clamp(lifetimeRemainingSeconds/totalLifetimeSeconds, 0.0, 1.0)
 	}
 	return remaining
 }

--- a/pkg/controllers/machine/disruption/blocked.go
+++ b/pkg/controllers/machine/disruption/blocked.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
+	"github.com/aws/karpenter-core/pkg/cloudprovider"
 	"github.com/aws/karpenter-core/pkg/controllers/deprovisioning"
 	deprovisioningevents "github.com/aws/karpenter-core/pkg/controllers/deprovisioning/events"
 	"github.com/aws/karpenter-core/pkg/controllers/state"
@@ -34,9 +35,10 @@ import (
 
 // Blocked is a machine sub-controller that adds or removes status conditions on machines if they're blocked for Deprovisioning
 type Blocked struct {
-	kubeClient client.Client
-	cluster    *state.Cluster
-	recorder   events.Recorder
+	kubeClient    client.Client
+	cluster       *state.Cluster
+	recorder      events.Recorder
+	cloudProvider cloudprovider.CloudProvider
 }
 
 // Blocked will wait for cluster state to be synced before checking if a machine should not be deprovisioned. Karpenter will check:
@@ -122,10 +124,23 @@ func (b *Blocked) Reconcile(ctx context.Context, nodePool *v1beta1.NodePool, nod
 		b.recorder.Publish(deprovisioningevents.Blocked(node.Node, node.Machine, fmt.Sprintf("Required label(s) %q do not exist", strings.Join(missingLabelKeys, ",")))...)
 	}
 
-	// skip any nodes where there isn't a provisioner
-	if nodePool == nil {
+	provisionerMap, provisionerToInstanceTypes, err := deprovisioning.BuildProvisionerMap(ctx, b.kubeClient, b.cloudProvider)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("building provisioner mapping")
+	}
+
+	provisioner := provisionerMap[node.Labels()[v1alpha5.ProvisionerNameLabelKey]]
+	instanceTypeMap := provisionerToInstanceTypes[node.Labels()[v1alpha5.ProvisionerNameLabelKey]]
+	// skip any nodes where we can't determine the provisioner
+	if nodePool == nil || provisioner == nil || instanceTypeMap == nil {
 		reasons = append(reasons, fmt.Sprintf("provisioner '%s' can't be resolved for state node", node.Labels()[v1alpha5.ProvisionerNameLabelKey]))
 		b.recorder.Publish(deprovisioningevents.Blocked(node.Node, node.Machine, fmt.Sprintf("Owning provisioner %q not found", node.Labels()[v1alpha5.ProvisionerNameLabelKey]))...)
+	}
+	instanceType := instanceTypeMap[node.Labels()[v1.LabelInstanceTypeStable]]
+	// skip any nodes that we can't determine the instance of
+	if instanceType == nil {
+		reasons = append(reasons, fmt.Sprintf("instance type '%s' can't be resolved", node.Labels()[v1.LabelInstanceTypeStable]))
+		b.recorder.Publish(deprovisioningevents.Blocked(node.Node, node.Machine, fmt.Sprintf("Instance type %q not found", node.Labels()[v1.LabelInstanceTypeStable]))...)
 	}
 
 	// 3. Check that there are no pods blocking eviction.

--- a/pkg/controllers/machine/disruption/blocked.go
+++ b/pkg/controllers/machine/disruption/blocked.go
@@ -1,0 +1,167 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disruption
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/utils/clock"
+	"knative.dev/pkg/apis"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
+	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
+	"github.com/aws/karpenter-core/pkg/cloudprovider"
+	"github.com/aws/karpenter-core/pkg/controllers/deprovisioning"
+	deprovisioningevents "github.com/aws/karpenter-core/pkg/controllers/deprovisioning/events"
+	"github.com/aws/karpenter-core/pkg/controllers/state"
+	"github.com/aws/karpenter-core/pkg/events"
+)
+
+// Blocked is a machine sub-controller that adds or removes status conditions on machines if they're blocked for Deprovisioning
+type Blocked struct {
+	kubeClient    client.Client
+	clock         clock.Clock
+	cluster       *state.Cluster
+	recorder      events.Recorder
+	cloudProvider cloudprovider.CloudProvider
+}
+
+// Blocked will wait for cluster state to be synced before checking if a machine should not be deprovisioned. Karpenter will check:
+// 1. If the node is in a deprovisionable state: (1) Initialized (2) Not Deleting (3) Not Recently Nominated
+// 2. Has all necesssary labels for computation
+// 3. Does not have pods blocking eviction - PDBs/do-not-evict
+//nolint:gocycle
+func (b *Blocked) Reconcile(ctx context.Context, nodePool *v1beta1.NodePool, nodeClaim *v1beta1.NodeClaim) (reconcile.Result, error) {
+	if nodeClaim == nil {
+		return reconcile.Result{}, nil
+	}
+	if !b.cluster.Synced(ctx) {
+		return reconcile.Result{}, fmt.Errorf("waiting for cluster state to sync")
+	}
+
+	condition := apis.Condition{
+		Type:     v1beta1.NodeDeprovisioningBlocked,
+		Status:   v1.ConditionTrue,
+		Severity: apis.ConditionSeverityWarning,
+	}
+
+	// Get the node from cluster state before we can check anything else.
+	// If we fail to get a node, this means cluster state is no longer synced after we thought it was.
+	node, err := b.cluster.GetNode(nodeClaim.Name)
+	if err != nil {
+		condition.Reason = fmt.Sprintf("state doesn't have nodeclaim, %w", err)
+		nodeClaim.StatusConditions().SetCondition(condition)
+		return reconcile.Result{}, nil
+	}
+	// If there's no node or no machine, we may have incomplete information, so add that it's blocked.
+	if node.Node == nil || node.Machine == nil {
+		condition.Reason = "state node doesn't contain both a node and a machine"
+		nodeClaim.StatusConditions().SetCondition(condition)
+		return reconcile.Result{}, nil
+	}
+	// Cluster state is synced, so append all blocked reasons together and set the condition for any failed reasons.
+	var reasons []string
+	defer func() {
+		if len(reasons) == 0 {
+			nodeClaim.StatusConditions().SetCondition(apis.Condition{
+				Type:     v1beta1.NodeDeprovisioningBlocked,
+				Status:   v1.ConditionFalse,
+			})
+		} else {
+			condition.Reason = strings.Join(reasons, ";")
+			nodeClaim.StatusConditions().SetCondition(condition)
+		}
+	}()
+
+	// 1. Ensure the node is in a deprovisionable state.
+
+	// skip any nodes that are already marked for deletion and being handled
+	if node.MarkedForDeletion() {
+		reasons = append(reasons, "node claim is marked for deletion")
+	}
+	// skip nodes that aren't initialized
+	// This also means that the real Node doesn't exist for it
+	if !node.Initialized() {
+		reasons = append(reasons, "node claim is not initialized")
+	}
+	// skip the node if it is nominated by a recent provisioning pass to be the target of a pending pod.
+	if node.Nominated() {
+		reasons = append(reasons, "state node is nominated for a pending pod")
+		b.recorder.Publish(deprovisioningevents.Blocked(node.Node, node.Machine, "Nominated for a pending pod")...)
+	}
+
+	// 2. Ensure the node has all the labels we need
+	var missingLabelKeys []string
+	for _, label := range []string{
+		v1alpha5.LabelCapacityType,
+		v1.LabelTopologyZone,
+		v1alpha5.ProvisionerNameLabelKey,
+	} {
+		if _, ok := node.Labels()[label]; !ok {
+			missingLabelKeys = append(missingLabelKeys, label)
+			// return nil, fmt.Errorf("state node doesn't have required label '%s'", label)
+		}
+		missingLabelKeys = append(missingLabelKeys, label)
+	}
+	if missingLabelKeys != nil {
+		reasons = append(reasons, fmt.Sprintf("node claim doesn't have required label(s) '%s'", strings.Join(missingLabelKeys, ",")))
+		b.recorder.Publish(deprovisioningevents.Blocked(node.Node, node.Machine, fmt.Sprintf("Required label(s) %q do not exist", strings.Join(missingLabelKeys, ",")))...)
+	}
+
+	provisionerMap, provisionerToInstanceTypes, err := deprovisioning.BuildProvisionerMap(ctx, b.kubeClient, b.cloudProvider)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("building provisioner mapping")
+	}
+
+	provisioner := provisionerMap[node.Labels()[v1alpha5.ProvisionerNameLabelKey]]
+	instanceTypeMap := provisionerToInstanceTypes[node.Labels()[v1alpha5.ProvisionerNameLabelKey]]
+	// skip any nodes where we can't determine the provisioner
+	if provisioner == nil || instanceTypeMap == nil {
+		reasons = append(reasons, fmt.Sprintf("provisioner '%s' can't be resolved for state node", node.Labels()[v1alpha5.ProvisionerNameLabelKey]))
+		b.recorder.Publish(deprovisioningevents.Blocked(node.Node, node.Machine, fmt.Sprintf("Owning provisioner %q not found", node.Labels()[v1alpha5.ProvisionerNameLabelKey]))...)
+	}
+	instanceType := instanceTypeMap[node.Labels()[v1.LabelInstanceTypeStable]]
+	// skip any nodes that we can't determine the instance of
+	if instanceType == nil {
+		reasons = append(reasons, fmt.Sprintf("instance type '%s' can't be resolved", node.Labels()[v1.LabelInstanceTypeStable]))
+		b.recorder.Publish(deprovisioningevents.Blocked(node.Node, node.Machine, fmt.Sprintf("Instance type %q not found", node.Labels()[v1.LabelInstanceTypeStable]))...)
+	}
+
+	// 3. Check that there are no pods blocking eviction.
+	pdbs, err := deprovisioning.NewPDBLimits(ctx, b.kubeClient)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("tracking PodDisruptionBudgets, %w", err)
+	}
+
+	pods, err := node.Pods(ctx, b.kubeClient)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("getting pods from state node, %w", err)
+	}
+
+	if pdb, ok := pdbs.CanEvictPods(pods); !ok {
+		reasons = append(reasons, fmt.Sprintf("has blocking PDB %q preventing pod evictions", pdb.Name))
+		b.recorder.Publish(deprovisioningevents.Blocked(node.Node, node.Machine, fmt.Sprintf("PDB %q prevents pod evictions", pdb))...)
+	}
+	if p, ok := deprovisioning.HasDoNotEvictPod(pods); ok {
+		reasons = append(reasons, fmt.Sprintf("has do-not-evict pod %s", p))
+		b.recorder.Publish(deprovisioningevents.Blocked(node.Node, node.Machine, fmt.Sprintf("Pod %q has do not evict annotation", client.ObjectKeyFromObject(p)))...)
+	}
+	return reconcile.Result{}, nil
+}

--- a/pkg/controllers/machine/disruption/blocked_test.go
+++ b/pkg/controllers/machine/disruption/blocked_test.go
@@ -1,0 +1,185 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package disruption_test
+
+import (
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	. "github.com/aws/karpenter-core/pkg/test/expectations"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
+	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
+	"github.com/aws/karpenter-core/pkg/test"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Blocked", func() {
+	var provisioner *v1alpha5.Provisioner
+	var machine *v1alpha5.Machine
+	var node *v1.Node
+	BeforeEach(func() {
+		provisioner = test.Provisioner()
+		machine, node = test.MachineAndNode(v1alpha5.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
+					v1.LabelInstanceTypeStable:       test.RandomName(),
+					v1alpha5.LabelCapacityType:       "on-demand",
+					v1.LabelTopologyZone:             "us-west-2a",
+				},
+				Annotations: map[string]string{
+					v1alpha5.ProvisionerHashAnnotationKey: provisioner.Hash(),
+				},
+			},
+			Status: v1alpha5.MachineStatus{
+				ProviderID: test.RandomProviderID(),
+			},
+		})
+	})
+	It("should not detect a node as blocked", func() {
+		ExpectApplied(ctx, env.Client, provisioner, machine, node)
+		// Make state aware of the node and machine.
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
+		ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKeyFromObject(machine))
+
+		machine = ExpectExists(ctx, env.Client, machine)
+		Expect(machine.StatusConditions().GetCondition(v1beta1.NodeDeprovisioningBlocked).IsTrue()).To(BeFalse())
+	})
+	// 1. Must be synced
+	// 2. Node in cluster state
+	// 3. Node and Machine must exist in cluster state
+	// 4. Not Marked for Deletion
+	// 5. Initialized
+	// 6. Not Nominated for scheduling
+	// 7. Has capacity type, topology zone, provisioner name label key labels
+	// 8. Instance type label
+	// 9. No PDB pod or do-not-evict
+	It("should detect a node as blocked if cluster state is not synced", func() {
+		ExpectApplied(ctx, env.Client, provisioner, machine, node)
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{}, []*v1alpha5.Machine{})
+		ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKeyFromObject(machine))
+
+		machine = ExpectExists(ctx, env.Client, machine)
+		Expect(machine.StatusConditions().GetCondition(v1beta1.NodeDeprovisioningBlocked).IsTrue()).To(BeTrue())
+	})
+	It("should detect a node as blocked if cluster state has machine but not node", func() {
+		ExpectApplied(ctx, env.Client, provisioner, machine, node)
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{}, []*v1alpha5.Machine{machine})
+		ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKeyFromObject(machine))
+
+		machine = ExpectExists(ctx, env.Client, machine)
+		Expect(machine.StatusConditions().GetCondition(v1beta1.NodeDeprovisioningBlocked).IsTrue()).To(BeTrue())
+	})
+	It("should detect a node as blocked if cluster state has node but not machine", func() {
+		ExpectApplied(ctx, env.Client, provisioner, machine, node)
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{})
+		ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKeyFromObject(machine))
+
+		machine = ExpectExists(ctx, env.Client, machine)
+		Expect(machine.StatusConditions().GetCondition(v1beta1.NodeDeprovisioningBlocked).IsTrue()).To(BeTrue())
+	})
+	It("should detect a node as blocked if the node is marked for deletion", func() {
+		ExpectApplied(ctx, env.Client, provisioner, machine, node)
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
+		ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKeyFromObject(machine))
+		cluster.MarkForDeletion(node.Name)
+
+		machine = ExpectExists(ctx, env.Client, machine)
+		Expect(machine.StatusConditions().GetCondition(v1beta1.NodeDeprovisioningBlocked).IsTrue()).To(BeTrue())
+	})
+	It("should detect a node as blocked if the node is not initialized", func() {
+		ExpectApplied(ctx, env.Client, provisioner, machine, node)
+		// Inform cluster state about node and machine readiness, but not initialize
+		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node))
+		ExpectReconcileSucceeded(ctx, machineStateController, client.ObjectKeyFromObject(machine))
+		ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKeyFromObject(machine))
+
+		machine = ExpectExists(ctx, env.Client, machine)
+		Expect(machine.StatusConditions().GetCondition(v1beta1.NodeDeprovisioningBlocked).IsTrue()).To(BeTrue())
+	})
+	It("should detect a node as blocked if it was the target of a recent scheduling simulation", func() {
+		ExpectApplied(ctx, env.Client, provisioner, machine, node)
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
+		ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKeyFromObject(machine))
+		cluster.NominateNodeForPod(ctx, node.Name)
+
+		machine = ExpectExists(ctx, env.Client, machine)
+		Expect(machine.StatusConditions().GetCondition(v1beta1.NodeDeprovisioningBlocked).IsTrue()).To(BeTrue())
+	})
+	It("should detect a node as blocked if it does not have the correct labels", func() {
+		machine.Labels = map[string]string{
+			v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
+			v1.LabelInstanceTypeStable:       test.RandomName(),
+		}
+		node.Labels = map[string]string{
+			v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
+			v1.LabelInstanceTypeStable:       test.RandomName(),
+		}
+		ExpectApplied(ctx, env.Client, provisioner, machine, node)
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
+		ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKeyFromObject(machine))
+		cluster.NominateNodeForPod(ctx, node.Name)
+
+		machine = ExpectExists(ctx, env.Client, machine)
+		Expect(machine.StatusConditions().GetCondition(v1beta1.NodeDeprovisioningBlocked).IsTrue()).To(BeTrue())
+	})
+	It("should detect a node as blocked if it has a do-not-evict pod", func() {
+		// Add a do-not-evict pod to the node so that it's not deprovisionable.
+		pod := test.Pod(test.PodOptions{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					v1alpha5.DoNotEvictPodAnnotationKey: "true",
+				}}})
+
+		ExpectApplied(ctx, env.Client, provisioner, machine, node, pod)
+		ExpectManualBinding(ctx, env.Client, pod, node)
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
+		ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKeyFromObject(machine))
+		cluster.NominateNodeForPod(ctx, node.Name)
+
+		machine = ExpectExists(ctx, env.Client, machine)
+		Expect(machine.StatusConditions().GetCondition(v1beta1.NodeDeprovisioningBlocked).IsTrue()).To(BeTrue())
+	})
+	It("should detect a node as blocked if it has a pod with a blocking PDB", func() {
+		// Add a do-not-evict pod to the node so that it's not deprovisionable.
+		pod := test.Pod(test.PodOptions{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					"test": "app",
+				},
+			}},
+		)
+		pdb := test.PodDisruptionBudget(test.PDBOptions{
+			Labels: map[string]string{
+				"test": "app",
+			},
+			MaxUnavailable: intstr.ValueOrDefault(nil, intstr.FromInt(0)),
+		})
+
+		ExpectApplied(ctx, env.Client, provisioner, machine, node, pod, pdb)
+		ExpectManualBinding(ctx, env.Client, pod, node)
+		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
+		ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKeyFromObject(machine))
+
+		machine = ExpectExists(ctx, env.Client, machine)
+		Expect(machine.StatusConditions().GetCondition(v1beta1.NodeDeprovisioningBlocked).IsTrue()).To(BeTrue())
+	})
+})

--- a/pkg/controllers/machine/disruption/controller.go
+++ b/pkg/controllers/machine/disruption/controller.go
@@ -54,6 +54,7 @@ type Controller struct {
 	drift      *Drift
 	expiration *Expiration
 	emptiness  *Emptiness
+	blocked    *Blocked
 }
 
 // NewController constructs a machine disruption controller
@@ -63,6 +64,7 @@ func NewController(clk clock.Clock, kubeClient client.Client, cluster *state.Clu
 		drift:      &Drift{cloudProvider: cloudProvider},
 		expiration: &Expiration{kubeClient: kubeClient, clock: clk},
 		emptiness:  &Emptiness{kubeClient: kubeClient, cluster: cluster, clock: clk},
+		blocked:    &Blocked{kubeClient: kubeClient, cluster: cluster},
 	}
 }
 
@@ -83,6 +85,7 @@ func (c *Controller) Reconcile(ctx context.Context, nodeClaim *v1beta1.NodeClaim
 		c.expiration,
 		c.drift,
 		c.emptiness,
+		c.blocked,
 	}
 	for _, reconciler := range reconcilers {
 		res, err := reconciler.Reconcile(ctx, nodePool, nodeClaim)

--- a/pkg/controllers/machine/disruption/suite_test.go
+++ b/pkg/controllers/machine/disruption/suite_test.go
@@ -144,6 +144,7 @@ var _ = Describe("Disruption", func() {
 		ExpectMakeInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
 
 		// Drift, Expiration, and Emptiness are disabled through configuration
+		// Blocked doesn't apply for the given node.
 		ctx = settings.ToContext(ctx, test.Settings(settings.Settings{DriftEnabled: false}))
 		ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKeyFromObject(machine))
 

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -153,13 +153,11 @@ func (c *Cluster) ForEachNode(f func(n *StateNode) bool) {
 
 // More efficient way to get a node from cluster state without grabbing the whole list of nodes.
 // If you need to grab all nodes, use Nodes() instead.
-func (c *Cluster) GetNode(ctx context.Context, providerID string) (*StateNode, error) {
+func (c *Cluster) GetNode(providerID string) (*StateNode, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	logging.FromContext(ctx).Infof("DEBUGGING: this is the get node map %s", c.nameToProviderID)
 	node, ok := c.nodes[providerID]
 	if !ok {
-		logging.FromContext(ctx).Infof("DEBUGGING: providerID failed %s", providerID)
 		return nil, fmt.Errorf("state has no node with providerID %s", providerID)
 	}
 	return node, nil

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -151,6 +151,16 @@ func (c *Cluster) ForEachNode(f func(n *StateNode) bool) {
 	}
 }
 
+func (c *Cluster) GetNode(nodeName string) (*StateNode, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	node, ok := c.nodes[nodeName]
+	if !ok {
+		return nil, fmt.Errorf("state has no node with name %s", nodeName)
+	}
+	return node, nil
+}
+
 // Nodes creates a DeepCopy of all state nodes.
 // NOTE: This is very inefficient so this should only be used when DeepCopying is absolutely necessary
 func (c *Cluster) Nodes() StateNodes {

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -153,12 +153,14 @@ func (c *Cluster) ForEachNode(f func(n *StateNode) bool) {
 
 // More efficient way to get a node from cluster state without grabbing the whole list of nodes.
 // If you need to grab all nodes, use Nodes() instead.
-func (c *Cluster) GetNode(nodeName string) (*StateNode, error) {
+func (c *Cluster) GetNode(ctx context.Context, providerID string) (*StateNode, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
-	node, ok := c.nodes[nodeName]
+	logging.FromContext(ctx).Infof("DEBUGGING: this is the get node map %s", c.nameToProviderID)
+	node, ok := c.nodes[providerID]
 	if !ok {
-		return nil, fmt.Errorf("state has no node with name %s", nodeName)
+		logging.FromContext(ctx).Infof("DEBUGGING: providerID failed %s", providerID)
+		return nil, fmt.Errorf("state has no node with providerID %s", providerID)
 	}
 	return node, nil
 }

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -151,6 +151,8 @@ func (c *Cluster) ForEachNode(f func(n *StateNode) bool) {
 	}
 }
 
+// More efficient way to get a node from cluster state without grabbing the whole list of nodes.
+// If you need to grab all nodes, use Nodes() instead.
 func (c *Cluster) GetNode(nodeName string) (*StateNode, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -54,6 +54,7 @@ import (
 	"github.com/aws/karpenter-core/pkg/controllers/provisioning/scheduling"
 	"github.com/aws/karpenter-core/pkg/controllers/state"
 	"github.com/aws/karpenter-core/pkg/metrics"
+	"github.com/aws/karpenter-core/pkg/operator/controller"
 	"github.com/aws/karpenter-core/pkg/operator/scheme"
 	pscheduling "github.com/aws/karpenter-core/pkg/scheduling"
 	"github.com/aws/karpenter-core/pkg/test"
@@ -366,6 +367,19 @@ func ExpectMachinesCascadeDeletion(ctx context.Context, c client.Client, machine
 				ExpectNotFound(ctx, c, node)
 			}
 		}
+	}
+}
+
+func ExpectMakeInitializedAndStateUpdated(ctx context.Context, c client.Client, nodeStateController, machineStateController controller.Controller, nodes []*v1.Node, machines []*v1alpha5.Machine) {
+	ExpectMakeNodesInitializedWithOffset(1, ctx, c, nodes...)
+	ExpectMakeMachinesInitializedWithOffset(1, ctx, c, machines...)
+
+	// Inform cluster state about node and machine readiness
+	for _, n := range nodes {
+		ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(n))
+	}
+	for _, m := range machines {
+		ExpectReconcileSucceeded(ctx, machineStateController, client.ObjectKeyFromObject(m))
 	}
 }
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Adds in a Machine Disruption Controller to check if a machine is deprovisionable and adds it as a status condition that can be referenced in the deprovisioning controller. 

This should allow users to query if a Machine is deprovisionable by checking its status, rather than having to find events, which have a de-dupe interval. 

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
