### PR TITLE
chore: Allow `node-restriction.kubernetes.io/` prefix in the label set

### DIFF
--- a/pkg/apis/v1alpha5/labels.go
+++ b/pkg/apis/v1alpha5/labels.go
@@ -68,6 +68,7 @@ var (
 	LabelDomainExceptions = sets.NewString(
 		"kops.k8s.io",
 		v1.LabelNamespaceSuffixNode,
+		v1.LabelNamespaceNodeRestriction,
 		TestingGroup,
 	)
 

--- a/pkg/apis/v1alpha5/suite_test.go
+++ b/pkg/apis/v1alpha5/suite_test.go
@@ -158,6 +158,14 @@ var _ = Describe("Validation", func() {
 				Expect(provisioner.Validate(ctx)).To(Succeed())
 			}
 		})
+		It("should allow labels prefixed with the restricted domain exceptions", func() {
+			for label := range LabelDomainExceptions {
+				provisioner.Spec.Labels = map[string]string{
+					fmt.Sprintf("%s/key", label): "test-value",
+				}
+				Expect(provisioner.Validate(ctx)).To(Succeed())
+			}
+		})
 	})
 	Context("Taints", func() {
 		It("should succeed for valid taints", func() {

--- a/pkg/apis/v1beta1/labels.go
+++ b/pkg/apis/v1beta1/labels.go
@@ -64,6 +64,7 @@ var (
 	LabelDomainExceptions = sets.New(
 		"kops.k8s.io",
 		v1.LabelNamespaceSuffixNode,
+		v1.LabelNamespaceNodeRestriction,
 	)
 
 	// WellKnownLabels are labels that belong to the RestrictedLabelDomains but allowed.

--- a/pkg/apis/v1beta1/nodepool_validation_test.go
+++ b/pkg/apis/v1beta1/nodepool_validation_test.go
@@ -15,6 +15,7 @@ limitations under the License.
 package v1beta1
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
@@ -127,6 +128,14 @@ var _ = Describe("Validation", func() {
 				for label := range LabelDomainExceptions {
 					nodePool.Spec.Template.Labels = map[string]string{
 						label: "test-value",
+					}
+					Expect(nodePool.Validate(ctx)).To(Succeed())
+				}
+			})
+			It("should allow labels prefixed with the restricted domain exceptions", func() {
+				for label := range LabelDomainExceptions {
+					nodePool.Spec.Template.Labels = map[string]string{
+						fmt.Sprintf("%s/key", label): "test-value",
 					}
 					Expect(nodePool.Validate(ctx)).To(Succeed())
 				}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change allows users to pass labels prefixed with `node-restriction.kubernetes.io` into Karpenter labels and requirements. These labels were previously disallowed.

**How was this change tested?**

`make presubmit`
`make apply`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
