### PR TITLE
chore: Handle shared state for Machine/NodeClaim

### DIFF
--- a/pkg/controllers/deprovisioning/emptymachineconsolidation.go
+++ b/pkg/controllers/deprovisioning/emptymachineconsolidation.go
@@ -82,7 +82,7 @@ func (c *EmptyMachineConsolidation) ComputeCommand(ctx context.Context, candidat
 	// 1. All the candidatesToDelete are still empty
 	// 2. The node isn't a target of a recent scheduling simulation
 	for _, n := range candidatesToDelete {
-		if len(n.pods) != 0 || c.cluster.IsNodeNominated(n.Name()) {
+		if len(n.pods) != 0 || c.cluster.IsNodeNominated(n.ProviderID()) {
 			logging.FromContext(ctx).Debugf("abandoning empty machine consolidation attempt due to pod churn, command is no longer valid, %s", cmd)
 			return Command{}, nil
 		}

--- a/pkg/controllers/deprovisioning/suite_test.go
+++ b/pkg/controllers/deprovisioning/suite_test.go
@@ -2446,7 +2446,7 @@ var _ = Describe("Parallelization", func() {
 
 		// Mark the node for deletion and re-trigger reconciliation
 		oldNodeName := nodes[0].Name
-		cluster.MarkForDeletion(nodes[0].Name)
+		cluster.MarkForDeletion(nodes[0].Spec.ProviderID)
 		ExpectProvisionedNoBinding(ctx, env.Client, cluster, cloudProvider, provisioner, lo.Map(pods, func(p *v1.Pod, _ int) *v1.Pod { return p.DeepCopy() })...)
 
 		// Make sure that the cluster state is aware of the current node state

--- a/pkg/controllers/deprovisioning/validation.go
+++ b/pkg/controllers/deprovisioning/validation.go
@@ -93,7 +93,7 @@ func (v *Validation) IsValid(ctx context.Context, cmd Command) (bool, error) {
 	// a candidate we are about to delete is a target of a currently pending pod, wait for that to settle
 	// before continuing consolidation
 	for _, n := range cmd.candidates {
-		if v.cluster.IsNodeNominated(n.Name()) {
+		if v.cluster.IsNodeNominated(n.ProviderID()) {
 			return false, nil
 		}
 	}

--- a/pkg/controllers/machine/disruption/emptiness.go
+++ b/pkg/controllers/machine/disruption/emptiness.go
@@ -78,7 +78,7 @@ func (e *Emptiness) Reconcile(ctx context.Context, nodePool *v1beta1.NodePool, n
 	// We perform a short requeue if the node is nominated, so we can check the node for emptiness when the node
 	// nomination time ends since we don't watch node nomination events
 	// 4. If the Node is nominated for pods to schedule to it, remove the emptiness status condition
-	if e.cluster.IsNodeNominated(n.Name) {
+	if e.cluster.IsNodeNominated(n.Spec.ProviderID) {
 		_ = nodeClaim.StatusConditions().ClearCondition(v1beta1.NodeEmpty)
 		if hasEmptyCondition {
 			logging.FromContext(ctx).Debugf("removing emptiness status condition, is nominated for pods")

--- a/pkg/controllers/machine/disruption/emptiness_test.go
+++ b/pkg/controllers/machine/disruption/emptiness_test.go
@@ -130,7 +130,7 @@ var _ = Describe("Emptiness", func() {
 
 		// Add the node to the cluster state and nominate it in the internal cluster state
 		Expect(cluster.UpdateNode(ctx, node)).To(Succeed())
-		cluster.NominateNodeForPod(ctx, node.Name)
+		cluster.NominateNodeForPod(ctx, node.Spec.ProviderID)
 
 		result := ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKeyFromObject(machine))
 		Expect(result.RequeueAfter).To(Equal(time.Second * 30))

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -349,7 +349,6 @@ func (p *Provisioner) launchMachine(ctx context.Context, n *scheduler.NodeClaim,
 	}
 	instanceTypeRequirement, _ := lo.Find(machine.Spec.Requirements, func(req v1.NodeSelectorRequirement) bool { return req.Key == v1.LabelInstanceTypeStable })
 	logging.FromContext(ctx).With("machine", machine.Name, "requests", machine.Spec.Resources.Requests, "instance-types", instanceTypeList(instanceTypeRequirement.Values)).Infof("created machine")
-	p.cluster.NominateNodeForPod(ctx, machine.Name)
 	metrics.MachinesCreatedCounter.With(prometheus.Labels{
 		metrics.ReasonLabel:      options.Reason,
 		metrics.ProvisionerLabel: machine.Labels[v1alpha5.ProvisionerNameLabelKey],
@@ -378,7 +377,6 @@ func (p *Provisioner) launchNodeClaim(ctx context.Context, n *scheduler.NodeClai
 	}
 	instanceTypeRequirement, _ := lo.Find(nodeClaim.Spec.Requirements, func(req v1.NodeSelectorRequirement) bool { return req.Key == v1.LabelInstanceTypeStable })
 	logging.FromContext(ctx).With("nodeclaim", nodeClaim.Name, "requests", nodeClaim.Spec.Resources.Requests, "instance-types", instanceTypeList(instanceTypeRequirement.Values)).Infof("created nodeclaim")
-	p.cluster.NominateNodeForPod(ctx, nodeClaim.Name)
 	metrics.NodeClaimsCreatedCounter.With(prometheus.Labels{
 		metrics.ReasonLabel:   options.Reason,
 		metrics.NodePoolLabel: nodeClaim.Labels[v1beta1.NodePoolLabelKey],

--- a/pkg/controllers/provisioning/scheduling/scheduler.go
+++ b/pkg/controllers/provisioning/scheduling/scheduler.go
@@ -193,7 +193,7 @@ func (s *Scheduler) recordSchedulingResults(ctx context.Context, pods []*v1.Pod,
 
 	for _, existing := range s.existingNodes {
 		if len(existing.Pods) > 0 {
-			s.cluster.NominateNodeForPod(ctx, existing.Name())
+			s.cluster.NominateNodeForPod(ctx, existing.ProviderID())
 		}
 		for _, pod := range existing.Pods {
 			s.recorder.Publish(NominatePodEvent(pod, existing.Node, existing.NodeClaim))

--- a/pkg/controllers/state/informer/machine.go
+++ b/pkg/controllers/state/informer/machine.go
@@ -55,7 +55,7 @@ func (c *MachineController) Reconcile(ctx context.Context, req reconcile.Request
 	if err := c.kubeClient.Get(ctx, req.NamespacedName, machine); err != nil {
 		if errors.IsNotFound(err) {
 			// notify cluster state of the node deletion
-			c.cluster.DeleteNodeClaim(req.Name)
+			c.cluster.DeleteNodeClaim(nodeclaimutil.Key{Name: req.Name, IsMachine: true})
 		}
 		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}

--- a/pkg/controllers/state/statenode.go
+++ b/pkg/controllers/state/statenode.go
@@ -135,6 +135,16 @@ func (in *StateNode) Name() string {
 	return in.Node.Name
 }
 
+// ProviderID is the key that is used to map this StateNode
+// If the Node and NodeClaim have a providerID, this should map to a real providerID
+// If the Node does not have a providerID, this will map to the node name
+func (in *StateNode) ProviderID() string {
+	if in.Node == nil {
+		return in.NodeClaim.Status.ProviderID
+	}
+	return in.Node.Spec.ProviderID
+}
+
 // Pods gets the pods assigned to the Node based on the kubernetes api-server bindings
 func (in *StateNode) Pods(ctx context.Context, c client.Client) ([]*v1.Pod, error) {
 	if in.Node == nil {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change converts all of the state functions to take in a provider id as a string rather than a name for `NominateForPod`, `IsNodeNominated`, `MarkForDeletion`, and `UnmarkForDeletion`. This change also changes the name tracking to providerID for deletion to happen per-kind so no naming conflicts cause inconsistent state or leaks.

**How was this change tested?**

`make presubmit`
`/karpenter snapshot`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
