### PR TITLE
fix: do not consider provisioners without a provider

### DIFF
--- a/pkg/cloudprovider/fake/cloudprovider.go
+++ b/pkg/cloudprovider/fake/cloudprovider.go
@@ -23,10 +23,8 @@ import (
 
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
@@ -154,12 +152,6 @@ func (c *CloudProvider) List(_ context.Context) ([]*v1alpha5.Machine, error) {
 }
 
 func (c *CloudProvider) GetInstanceTypes(_ context.Context, p *v1alpha5.Provisioner) ([]*cloudprovider.InstanceType, error) {
-	// Return a NotFound error for the provisioning controller so we can opt it out of scheduling.
-	if p != nil {
-		if p.Spec.ProviderRef == nil && p.Spec.Provider == nil {
-			return nil, errors.NewNotFound(schema.GroupResource{}, fmt.Sprintf("provisioner.providerRef/%s", p.Name))
-		}
-	}
 	if c.InstanceTypes != nil {
 		return c.InstanceTypes, nil
 	}

--- a/pkg/cloudprovider/fake/cloudprovider.go
+++ b/pkg/cloudprovider/fake/cloudprovider.go
@@ -151,7 +151,7 @@ func (c *CloudProvider) List(_ context.Context) ([]*v1alpha5.Machine, error) {
 	}), nil
 }
 
-func (c *CloudProvider) GetInstanceTypes(_ context.Context, p *v1alpha5.Provisioner) ([]*cloudprovider.InstanceType, error) {
+func (c *CloudProvider) GetInstanceTypes(_ context.Context, _ *v1alpha5.Provisioner) ([]*cloudprovider.InstanceType, error) {
 	if c.InstanceTypes != nil {
 		return c.InstanceTypes, nil
 	}

--- a/pkg/cloudprovider/fake/cloudprovider.go
+++ b/pkg/cloudprovider/fake/cloudprovider.go
@@ -23,8 +23,10 @@ import (
 
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
@@ -151,7 +153,13 @@ func (c *CloudProvider) List(_ context.Context) ([]*v1alpha5.Machine, error) {
 	}), nil
 }
 
-func (c *CloudProvider) GetInstanceTypes(_ context.Context, _ *v1alpha5.Provisioner) ([]*cloudprovider.InstanceType, error) {
+func (c *CloudProvider) GetInstanceTypes(_ context.Context, p *v1alpha5.Provisioner) ([]*cloudprovider.InstanceType, error) {
+	// Return a NotFound error for the provisioning controller so we can opt it out of scheduling.
+	if p != nil {
+		if p.Spec.ProviderRef == nil && p.Spec.Provider == nil {
+			return nil, errors.NewNotFound(schema.GroupResource{}, fmt.Sprintf("provisioner.providerRef/%s", p.Name))
+		}
+	}
 	if c.InstanceTypes != nil {
 		return c.InstanceTypes, nil
 	}

--- a/pkg/controllers/deprovisioning/helpers.go
+++ b/pkg/controllers/deprovisioning/helpers.go
@@ -210,7 +210,6 @@ func buildNodePoolMap(ctx context.Context, kubeClient client.Client, cloudProvid
 			return nil, nil, fmt.Errorf("listing instance types for %s, %w", np.Name, err)
 		}
 		if len(nodePoolInstanceTypes) == 0 {
-			logging.FromContext(ctx).With("provisioner", np.Name).Debug("skipping provisioner, no resolved instance types found")
 			continue
 		}
 		nodePoolToInstanceTypesMap[key] = map[string]*cloudprovider.InstanceType{}

--- a/pkg/controllers/deprovisioning/helpers.go
+++ b/pkg/controllers/deprovisioning/helpers.go
@@ -22,6 +22,8 @@ import (
 
 	"github.com/samber/lo"
 
+	"k8s.io/apimachinery/pkg/api/errors"
+
 	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
 	deprovisioningevents "github.com/aws/karpenter-core/pkg/controllers/deprovisioning/events"
@@ -207,6 +209,9 @@ func buildNodePoolMap(ctx context.Context, kubeClient client.Client, cloudProvid
 
 		nodePoolInstanceTypes, err := cloudProvider.GetInstanceTypes(ctx, provisionerutil.New(np))
 		if err != nil {
+			if errors.IsNotFound(err) {
+				continue
+			}
 			return nil, nil, fmt.Errorf("listing instance types for %s, %w", np.Name, err)
 		}
 		nodePoolToInstanceTypesMap[key] = map[string]*cloudprovider.InstanceType{}

--- a/pkg/controllers/deprovisioning/helpers.go
+++ b/pkg/controllers/deprovisioning/helpers.go
@@ -210,7 +210,7 @@ func buildNodePoolMap(ctx context.Context, kubeClient client.Client, cloudProvid
 			return nil, nil, fmt.Errorf("listing instance types for %s, %w", np.Name, err)
 		}
 		if len(nodePoolInstanceTypes) == 0 {
-			logging.FromContext(ctx).With("provisioner", np.Name).Debug("failed to get instance types for provisioner")
+			logging.FromContext(ctx).With("provisioner", np.Name).Debug("skipping provisioner, no resolved instance types found")
 			continue
 		}
 		nodePoolToInstanceTypesMap[key] = map[string]*cloudprovider.InstanceType{}

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -235,7 +235,7 @@ func (p *Provisioner) NewScheduler(ctx context.Context, pods []*v1.Pod, stateNod
 			return nil, fmt.Errorf("getting instance types, %w", err)
 		}
 		if len(instanceTypeOptions) == 0 {
-			logging.FromContext(ctx).With("provisioner", nodePool.Name).Info("excluding from scheduling, no instance types exist")
+			logging.FromContext(ctx).With("provisioner", nodePool.Name).Info("skipping provisioner, no resolved instance types found")
 			continue
 		}
 		instanceTypes[nodepoolutil.Key{Name: nodePool.Name, IsProvisioner: nodePool.IsProvisioner}] = append(instanceTypes[nodepoolutil.Key{Name: nodePool.Name, IsProvisioner: nodePool.IsProvisioner}], instanceTypeOptions...)

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -235,7 +235,7 @@ func (p *Provisioner) NewScheduler(ctx context.Context, pods []*v1.Pod, stateNod
 			return nil, fmt.Errorf("getting instance types, %w", err)
 		}
 		if len(instanceTypeOptions) == 0 {
-			logging.FromContext(ctx).With(lo.Ternary(nodePool.IsProvisioner, "provisioner", "nodePool"), nodePool.Name).Info("skipping, no resolved instance types found")
+			logging.FromContext(ctx).With(lo.Ternary(nodePool.IsProvisioner, "provisioner", "nodepool"), nodePool.Name).Info("skipping, no resolved instance types found")
 			continue
 		}
 		instanceTypes[nodepoolutil.Key{Name: nodePool.Name, IsProvisioner: nodePool.IsProvisioner}] = append(instanceTypes[nodepoolutil.Key{Name: nodePool.Name, IsProvisioner: nodePool.IsProvisioner}], instanceTypeOptions...)

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -235,7 +235,7 @@ func (p *Provisioner) NewScheduler(ctx context.Context, pods []*v1.Pod, stateNod
 			return nil, fmt.Errorf("getting instance types, %w", err)
 		}
 		if len(instanceTypeOptions) == 0 {
-			logging.FromContext(ctx).With("provisioner", nodePool.Name).Info("skipping provisioner, no resolved instance types found")
+			logging.FromContext(ctx).With(lo.Ternary(nodePool.IsProvisioner, "provisioner", "nodePool"), nodePool.Name).Info("skipping, no resolved instance types found")
 			continue
 		}
 		instanceTypes[nodepoolutil.Key{Name: nodePool.Name, IsProvisioner: nodePool.IsProvisioner}] = append(instanceTypes[nodepoolutil.Key{Name: nodePool.Name, IsProvisioner: nodePool.IsProvisioner}], instanceTypeOptions...)

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -26,7 +26,6 @@ import (
 	"go.uber.org/multierr"
 	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/sets"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -233,12 +232,11 @@ func (p *Provisioner) NewScheduler(ctx context.Context, pods []*v1.Pod, stateNod
 		// Get instance type options
 		instanceTypeOptions, err := p.cloudProvider.GetInstanceTypes(ctx, provisionerutil.New(nodePool))
 		if err != nil {
-			// If the node pool does not have a providerRef that resolves to an object in the cluster, don't consider it for provisioning.
-			if apierrors.IsNotFound(err) {
-				logging.FromContext(ctx).Infof("excluding nodePool %s from scheduling, provider not found", nodePool.Name)
-				continue
-			}
 			return nil, fmt.Errorf("getting instance types, %w", err)
+		}
+		if len(instanceTypeOptions) == 0 {
+			logging.FromContext(ctx).With("provisioner", nodePool.Name).Info("excluding from scheduling, no instance types exist")
+			continue
 		}
 		instanceTypes[nodepoolutil.Key{Name: nodePool.Name, IsProvisioner: nodePool.IsProvisioner}] = append(instanceTypes[nodepoolutil.Key{Name: nodePool.Name, IsProvisioner: nodePool.IsProvisioner}], instanceTypeOptions...)
 

--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -108,7 +108,7 @@ var _ = BeforeEach(func() {
 	}}})
 	// reset instance types
 	newCP := fake.CloudProvider{}
-	cloudProvider.InstanceTypes, _ = newCP.GetInstanceTypes(context.Background(), nil)
+	cloudProvider.InstanceTypes, _ = newCP.GetInstanceTypes(ctx, nil)
 	cloudProvider.CreateCalls = nil
 	pscheduling.ResetDefaultStorageClass()
 })

--- a/pkg/controllers/provisioning/suite_test.go
+++ b/pkg/controllers/provisioning/suite_test.go
@@ -109,7 +109,7 @@ var _ = Describe("Provisioning", func() {
 		Expect(len(nodes.Items)).To(Equal(1))
 		ExpectScheduled(ctx, env.Client, pod)
 	})
-	It("should continue with provisioning when at least one node pool has instance types", func() {
+	It("should continue with provisioning when at least a provisioner doesn't have resolved instance types", func() {
 		provNotDefined := test.Provisioner()
 		provNotDefined.Spec.ProviderRef = nil
 		ExpectApplied(ctx, env.Client, test.Provisioner(), provNotDefined)

--- a/pkg/controllers/provisioning/suite_test.go
+++ b/pkg/controllers/provisioning/suite_test.go
@@ -212,11 +212,13 @@ var _ = Describe("Provisioning", func() {
 	})
 	It("should schedule all pods on one node when node is in deleting state", func() {
 		provisioner := test.Provisioner()
+		its, err := cloudProvider.GetInstanceTypes(ctx, provisioner)
+		Expect(err).To(BeNil())
 		node := test.Node(test.NodeOptions{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
-					v1.LabelInstanceTypeStable:       cloudProvider.InstanceTypes[0].Name,
+					v1.LabelInstanceTypeStable:       its[0].Name,
 				},
 				Finalizers: []string{v1alpha5.TerminationFinalizer},
 			}},

--- a/pkg/controllers/provisioning/suite_test.go
+++ b/pkg/controllers/provisioning/suite_test.go
@@ -109,7 +109,7 @@ var _ = Describe("Provisioning", func() {
 		Expect(len(nodes.Items)).To(Equal(1))
 		ExpectScheduled(ctx, env.Client, pod)
 	})
-	It("should continue with provisioning when not all nodePools have defined providers", func() {
+	It("should continue with provisioning when at least one node pool has instance types", func() {
 		provNotDefined := test.Provisioner()
 		provNotDefined.Spec.ProviderRef = nil
 		ExpectApplied(ctx, env.Client, test.Provisioner(), provNotDefined)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
If none of the provisioners in the cluster had a nodePool defined, users could see the following message when a pod fails to schedule, when Karpenter should either log or return here. 

Similarly, we should be able to opt these provisioners out of any scheduling simulations, since we know that the GetInstanceTypes() call will fail. 

```
ERROR	controller.provisioner	Could not schedule pod, all available instance types exceed limits for provisioner: "default"	
```

**How was this change tested?**
- `make presubmit` and local application

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
