### PR TITLE
chore: single init inflight capacity / startup taints

### DIFF
--- a/pkg/controllers/state/statenode.go
+++ b/pkg/controllers/state/statenode.go
@@ -77,9 +77,12 @@ type StateNode struct {
 	Node      *v1.Node
 	NodeClaim *v1beta1.NodeClaim
 
+	inflightInitialized bool
 	inflightAllocatable v1.ResourceList // TODO @joinnis: This can be removed when machine is added
 	inflightCapacity    v1.ResourceList // TODO @joinnis: This can be removed when machine is added
-	startupTaints       []v1.Taint      // TODO: @joinnis: This can be removed when machine is added
+
+	startupTaintsInitialized bool       // TODO: @joinnis: This can be removed when machine is added
+	startupTaints            []v1.Taint // TODO: @joinnis: This can be removed when machine is added
 
 	// daemonSetRequests is the total amount of resources that have been requested by daemon sets. This allows users
 	// of the Node to identify the remaining resources that we expect future daemonsets to consume.

--- a/pkg/controllers/state/statenode.go
+++ b/pkg/controllers/state/statenode.go
@@ -77,7 +77,7 @@ type StateNode struct {
 	Node      *v1.Node
 	NodeClaim *v1beta1.NodeClaim
 
-	inflightInitialized bool
+	inflightInitialized bool            // TODO @joinnis: This can be removed when machine is added
 	inflightAllocatable v1.ResourceList // TODO @joinnis: This can be removed when machine is added
 	inflightCapacity    v1.ResourceList // TODO @joinnis: This can be removed when machine is added
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Adds an initialization flag to the inflight capacity and startup taints for `StateNode` ensuring that the values are only set once. Additionally, this change helps clean up spurious logging due to inflight resource checks during test environment tear down.

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
