### PR TITLE
test: static provisioner hash test

### DIFF
--- a/pkg/apis/v1alpha5/suite_test.go
+++ b/pkg/apis/v1alpha5/suite_test.go
@@ -567,38 +567,40 @@ var _ = Describe("Provisioner Annotation", func() {
 		}
 		provisioner = test.Provisioner(testProvisionerOptions)
 	})
-	It("should match previous static hashes", func() {
-		provisioners := []struct {
-			provisioner *Provisioner
-			hash        string
-		}{
-			{
-				provisioner: provisioner,
-				hash:        "14114424411830460479",
-			},
-			{
-				provisioner: test.Provisioner(testProvisionerOptions, test.ProvisionerOptions{Annotations: map[string]string{"keyAnnotationTest": "valueAnnotationTest"}}),
-				hash:        "7374986726887162519",
-			},
-			{
-				provisioner: test.Provisioner(testProvisionerOptions, test.ProvisionerOptions{Labels: map[string]string{"keyLabelTest": "valueLabelTest"}}),
-				hash:        "9065364558915106368",
-			},
-			{
-				provisioner: test.Provisioner(testProvisionerOptions, test.ProvisionerOptions{Taints: []v1.Taint{{Key: "keytest2Taint", Effect: v1.TaintEffectNoExecute}}}),
-				hash:        "9081458816929490897",
-			},
-			{
-				provisioner: test.Provisioner(testProvisionerOptions, test.ProvisionerOptions{StartupTaints: []v1.Taint{{Key: "keytest2StartupTaint", Effect: v1.TaintEffectNoExecute}}}),
-				hash:        "2352640223763896447",
-			},
-		}
-
-		for _, p := range provisioners {
-			hash := p.provisioner.Hash()
-			Expect(hash).To(Equal(p.hash))
-		}
-	})
+	DescribeTable(
+		"Static Hash Values",
+		func(expectedHash string, opts ...test.ProvisionerOptions) {
+			overrides := append([]test.ProvisionerOptions{testProvisionerOptions}, opts...)
+			p := test.Provisioner(overrides...)
+			Expect(p.Hash()).To(Equal(expectedHash))
+		},
+		Entry("should match static hash values", "14114424411830460479"),
+		Entry(
+			"should match static hash values with modified annotations",
+			"7374986726887162519",
+			test.ProvisionerOptions{Annotations: map[string]string{"keyAnnotationTest": "valueAnnotationTest"}},
+		),
+		Entry(
+			"should match static hash values with modified labels",
+			"9065364558915106368",
+			test.ProvisionerOptions{Labels: map[string]string{"keyLabelTest": "valueLabelTest"}},
+		),
+		Entry(
+			"should match static hash values with modified taints",
+			"9081458816929490897",
+			test.ProvisionerOptions{Taints: []v1.Taint{{Key: "keytest2Taint", Effect: v1.TaintEffectNoExecute}}},
+		),
+		Entry(
+			"should match static hash values with modified startup taints",
+			"2352640223763896447",
+			test.ProvisionerOptions{StartupTaints: []v1.Taint{{Key: "keytest2StartupTaint", Effect: v1.TaintEffectNoExecute}}},
+		),
+		Entry(
+			"should match static hash values with modified kubelet config",
+			"3622457352880294488",
+			test.ProvisionerOptions{Kubelet: &KubeletConfiguration{MaxPods: ptr.Int32(30)}},
+		),
+	)
 	It("should change hash when static fields are updated", func() {
 		expectedHash := provisioner.Hash()
 

--- a/pkg/apis/v1alpha5/suite_test.go
+++ b/pkg/apis/v1alpha5/suite_test.go
@@ -578,48 +578,48 @@ var _ = Describe("Provisioner Annotation", func() {
 			Expect(p.Hash()).To(Equal(expectedHash))
 		},
 		// Base provisioner
-		Entry("should match static hash values", baseProvisionerExpectedHash),
+		Entry("should match with the base provisioner", baseProvisionerExpectedHash),
 
 		// Modified static fields - expect change from base provisioner
 		Entry(
-			"should match static hash values with modified annotations",
+			"should match with modified annotations",
 			"7374986726887162519",
 			test.ProvisionerOptions{Annotations: map[string]string{"keyAnnotationTest": "valueAnnotationTest"}},
 		),
 		Entry(
-			"should match static hash values with modified labels",
+			"should match with modified labels",
 			"9065364558915106368",
 			test.ProvisionerOptions{Labels: map[string]string{"keyLabelTest": "valueLabelTest"}},
 		),
 		Entry(
-			"should match static hash values with modified taints",
+			"should match with modified taints",
 			"9081458816929490897",
 			test.ProvisionerOptions{Taints: []v1.Taint{{Key: "keytest2Taint", Effect: v1.TaintEffectNoExecute}}},
 		),
 		Entry(
-			"should match static hash values with modified startup taints",
+			"should match with modified startup taints",
 			"2352640223763896447",
 			test.ProvisionerOptions{StartupTaints: []v1.Taint{{Key: "keytest2StartupTaint", Effect: v1.TaintEffectNoExecute}}},
 		),
 		Entry(
-			"should match static hash values with modified kubelet config",
+			"should match with modified kubelet config",
 			"3622457352880294488",
 			test.ProvisionerOptions{Kubelet: &KubeletConfiguration{MaxPods: ptr.Int32(30)}},
 		),
 
 		// Modified behavior fields - shouldn't change from base provisioner
 		Entry(
-			"should match static hash values with modified limits",
+			"should match with modified limits",
 			baseProvisionerExpectedHash,
 			test.ProvisionerOptions{Limits: v1.ResourceList{"cpu": resource.MustParse("4")}},
 		),
 		Entry(
-			"should match static hash values with modified provider ref",
+			"should match with modified provider ref",
 			baseProvisionerExpectedHash,
 			test.ProvisionerOptions{ProviderRef: &MachineTemplateRef{Name: "foobar"}},
 		),
 		Entry(
-			"should match static hash values with modified requirements",
+			"should match with modified requirements",
 			baseProvisionerExpectedHash,
 			test.ProvisionerOptions{Requirements: []v1.NodeSelectorRequirement{
 				{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test"}},
@@ -628,22 +628,22 @@ var _ = Describe("Provisioner Annotation", func() {
 			}},
 		),
 		Entry(
-			"should match static hash values with modified TTLSecondsUntilExpired",
+			"should match with modified TTLSecondsUntilExpired",
 			baseProvisionerExpectedHash,
 			test.ProvisionerOptions{TTLSecondsUntilExpired: lo.ToPtr(int64(30))},
 		),
 		Entry(
-			"should match static hash values with modified TTLSecondsAfterEmpty",
+			"should match with modified TTLSecondsAfterEmpty",
 			baseProvisionerExpectedHash,
 			test.ProvisionerOptions{TTLSecondsAfterEmpty: lo.ToPtr(int64(50))},
 		),
 		Entry(
-			"should match static hash values with modified weight",
+			"should match with modified weight",
 			baseProvisionerExpectedHash,
 			test.ProvisionerOptions{Weight: lo.ToPtr(int32(80))},
 		),
 		Entry(
-			"should match static hash values with modified consolidation flag",
+			"should match with modified consolidation flag",
 			baseProvisionerExpectedHash,
 			test.ProvisionerOptions{Consolidation: &Consolidation{lo.ToPtr(true)}},
 		),

--- a/pkg/apis/v1alpha5/suite_test.go
+++ b/pkg/apis/v1alpha5/suite_test.go
@@ -567,6 +567,38 @@ var _ = Describe("Provisioner Annotation", func() {
 		}
 		provisioner = test.Provisioner(testProvisionerOptions)
 	})
+	It("should match previous static hashes", func() {
+		provisioners := []struct {
+			provisioner *Provisioner
+			hash        string
+		}{
+			{
+				provisioner: provisioner,
+				hash:        "14114424411830460479",
+			},
+			{
+				provisioner: test.Provisioner(testProvisionerOptions, test.ProvisionerOptions{Annotations: map[string]string{"keyAnnotationTest": "valueAnnotationTest"}}),
+				hash:        "7374986726887162519",
+			},
+			{
+				provisioner: test.Provisioner(testProvisionerOptions, test.ProvisionerOptions{Labels: map[string]string{"keyLabelTest": "valueLabelTest"}}),
+				hash:        "9065364558915106368",
+			},
+			{
+				provisioner: test.Provisioner(testProvisionerOptions, test.ProvisionerOptions{Taints: []v1.Taint{{Key: "keytest2Taint", Effect: v1.TaintEffectNoExecute}}}),
+				hash:        "9081458816929490897",
+			},
+			{
+				provisioner: test.Provisioner(testProvisionerOptions, test.ProvisionerOptions{StartupTaints: []v1.Taint{{Key: "keytest2StartupTaint", Effect: v1.TaintEffectNoExecute}}}),
+				hash:        "2352640223763896447",
+			},
+		}
+
+		for _, p := range provisioners {
+			hash := p.provisioner.Hash()
+			Expect(hash).To(Equal(p.hash))
+		}
+	})
 	It("should change hash when static fields are updated", func() {
 		expectedHash := provisioner.Hash()
 

--- a/pkg/apis/v1alpha5/suite_test.go
+++ b/pkg/apis/v1alpha5/suite_test.go
@@ -539,6 +539,9 @@ var _ = Describe("Limits", func() {
 var _ = Describe("Provisioner Annotation", func() {
 	var testProvisionerOptions test.ProvisionerOptions
 	var provisioner *Provisioner
+
+	const baseProvisionerExpectedHash = "14114424411830460479"
+
 	BeforeEach(func() {
 		taints := []v1.Taint{
 			{
@@ -574,7 +577,10 @@ var _ = Describe("Provisioner Annotation", func() {
 			p := test.Provisioner(overrides...)
 			Expect(p.Hash()).To(Equal(expectedHash))
 		},
-		Entry("should match static hash values", "14114424411830460479"),
+		// Base provisioner
+		Entry("should match static hash values", baseProvisionerExpectedHash),
+
+		// Modified static fields - expect change from base provisioner
 		Entry(
 			"should match static hash values with modified annotations",
 			"7374986726887162519",
@@ -599,6 +605,47 @@ var _ = Describe("Provisioner Annotation", func() {
 			"should match static hash values with modified kubelet config",
 			"3622457352880294488",
 			test.ProvisionerOptions{Kubelet: &KubeletConfiguration{MaxPods: ptr.Int32(30)}},
+		),
+
+		// Modified behavior fields - shouldn't change from base provisioner
+		Entry(
+			"should match static hash values with modified limits",
+			baseProvisionerExpectedHash,
+			test.ProvisionerOptions{Limits: v1.ResourceList{"cpu": resource.MustParse("4")}},
+		),
+		Entry(
+			"should match static hash values with modified provider ref",
+			baseProvisionerExpectedHash,
+			test.ProvisionerOptions{ProviderRef: &MachineTemplateRef{Name: "foobar"}},
+		),
+		Entry(
+			"should match static hash values with modified requirements",
+			baseProvisionerExpectedHash,
+			test.ProvisionerOptions{Requirements: []v1.NodeSelectorRequirement{
+				{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test"}},
+				{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpGt, Values: []string{"1"}},
+				{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpLt, Values: []string{"1"}},
+			}},
+		),
+		Entry(
+			"should match static hash values with modified TTLSecondsUntilExpired",
+			baseProvisionerExpectedHash,
+			test.ProvisionerOptions{TTLSecondsUntilExpired: lo.ToPtr(int64(30))},
+		),
+		Entry(
+			"should match static hash values with modified TTLSecondsAfterEmpty",
+			baseProvisionerExpectedHash,
+			test.ProvisionerOptions{TTLSecondsAfterEmpty: lo.ToPtr(int64(50))},
+		),
+		Entry(
+			"should match static hash values with modified weight",
+			baseProvisionerExpectedHash,
+			test.ProvisionerOptions{Weight: lo.ToPtr(int32(80))},
+		),
+		Entry(
+			"should match static hash values with modified consolidation flag",
+			baseProvisionerExpectedHash,
+			test.ProvisionerOptions{Consolidation: &Consolidation{lo.ToPtr(true)}},
 		),
 	)
 	It("should change hash when static fields are updated", func() {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Adds a test to compare the hash of different provisioners to previously computed values. This ensures that equivalent provisioners hash to the same value between versions.

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
