### PR TITLE
chore: Support `v1beta1` in CloudProvider interface

### DIFF
--- a/pkg/apis/v1alpha5/labels.go
+++ b/pkg/apis/v1alpha5/labels.go
@@ -69,7 +69,6 @@ var (
 		"kops.k8s.io",
 		v1.LabelNamespaceSuffixNode,
 		v1.LabelNamespaceNodeRestriction,
-		TestingGroup,
 	)
 
 	// WellKnownLabels are labels that belong to the RestrictedLabelDomains but allowed.

--- a/pkg/apis/v1alpha5/suite_test.go
+++ b/pkg/apis/v1alpha5/suite_test.go
@@ -540,7 +540,7 @@ var _ = Describe("Provisioner Annotation", func() {
 	var testProvisionerOptions test.ProvisionerOptions
 	var provisioner *Provisioner
 
-	const baseProvisionerExpectedHash = "14114424411830460479"
+	const baseProvisionerExpectedHash = "775825888864018614"
 
 	BeforeEach(func() {
 		taints := []v1.Taint{
@@ -583,27 +583,27 @@ var _ = Describe("Provisioner Annotation", func() {
 		// Modified static fields - expect change from base provisioner
 		Entry(
 			"should match with modified annotations",
-			"7374986726887162519",
+			"8291486979066679783",
 			test.ProvisionerOptions{Annotations: map[string]string{"keyAnnotationTest": "valueAnnotationTest"}},
 		),
 		Entry(
 			"should match with modified labels",
-			"9065364558915106368",
+			"13084558173553732887",
 			test.ProvisionerOptions{Labels: map[string]string{"keyLabelTest": "valueLabelTest"}},
 		),
 		Entry(
 			"should match with modified taints",
-			"9081458816929490897",
+			"2448241124432930761",
 			test.ProvisionerOptions{Taints: []v1.Taint{{Key: "keytest2Taint", Effect: v1.TaintEffectNoExecute}}},
 		),
 		Entry(
 			"should match with modified startup taints",
-			"2352640223763896447",
+			"6798849987795493190",
 			test.ProvisionerOptions{StartupTaints: []v1.Taint{{Key: "keytest2StartupTaint", Effect: v1.TaintEffectNoExecute}}},
 		),
 		Entry(
 			"should match with modified kubelet config",
-			"3622457352880294488",
+			"12466819533084384505",
 			test.ProvisionerOptions{Kubelet: &KubeletConfiguration{MaxPods: ptr.Int32(30)}},
 		),
 

--- a/pkg/cloudprovider/metrics/cloudprovider_test.go
+++ b/pkg/cloudprovider/metrics/cloudprovider_test.go
@@ -25,14 +25,14 @@ import (
 )
 
 var _ = Describe("Cloudprovider", func() {
-	var machineNotFoundErr = cloudprovider.NewMachineNotFoundError(errors.New("not found"))
+	var nodeClaimNotFoundErr = cloudprovider.NewNodeClaimNotFoundError(errors.New("not found"))
 	var insufficientCapacityErr = cloudprovider.NewInsufficientCapacityError(errors.New("not enough capacity"))
 	var unknownErr = errors.New("this is an error we don't know about")
 
 	Describe("CloudProvider machine errors via GetErrorTypeLabelValue()", func() {
 		Context("when the error is known", func() {
-			It("machine not found should be recognized", func() {
-				Expect(metrics.GetErrorTypeLabelValue(machineNotFoundErr)).To(Equal(metrics.MachineNotFoundError))
+			It("nodeclaim not found should be recognized", func() {
+				Expect(metrics.GetErrorTypeLabelValue(nodeClaimNotFoundErr)).To(Equal(metrics.NodeClaimNotFoundError))
 			})
 			It("insufficient capacity should be recognized", func() {
 				Expect(metrics.GetErrorTypeLabelValue(insufficientCapacityErr)).To(Equal(metrics.InsufficientCapacityError))

--- a/pkg/controllers/machine/disruption/drift.go
+++ b/pkg/controllers/machine/disruption/drift.go
@@ -32,7 +32,6 @@ import (
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
 	"github.com/aws/karpenter-core/pkg/metrics"
 	"github.com/aws/karpenter-core/pkg/scheduling"
-	machineutil "github.com/aws/karpenter-core/pkg/utils/machine"
 	nodeclaimutil "github.com/aws/karpenter-core/pkg/utils/nodeclaim"
 )
 
@@ -68,7 +67,7 @@ func (d *Drift) Reconcile(ctx context.Context, nodePool *v1beta1.NodePool, nodeC
 	}
 	driftedReason, err := d.isDrifted(ctx, nodePool, nodeClaim)
 	if err != nil {
-		return reconcile.Result{}, cloudprovider.IgnoreMachineNotFoundError(fmt.Errorf("getting drift, %w", err))
+		return reconcile.Result{}, cloudprovider.IgnoreNodeClaimNotFoundError(fmt.Errorf("getting drift, %w", err))
 	}
 	// 3. Otherwise, if the NodeClaim isn't drifted, but has the status condition, remove it.
 	if driftedReason == "" {
@@ -102,7 +101,7 @@ func (d *Drift) isDrifted(ctx context.Context, nodePool *v1beta1.NodePool, nodeC
 	}); reason != "" {
 		return reason, nil
 	}
-	driftedReason, err := d.cloudProvider.IsMachineDrifted(ctx, machineutil.NewFromNodeClaim(nodeClaim))
+	driftedReason, err := d.cloudProvider.IsDrifted(ctx, nodeClaim)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/controllers/machine/garbagecollection/controller.go
+++ b/pkg/controllers/machine/garbagecollection/controller.go
@@ -27,7 +27,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
 	corecontroller "github.com/aws/karpenter-core/pkg/operator/controller"
@@ -58,15 +57,15 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 	if err != nil {
 		return reconcile.Result{}, err
 	}
-	cloudProviderMachines, err := c.cloudProvider.List(ctx)
+	cloudProviderNodeClaims, err := c.cloudProvider.List(ctx)
 	if err != nil {
 		return reconcile.Result{}, err
 	}
-	cloudProviderMachines = lo.Filter(cloudProviderMachines, func(m *v1alpha5.Machine, _ int) bool {
-		return m.DeletionTimestamp.IsZero()
+	cloudProviderNodeClaims = lo.Filter(cloudProviderNodeClaims, func(nc *v1beta1.NodeClaim, _ int) bool {
+		return nc.DeletionTimestamp.IsZero()
 	})
-	cloudProviderProviderIDs := sets.New[string](lo.Map(cloudProviderMachines, func(m *v1alpha5.Machine, _ int) string {
-		return m.Status.ProviderID
+	cloudProviderProviderIDs := sets.New[string](lo.Map(cloudProviderNodeClaims, func(nc *v1beta1.NodeClaim, _ int) string {
+		return nc.Status.ProviderID
 	})...)
 	nodeClaims := lo.Filter(lo.ToSlicePtr(nodeClaimList.Items), func(n *v1beta1.NodeClaim, _ int) bool {
 		return n.StatusConditions().GetCondition(v1beta1.NodeLaunched).IsTrue() &&

--- a/pkg/controllers/machine/garbagecollection/machine_test.go
+++ b/pkg/controllers/machine/garbagecollection/machine_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/test"
+	nodeclaimutil "github.com/aws/karpenter-core/pkg/utils/nodeclaim"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -53,7 +54,7 @@ var _ = Describe("Machine/GarbageCollection", func() {
 		fakeClock.SetTime(time.Now().Add(time.Second * 20))
 
 		// Delete the machine from the cloudprovider
-		Expect(cloudProvider.Delete(ctx, machine)).To(Succeed())
+		Expect(cloudProvider.Delete(ctx, nodeclaimutil.New(machine))).To(Succeed())
 
 		// Expect the Machine to be removed now that the Instance is gone
 		ExpectReconcileSucceeded(ctx, garbageCollectionController, client.ObjectKey{})
@@ -85,7 +86,7 @@ var _ = Describe("Machine/GarbageCollection", func() {
 		workqueue.ParallelizeUntil(ctx, len(machines), len(machines), func(i int) {
 			defer GinkgoRecover()
 			// Delete the machine from the cloudprovider
-			Expect(cloudProvider.Delete(ctx, machines[i])).To(Succeed())
+			Expect(cloudProvider.Delete(ctx, nodeclaimutil.New(machines[i]))).To(Succeed())
 		})
 
 		// Expect the Machines to be removed now that the Instance is gone

--- a/pkg/controllers/machine/garbagecollection/nodeclaim_test.go
+++ b/pkg/controllers/machine/garbagecollection/nodeclaim_test.go
@@ -22,12 +22,11 @@ import (
 	"k8s.io/client-go/util/workqueue"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
-	"github.com/aws/karpenter-core/pkg/test"
-	machineutil "github.com/aws/karpenter-core/pkg/utils/machine"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
+	"github.com/aws/karpenter-core/pkg/test"
 
 	. "github.com/aws/karpenter-core/pkg/test/expectations"
 )
@@ -54,7 +53,7 @@ var _ = Describe("NodeClaim/GarbageCollection", func() {
 		fakeClock.SetTime(time.Now().Add(time.Second * 20))
 
 		// Delete the nodeClaim from the cloudprovider
-		Expect(cloudProvider.Delete(ctx, machineutil.NewFromNodeClaim(nodeClaim))).To(Succeed())
+		Expect(cloudProvider.Delete(ctx, nodeClaim)).To(Succeed())
 
 		// Expect the NodeClaim to be removed now that the Instance is gone
 		ExpectReconcileSucceeded(ctx, garbageCollectionController, client.ObjectKey{})
@@ -86,7 +85,7 @@ var _ = Describe("NodeClaim/GarbageCollection", func() {
 		workqueue.ParallelizeUntil(ctx, len(nodeClaims), len(nodeClaims), func(i int) {
 			defer GinkgoRecover()
 			// Delete the NodeClaim from the cloudprovider
-			Expect(cloudProvider.Delete(ctx, machineutil.NewFromNodeClaim(nodeClaims[i]))).To(Succeed())
+			Expect(cloudProvider.Delete(ctx, nodeClaims[i])).To(Succeed())
 		})
 
 		// Expect the NodeClaims to be removed now that the Instance is gone

--- a/pkg/controllers/machine/garbagecollection/suite_test.go
+++ b/pkg/controllers/machine/garbagecollection/suite_test.go
@@ -41,7 +41,7 @@ import (
 	"github.com/aws/karpenter-core/pkg/operator/controller"
 	"github.com/aws/karpenter-core/pkg/operator/scheme"
 	"github.com/aws/karpenter-core/pkg/test"
-	machineutil "github.com/aws/karpenter-core/pkg/utils/machine"
+	nodeclaimutil "github.com/aws/karpenter-core/pkg/utils/nodeclaim"
 
 	. "github.com/aws/karpenter-core/pkg/test/expectations"
 )
@@ -117,9 +117,9 @@ var _ = Describe("Combined/GarbageCollection", func() {
 		// Step forward to move past the cache eventual consistency timeout
 		fakeClock.SetTime(time.Now().Add(time.Second * 20))
 
-		// Delete the nodeClaim from the cloudprovider
-		Expect(cloudProvider.Delete(ctx, machine)).To(Succeed())
-		Expect(cloudProvider.Delete(ctx, machineutil.NewFromNodeClaim(nodeClaim))).To(Succeed())
+		// Delete the NodeClaim and Machine from the cloudprovider
+		Expect(cloudProvider.Delete(ctx, nodeclaimutil.New(machine))).To(Succeed())
+		Expect(cloudProvider.Delete(ctx, nodeClaim)).To(Succeed())
 
 		// Expect the NodeClaim to be removed now that the Instance is gone
 		ExpectReconcileSucceeded(ctx, garbageCollectionController, client.ObjectKey{})

--- a/pkg/controllers/machine/lifecycle/nodeclaim_launch_test.go
+++ b/pkg/controllers/machine/lifecycle/nodeclaim_launch_test.go
@@ -51,7 +51,7 @@ var _ = Describe("NodeClaim/Launch", func() {
 		machine = ExpectExists(ctx, env.Client, machine)
 
 		Expect(cloudProvider.CreateCalls).To(HaveLen(1))
-		Expect(cloudProvider.CreatedMachines).To(HaveLen(1))
+		Expect(cloudProvider.CreatedNodeClaims).To(HaveLen(1))
 		_, err := cloudProvider.Get(ctx, machine.Status.ProviderID)
 		Expect(err).ToNot(HaveOccurred())
 	})

--- a/pkg/controllers/machine/termination/controller.go
+++ b/pkg/controllers/machine/termination/controller.go
@@ -88,7 +88,7 @@ func (c *Controller) Finalize(ctx context.Context, nodeClaim *v1beta1.NodeClaim)
 		return reconcile.Result{}, nil
 	}
 	if nodeClaim.Status.ProviderID != "" || nodeClaim.Annotations[v1alpha5.MachineLinkedAnnotationKey] != "" {
-		if err = c.cloudProvider.Delete(ctx, machineutil.NewFromNodeClaim(nodeClaim)); cloudprovider.IgnoreMachineNotFoundError(err) != nil {
+		if err = c.cloudProvider.Delete(ctx, nodeClaim); cloudprovider.IgnoreNodeClaimNotFoundError(err) != nil {
 			return reconcile.Result{}, fmt.Errorf("terminating cloudprovider instance, %w", err)
 		}
 	}

--- a/pkg/controllers/machine/termination/machine_test.go
+++ b/pkg/controllers/machine/termination/machine_test.go
@@ -80,7 +80,7 @@ var _ = Describe("Machine", func() {
 
 		// Expect the machine to be gone from the cloudprovider
 		_, err = cloudProvider.Get(ctx, machine.Status.ProviderID)
-		Expect(cloudprovider.IsMachineNotFoundError(err)).To(BeTrue())
+		Expect(cloudprovider.IsNodeClaimNotFoundError(err)).To(BeTrue())
 	})
 	It("should delete multiple Nodes if multiple Nodes map to the Machine", func() {
 		ExpectApplied(ctx, env.Client, provisioner, machine)
@@ -106,7 +106,7 @@ var _ = Describe("Machine", func() {
 
 		// Expect the machine to be gone from the cloudprovider
 		_, err = cloudProvider.Get(ctx, machine.Status.ProviderID)
-		Expect(cloudprovider.IsMachineNotFoundError(err)).To(BeTrue())
+		Expect(cloudprovider.IsNodeClaimNotFoundError(err)).To(BeTrue())
 	})
 	It("should delete the Instance if the Machine is linked but doesn't have its providerID resolved yet", func() {
 		node := test.MachineLinkedNode(machine)
@@ -122,7 +122,7 @@ var _ = Describe("Machine", func() {
 
 		// Expect the machine to be gone from the cloudprovider
 		_, err := cloudProvider.Get(ctx, machine.Annotations[v1alpha5.MachineLinkedAnnotationKey])
-		Expect(cloudprovider.IsMachineNotFoundError(err)).To(BeTrue())
+		Expect(cloudprovider.IsNodeClaimNotFoundError(err)).To(BeTrue())
 	})
 	It("should not delete the Machine until all the Nodes are removed", func() {
 		ExpectApplied(ctx, env.Client, provisioner, machine)

--- a/pkg/controllers/machine/termination/nodeclaim_test.go
+++ b/pkg/controllers/machine/termination/nodeclaim_test.go
@@ -81,7 +81,7 @@ var _ = Describe("NodeClaim", func() {
 
 		// Expect the nodeClaim to be gone from the cloudprovider
 		_, err = cloudProvider.Get(ctx, nodeClaim.Status.ProviderID)
-		Expect(cloudprovider.IsMachineNotFoundError(err)).To(BeTrue())
+		Expect(cloudprovider.IsNodeClaimNotFoundError(err)).To(BeTrue())
 	})
 	It("should delete multiple Nodes if multiple Nodes map to the NodeClaim", func() {
 		ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
@@ -107,7 +107,7 @@ var _ = Describe("NodeClaim", func() {
 
 		// Expect the nodeClaim to be gone from the cloudprovider
 		_, err = cloudProvider.Get(ctx, nodeClaim.Status.ProviderID)
-		Expect(cloudprovider.IsMachineNotFoundError(err)).To(BeTrue())
+		Expect(cloudprovider.IsNodeClaimNotFoundError(err)).To(BeTrue())
 	})
 	It("should delete the Instance if the NodeClaim is linked but doesn't have its providerID resolved yet", func() {
 		node := test.NodeClaimLinkedNode(nodeClaim)
@@ -123,7 +123,7 @@ var _ = Describe("NodeClaim", func() {
 
 		// Expect the nodeClaim to be gone from the cloudprovider
 		_, err := cloudProvider.Get(ctx, nodeClaim.Annotations[v1alpha5.MachineLinkedAnnotationKey])
-		Expect(cloudprovider.IsMachineNotFoundError(err)).To(BeTrue())
+		Expect(cloudprovider.IsNodeClaimNotFoundError(err)).To(BeTrue())
 	})
 	It("should not delete the NodeClaim until all the Nodes are removed", func() {
 		ExpectApplied(ctx, env.Client, nodePool, nodeClaim)

--- a/pkg/controllers/metrics/pod/controller.go
+++ b/pkg/controllers/metrics/pod/controller.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
+	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-core/pkg/metrics"
 	"github.com/aws/karpenter-core/pkg/operator/controller"
 )
@@ -43,6 +44,7 @@ const (
 	ownerSelfLink       = "owner"
 	podHostName         = "node"
 	podProvisioner      = "provisioner"
+	podNodePool         = "nodepool"
 	podHostZone         = "zone"
 	podHostArchitecture = "arch"
 	podHostCapacityType = "capacity_type"
@@ -93,6 +95,7 @@ func labelNames() []string {
 		ownerSelfLink,
 		podHostName,
 		podProvisioner,
+		podNodePool,
 		podHostZone,
 		podHostArchitecture,
 		podHostCapacityType,
@@ -179,9 +182,10 @@ func (c *Controller) makeLabels(ctx context.Context, pod *v1.Pod) (prometheus.La
 	}
 	metricLabels[podHostZone] = node.Labels[v1.LabelTopologyZone]
 	metricLabels[podHostArchitecture] = node.Labels[v1.LabelArchStable]
-	metricLabels[podHostCapacityType] = node.Labels[v1alpha5.LabelCapacityType]
+	metricLabels[podHostCapacityType] = node.Labels[v1beta1.CapacityTypeLabelKey]
 	metricLabels[podHostInstanceType] = node.Labels[v1.LabelInstanceTypeStable]
 	metricLabels[podProvisioner] = node.Labels[v1alpha5.ProvisionerNameLabelKey]
+	metricLabels[podNodePool] = node.Labels[v1beta1.NodePoolLabelKey]
 	return metricLabels, nil
 }
 

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -35,15 +35,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
-	nodeclaimutil "github.com/aws/karpenter-core/pkg/utils/nodeclaim"
-	nodepoolutil "github.com/aws/karpenter-core/pkg/utils/nodepool"
-	provisionerutil "github.com/aws/karpenter-core/pkg/utils/provisioner"
-
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
+	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-core/pkg/operator/controller"
 	"github.com/aws/karpenter-core/pkg/scheduling"
 	"github.com/aws/karpenter-core/pkg/utils/functional"
+	nodeclaimutil "github.com/aws/karpenter-core/pkg/utils/nodeclaim"
+	nodepoolutil "github.com/aws/karpenter-core/pkg/utils/nodepool"
 	"github.com/aws/karpenter-core/pkg/utils/pretty"
 
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
@@ -230,7 +228,7 @@ func (p *Provisioner) NewScheduler(ctx context.Context, pods []*v1.Pod, stateNod
 		// Create node template
 		nodeClaimTemplates = append(nodeClaimTemplates, scheduler.NewNodeClaimTemplate(nodePool))
 		// Get instance type options
-		instanceTypeOptions, err := p.cloudProvider.GetInstanceTypes(ctx, provisionerutil.New(nodePool))
+		instanceTypeOptions, err := p.cloudProvider.GetInstanceTypes(ctx, nodePool)
 		if err != nil {
 			return nil, fmt.Errorf("getting instance types, %w", err)
 		}

--- a/pkg/controllers/provisioning/scheduling/instance_selection_test.go
+++ b/pkg/controllers/provisioning/scheduling/instance_selection_test.go
@@ -28,6 +28,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
+	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
 	"github.com/aws/karpenter-core/pkg/cloudprovider/fake"
 	"github.com/aws/karpenter-core/pkg/scheduling"
@@ -595,8 +596,8 @@ var _ = Describe("Instance Type Selection", func() {
 	})
 })
 
-func supportedInstanceTypes(machine *v1alpha5.Machine) (res []*cloudprovider.InstanceType) {
-	reqs := scheduling.NewNodeSelectorRequirements(machine.Spec.Requirements...)
+func supportedInstanceTypes(nodeClaim *v1beta1.NodeClaim) (res []*cloudprovider.InstanceType) {
+	reqs := scheduling.NewNodeSelectorRequirements(nodeClaim.Spec.Requirements...)
 	return lo.Filter(cloudProvider.InstanceTypes, func(i *cloudprovider.InstanceType, _ int) bool {
 		return reqs.Get(v1.LabelInstanceTypeStable).Has(i.Name)
 	})

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -41,7 +41,6 @@ import (
 	"github.com/aws/karpenter-core/pkg/scheduling"
 	nodeclaimutil "github.com/aws/karpenter-core/pkg/utils/nodeclaim"
 	podutils "github.com/aws/karpenter-core/pkg/utils/pod"
-	provisionerutil "github.com/aws/karpenter-core/pkg/utils/provisioner"
 	"github.com/aws/karpenter-core/pkg/utils/sets"
 )
 
@@ -496,7 +495,7 @@ func (c *Cluster) populateInflight(ctx context.Context, n *StateNode) error {
 	if err != nil {
 		return client.IgnoreNotFound(err)
 	}
-	instanceTypes, err := c.cloudProvider.GetInstanceTypes(ctx, provisionerutil.New(owner))
+	instanceTypes, err := c.cloudProvider.GetInstanceTypes(ctx, owner)
 	if err != nil {
 		return err
 	}

--- a/pkg/controllers/termination/suite_test.go
+++ b/pkg/controllers/termination/suite_test.go
@@ -30,6 +30,7 @@ import (
 
 	"github.com/aws/karpenter-core/pkg/apis"
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
+	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-core/pkg/cloudprovider/fake"
 	"github.com/aws/karpenter-core/pkg/controllers/termination"
 	"github.com/aws/karpenter-core/pkg/controllers/termination/terminator"
@@ -38,6 +39,7 @@ import (
 	"github.com/aws/karpenter-core/pkg/operator/controller"
 	"github.com/aws/karpenter-core/pkg/operator/scheme"
 	"github.com/aws/karpenter-core/pkg/test"
+	nodeclaimutil "github.com/aws/karpenter-core/pkg/utils/nodeclaim"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -86,7 +88,7 @@ var _ = Describe("Termination", func() {
 
 	BeforeEach(func() {
 		machine, node = test.MachineAndNode(v1alpha5.Machine{ObjectMeta: metav1.ObjectMeta{Finalizers: []string{v1alpha5.TerminationFinalizer}}})
-		cloudProvider.CreatedMachines[node.Spec.ProviderID] = machine
+		cloudProvider.CreatedNodeClaims[node.Spec.ProviderID] = nodeclaimutil.New(machine)
 	})
 
 	AfterEach(func() {
@@ -409,7 +411,7 @@ var _ = Describe("Termination", func() {
 			ExpectDeleted(ctx, env.Client, pods[1])
 
 			// Remove the node from created machines so that the cloud provider returns DNE
-			cloudProvider.CreatedMachines = map[string]*v1alpha5.Machine{}
+			cloudProvider.CreatedNodeClaims = map[string]*v1beta1.NodeClaim{}
 
 			// Reconcile to delete node
 			node = ExpectNodeExists(ctx, env.Client, node.Name)

--- a/pkg/operator/controller/suite_test.go
+++ b/pkg/operator/controller/suite_test.go
@@ -99,7 +99,7 @@ var _ = Describe("Typed", func() {
 					v1alpha5.ProvisionerNameLabelKey: "default",
 				},
 				Finalizers: []string{
-					v1alpha5.TestingGroup + "/finalizer",
+					"testing/finalizer",
 				},
 			},
 		})

--- a/pkg/scheduling/requirement.go
+++ b/pkg/scheduling/requirement.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
+	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
 )
 
 // Requirement is an efficient represenatation of v1.NodeSelectorRequirement
@@ -38,6 +39,9 @@ type Requirement struct {
 
 func NewRequirement(key string, operator v1.NodeSelectorOperator, values ...string) *Requirement {
 	if normalized, ok := v1alpha5.NormalizedLabels[key]; ok {
+		key = normalized
+	}
+	if normalized, ok := v1beta1.NormalizedLabels[key]; ok {
 		key = normalized
 	}
 

--- a/pkg/scheduling/requirements.go
+++ b/pkg/scheduling/requirements.go
@@ -256,7 +256,7 @@ func (r Requirements) Intersects(requirements Requirements) (errs error) {
 func (r Requirements) Labels() map[string]string {
 	labels := map[string]string{}
 	for key, requirement := range r {
-		if !v1alpha5.IsRestrictedNodeLabel(key) {
+		if !v1alpha5.IsRestrictedNodeLabel(key) && !v1beta1.IsRestrictedNodeLabel(key) {
 			if value := requirement.Any(); value != "" {
 				labels[key] = value
 			}
@@ -266,7 +266,9 @@ func (r Requirements) Labels() map[string]string {
 }
 
 func (r Requirements) String() string {
-	requirements := lo.Reject(r.Values(), func(requirement *Requirement, _ int) bool { return v1alpha5.RestrictedLabels.Has(requirement.Key) })
+	requirements := lo.Reject(r.Values(), func(requirement *Requirement, _ int) bool {
+		return v1alpha5.RestrictedLabels.Has(requirement.Key) || v1beta1.RestrictedLabels.Has(requirement.Key)
+	})
 	stringRequirements := lo.Map(requirements, func(requirement *Requirement, _ int) string { return requirement.String() })
 	slices.Sort(stringRequirements)
 	return strings.Join(stringRequirements, ", ")

--- a/pkg/test/metadata.go
+++ b/pkg/test/metadata.go
@@ -24,11 +24,9 @@ import (
 	"github.com/Pallinder/go-randomdata"
 	"github.com/imdario/mergo"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 )
 
-const DiscoveryLabel = v1alpha5.TestingGroup + "/cluster"
+const DiscoveryLabel = "testing/cluster"
 
 var (
 	sequentialNumber     = 0

--- a/pkg/utils/nodepool/nodepool.go
+++ b/pkg/utils/nodepool/nodepool.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/samber/lo"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
@@ -105,6 +106,21 @@ func NewNodeClassReference(pr *v1alpha5.MachineTemplateRef) *v1beta1.NodeClassRe
 		Name:       pr.Name,
 		APIVersion: pr.APIVersion,
 	}
+}
+
+func Get(ctx context.Context, c client.Client, key Key) (*v1beta1.NodePool, error) {
+	if key.IsProvisioner {
+		provisioner := &v1alpha5.Provisioner{}
+		if err := c.Get(ctx, types.NamespacedName{Name: key.Name}, provisioner); err != nil {
+			return nil, err
+		}
+		return New(provisioner), nil
+	}
+	nodePool := &v1beta1.NodePool{}
+	if err := c.Get(ctx, types.NamespacedName{Name: key.Name}, nodePool); err != nil {
+		return nil, err
+	}
+	return nodePool, nil
 }
 
 func List(ctx context.Context, c client.Client, opts ...client.ListOption) (*v1beta1.NodePoolList, error) {

--- a/pkg/utils/pod/scheduling.go
+++ b/pkg/utils/pod/scheduling.go
@@ -19,6 +19,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
+	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-core/pkg/scheduling"
 )
 
@@ -79,11 +80,12 @@ func IsOwnedBy(pod *v1.Pod, gvks []schema.GroupVersionKind) bool {
 	return false
 }
 
-func HasDoNotEvict(pod *v1.Pod) bool {
+func HasDoNotDisrupt(pod *v1.Pod) bool {
 	if pod.Annotations == nil {
 		return false
 	}
-	return pod.Annotations[v1alpha5.DoNotEvictPodAnnotationKey] == "true"
+	return pod.Annotations[v1alpha5.DoNotEvictPodAnnotationKey] == "true" ||
+		pod.Annotations[v1beta1.DoNotDisruptAnnotationKey] == "true"
 }
 
 // HasUnschedulableToleration returns true if the pod tolerates node.kubernetes.io/unschedulable taint


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR migrates the CloudProvider interface to use the new `v1beta1` APIs. A change will have to be made in `aws/karpenter` to support this breaking change. This change is another one of the changes on the path to fully migrating the repository over to the new v1beta1 APIs.

**How was this change tested?**

`make presubmit`
`/karpenter snapshot`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
