### PR TITLE
chore: remove unprovisionable pods from scheduling results

### DIFF
--- a/pkg/controllers/deprovisioning/consolidation.go
+++ b/pkg/controllers/deprovisioning/consolidation.go
@@ -121,7 +121,7 @@ func (c *consolidation) computeConsolidation(ctx context.Context, candidates ...
 	}
 
 	// if not all of the pods were scheduled, we can't do anything
-	if !results.AllNonPendingPodsScheduled() {
+	if !results.AllPodsScheduled() {
 		// This method is used by multi-node consolidation as well, so we'll only report in the single node case
 		if len(candidates) == 1 {
 			c.recorder.Publish(deprovisioningevents.Unconsolidatable(candidates[0].Node, candidates[0].NodeClaim, results.PodSchedulingErrors())...)

--- a/pkg/controllers/deprovisioning/drift.go
+++ b/pkg/controllers/deprovisioning/drift.go
@@ -98,7 +98,7 @@ func (d *Drift) ComputeCommand(ctx context.Context, nodes ...*Candidate) (Comman
 			return Command{}, err
 		}
 		// Log when all pods can't schedule, as the command will get executed immediately.
-		if !results.AllNonPendingPodsScheduled() {
+		if !results.AllPodsScheduled() {
 			logging.FromContext(ctx).With("machine", candidate.NodeClaim.Name, "node", candidate.Node.Name).Debugf("cannot terminate drifted machine since scheduling simulation failed to schedule all pods %s", results.PodSchedulingErrors())
 			d.recorder.Publish(deprovisioningevents.Blocked(candidate.Node, candidate.NodeClaim, "Scheduling simulation failed to schedule all pods")...)
 			continue

--- a/pkg/controllers/deprovisioning/expiration.go
+++ b/pkg/controllers/deprovisioning/expiration.go
@@ -102,7 +102,7 @@ func (e *Expiration) ComputeCommand(ctx context.Context, nodes ...*Candidate) (C
 			return Command{}, err
 		}
 		// Log when all pods can't schedule, as the command will get executed immediately.
-		if !results.AllNonPendingPodsScheduled() {
+		if !results.AllPodsScheduled() {
 			logging.FromContext(ctx).With("machine", candidate.NodeClaim.Name, "node", candidate.Node.Name).Debugf("cannot terminate expired machine since scheduling simulation failed to schedule all pods, %s", results.PodSchedulingErrors())
 			e.recorder.Publish(deprovisioningevents.Blocked(candidate.Node, candidate.NodeClaim, "Scheduling simulation failed to schedule all pods")...)
 			continue

--- a/pkg/controllers/deprovisioning/helpers.go
+++ b/pkg/controllers/deprovisioning/helpers.go
@@ -109,11 +109,7 @@ func simulateScheduling(ctx context.Context, kubeClient client.Client, cluster *
 		return nil, fmt.Errorf("creating scheduler, %w", err)
 	}
 
-	results, err := scheduler.Solve(ctx, pods)
-	if err != nil {
-		return nil, fmt.Errorf("simulating scheduling, %w", err)
-	}
-
+	results := scheduler.Solve(ctx, pods)
 	// check if the scheduling relied on an existing node that isn't ready yet, if so we fail
 	// to schedule since we want to assume that we can delete a node and its pods will immediately
 	// move to an existing node which won't occur if that node isn't ready.

--- a/pkg/controllers/deprovisioning/validation.go
+++ b/pkg/controllers/deprovisioning/validation.go
@@ -128,7 +128,7 @@ func (v *Validation) ValidateCommand(ctx context.Context, cmd Command, candidate
 	if err != nil {
 		return false, fmt.Errorf("simluating scheduling, %w", err)
 	}
-	if !results.AllNonPendingPodsScheduled() {
+	if !results.AllPodsScheduled() {
 		return false, nil
 	}
 

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -327,7 +327,7 @@ func (p *Provisioner) Schedule(ctx context.Context) (*scheduler.Results, error) 
 		}
 		return nil, fmt.Errorf("creating scheduler, %w", err)
 	}
-	return s.Solve(ctx, pods)
+	return s.Solve(ctx, pods), nil
 }
 
 func (p *Provisioner) Launch(ctx context.Context, n *scheduler.NodeClaim, opts ...functional.Option[LaunchOptions]) (nodeclaimutil.Key, error) {

--- a/pkg/controllers/provisioning/scheduling/scheduling_benchmark_test.go
+++ b/pkg/controllers/provisioning/scheduling/scheduling_benchmark_test.go
@@ -136,10 +136,7 @@ func benchmarkScheduler(b *testing.B, instanceCount, podCount int) {
 	podsScheduledInRound1 := 0
 	nodesInRound1 := 0
 	for i := 0; i < b.N; i++ {
-		results, err := scheduler.Solve(ctx, pods)
-		if err != nil {
-			b.FailNow()
-		}
+		results := scheduler.Solve(ctx, pods)
 		if i == 0 {
 
 			minPods := math.MaxInt64


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
This change essentially moves the check to see if podSchedulingErrors has unprovisionable pods into the scheduling Solve() function itself, since we only need to log the PodSchedulingErrors for unprovisionable pods when we're in scheduling. Only deprovisioning needs to be aware of the PodSchedulingErrors, where unprovisionable pods are ignored.

**How was this change tested?**
- make presubmit 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
