### PR TITLE
chore: Add handling to delete all `v1beta1/NodeClaim` on node termination

### DIFF
--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -31,6 +31,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
+	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
+	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-core/pkg/utils/env"
 	"github.com/aws/karpenter-core/pkg/utils/functional"
 	nodeclaimutil "github.com/aws/karpenter-core/pkg/utils/nodeclaim"
@@ -65,6 +67,22 @@ func WithFieldIndexers(fieldIndexers ...func(cache.Cache) error) functional.Opti
 	return func(o EnvironmentOptions) EnvironmentOptions {
 		o.fieldIndexers = append(o.fieldIndexers, fieldIndexers...)
 		return o
+	}
+}
+
+func MachineFieldIndexer(ctx context.Context) func(cache.Cache) error {
+	return func(c cache.Cache) error {
+		return c.IndexField(ctx, &v1alpha5.Machine{}, "status.providerID", func(obj client.Object) []string {
+			return []string{obj.(*v1alpha5.Machine).Status.ProviderID}
+		})
+	}
+}
+
+func NodeClaimFieldIndexer(ctx context.Context) func(cache.Cache) error {
+	return func(c cache.Cache) error {
+		return c.IndexField(ctx, &v1beta1.NodeClaim{}, "status.providerID", func(obj client.Object) []string {
+			return []string{obj.(*v1beta1.NodeClaim).Status.ProviderID}
+		})
 	}
 }
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR adds the removal of the `v1beta1/NodeClaim`s that are associated with any given `v1.Node` provider ID. This change is another one of the changes on the path to fully migrating the repository over to the new v1beta1 APIs.

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
