### PR TITLE
feat: index default namespace endpoints for discovery

### DIFF
--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -26,6 +26,7 @@ import (
 	"github.com/samber/lo"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	v1 "k8s.io/api/core/v1"
+	discoveryv1 "k8s.io/api/discovery/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/leaderelection/resourcelock"
@@ -129,6 +130,9 @@ func NewOperator() (context.Context, *Operator) {
 			SelectorsByObject: cache.SelectorsByObject{
 				&coordinationv1.Lease{}: {
 					Field: fields.SelectorFromSet(fields.Set{"metadata.namespace": "kube-node-lease"}),
+				},
+				&discoveryv1.EndpointSlice{}: {
+					Field: fields.SelectorFromSet(fields.Set{"metadata.namespace": "default"}),
 				},
 			},
 		}),


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
This adds in a endpoint slice cache so that we can list/watch endpoints in the default namespace.

**How was this change tested?**
- make presubmit

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
