### PR TITLE
chore: Add nodepool informer for triggering consolidation updates

### DIFF
--- a/pkg/controllers/nodepool/hash/suite_test.go
+++ b/pkg/controllers/nodepool/hash/suite_test.go
@@ -27,8 +27,6 @@ import (
 	"github.com/aws/karpenter-core/pkg/operator/controller"
 	"github.com/aws/karpenter-core/pkg/operator/scheme"
 	"github.com/aws/karpenter-core/pkg/test"
-	nodeclaimutil "github.com/aws/karpenter-core/pkg/utils/nodeclaim"
-	nodepoolutil "github.com/aws/karpenter-core/pkg/utils/nodepool"
 )
 
 var provisionerController controller.Controller
@@ -43,8 +41,6 @@ func TestAPIs(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	nodeclaimutil.EnableNodeClaims = true
-	nodepoolutil.EnableNodePools = true
 	env = test.NewEnvironment(scheme.Scheme, test.WithCRDs(apis.CRDs...))
 	provisionerController = hash.NewProvisionerController(env.Client)
 	nodePoolController = hash.NewNodePoolController(env.Client)

--- a/pkg/controllers/provisioning/suite_test.go
+++ b/pkg/controllers/provisioning/suite_test.go
@@ -42,8 +42,6 @@ import (
 	"github.com/aws/karpenter-core/pkg/operator/scheme"
 	"github.com/aws/karpenter-core/pkg/test"
 	. "github.com/aws/karpenter-core/pkg/test/expectations"
-	nodeclaimutil "github.com/aws/karpenter-core/pkg/utils/nodeclaim"
-	nodepoolutil "github.com/aws/karpenter-core/pkg/utils/nodepool"
 )
 
 var ctx context.Context
@@ -63,8 +61,6 @@ func TestAPIs(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	nodeclaimutil.EnableNodeClaims = true
-	nodepoolutil.EnableNodePools = true
 	env = test.NewEnvironment(scheme.Scheme, test.WithCRDs(apis.CRDs...))
 	ctx = settings.ToContext(ctx, test.Settings())
 	cloudProvider = fake.NewCloudProvider()

--- a/pkg/controllers/state/informer/nodeclaim.go
+++ b/pkg/controllers/state/informer/nodeclaim.go
@@ -46,7 +46,7 @@ func NewNodeClaimController(kubeClient client.Client, cluster *state.Cluster) co
 }
 
 func (c *NodeClaimController) Name() string {
-	return "nodeclaim-state"
+	return "state.nodeclaim"
 }
 
 func (c *NodeClaimController) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {

--- a/pkg/controllers/state/informer/nodepool.go
+++ b/pkg/controllers/state/informer/nodepool.go
@@ -1,0 +1,66 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package informer
+
+import (
+	"context"
+
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
+	"github.com/aws/karpenter-core/pkg/controllers/state"
+	corecontroller "github.com/aws/karpenter-core/pkg/operator/controller"
+)
+
+var _ corecontroller.TypedController[*v1beta1.NodePool] = (*NodePoolController)(nil)
+
+// NodePoolController reconciles NodePools to re-trigger consolidation on change.
+type NodePoolController struct {
+	kubeClient client.Client
+	cluster    *state.Cluster
+}
+
+func NewNodePoolController(kubeClient client.Client, cluster *state.Cluster) corecontroller.Controller {
+	return corecontroller.Typed[*v1beta1.NodePool](kubeClient, &NodePoolController{
+		kubeClient: kubeClient,
+		cluster:    cluster,
+	})
+}
+
+func (c *NodePoolController) Name() string {
+	return "state.nodepool"
+}
+
+func (c *NodePoolController) Reconcile(_ context.Context, _ *v1beta1.NodePool) (reconcile.Result, error) {
+	// Something changed in the NodePool so we should re-consider consolidation
+	c.cluster.MarkUnconsolidated()
+	return reconcile.Result{}, nil
+}
+
+func (c *NodePoolController) Builder(_ context.Context, m manager.Manager) corecontroller.Builder {
+	return corecontroller.Adapt(controllerruntime.
+		NewControllerManagedBy(m).
+		For(&v1beta1.NodePool{}).
+		WithOptions(controller.Options{MaxConcurrentReconciles: 10}).
+		WithEventFilter(predicate.GenerationChangedPredicate{}).
+		WithEventFilter(predicate.Funcs{DeleteFunc: func(event event.DeleteEvent) bool { return false }}),
+	)
+}

--- a/pkg/controllers/termination/suite_test.go
+++ b/pkg/controllers/termination/suite_test.go
@@ -64,7 +64,6 @@ func TestAPIs(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	nodeclaimutil.EnableNodeClaims = true
 	fakeClock = clock.NewFakeClock(time.Now())
 	env = test.NewEnvironment(scheme.Scheme, test.WithCRDs(apis.CRDs...), test.WithFieldIndexers(test.MachineFieldIndexer(ctx), test.NodeClaimFieldIndexer(ctx)))
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR adds the `v1beta1/NodePool` informer to trigger consolidation updates anytime there is a change in the NodePool spec

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
