### PR TITLE
test: Don't constrain the NodeClaim if no test requirements are specified by default

### DIFF
--- a/pkg/test/nodeclaim.go
+++ b/pkg/test/nodeclaim.go
@@ -44,23 +44,7 @@ func NodeClaim(overrides ...v1beta1.NodeClaim) *v1beta1.NodeClaim {
 		}
 	}
 	if override.Spec.Requirements == nil {
-		override.Spec.Requirements = []v1.NodeSelectorRequirement{
-			{
-				Key:      v1beta1.CapacityTypeLabelKey,
-				Operator: v1.NodeSelectorOpIn,
-				Values:   []string{v1beta1.CapacityTypeOnDemand},
-			},
-			{
-				Key:      v1.LabelOSStable,
-				Operator: v1.NodeSelectorOpIn,
-				Values:   []string{string(v1.Linux)},
-			},
-			{
-				Key:      v1.LabelArchStable,
-				Operator: v1.NodeSelectorOpIn,
-				Values:   []string{v1beta1.ArchitectureAmd64},
-			},
-		}
+		override.Spec.Requirements = []v1.NodeSelectorRequirement{}
 	}
 	return &v1beta1.NodeClaim{
 		ObjectMeta: ObjectMeta(override.ObjectMeta),


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR removes the defaulting logic for the `v1.NodeSelectorRequirements` for the `NodeClaim`, similar to the removal for the `v1beta1.NodePool`

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
