### PR TITLE
chore: Drop the `containerRuntime` field from the `v1beta1` kubeletConfig

### DIFF
--- a/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
@@ -79,10 +79,6 @@ spec:
                     items:
                       type: string
                     type: array
-                  containerRuntime:
-                    description: ContainerRuntime is the container runtime to be used
-                      with your worker nodes.
-                    type: string
                   cpuCFSQuota:
                     description: CPUCFSQuota enables CPU CFS quota enforcement for
                       containers that specify CPU limits.

--- a/pkg/apis/crds/karpenter.sh_nodepools.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodepools.yaml
@@ -134,10 +134,6 @@ spec:
                             items:
                               type: string
                             type: array
-                          containerRuntime:
-                            description: ContainerRuntime is the container runtime
-                              to be used with your worker nodes.
-                            type: string
                           cpuCFSQuota:
                             description: CPUCFSQuota enables CPU CFS quota enforcement
                               for containers that specify CPU limits.

--- a/pkg/apis/v1beta1/nodeclaim.go
+++ b/pkg/apis/v1beta1/nodeclaim.go
@@ -67,9 +67,10 @@ type KubeletConfiguration struct {
 	// Note that not all providers may use all addresses.
 	//+optional
 	ClusterDNS []string `json:"clusterDNS,omitempty"`
+	// TODO @joinnis: Remove this field when v1alpha5 is unsupported in a future version of Karpenter
 	// ContainerRuntime is the container runtime to be used with your worker nodes.
 	// +optional
-	ContainerRuntime *string `json:"containerRuntime,omitempty"`
+	ContainerRuntime *string `json:"-"`
 	// MaxPods is an override for the maximum number of pods that can run on
 	// a worker node instance.
 	// +kubebuilder:validation:Minimum:=0


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR drops the `spec.kubelet.containerRuntime` field from the `v1beta1` APIs

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
