### PR TITLE
chore: Create custom `NodeClassNotReady` error for nodeClaim launch

### DIFF
--- a/pkg/cloudprovider/metrics/cloudprovider.go
+++ b/pkg/cloudprovider/metrics/cloudprovider.go
@@ -36,6 +36,7 @@ const (
 	MetricLabelErrorDefaultVal = ""
 	// Well-known metricLabelError values
 	NodeClaimNotFoundError    = "NodeClaimNotFoundError"
+	NodeClassNotReadyError    = "NodeClassNotReadyError"
 	InsufficientCapacityError = "InsufficientCapacityError"
 )
 
@@ -176,10 +177,14 @@ func getLabelsMapForError(ctx context.Context, d *decorator, method string, err 
 // GetErrorTypeLabelValue is a convenience func that returns
 // a string representation of well-known CloudProvider error types
 func GetErrorTypeLabelValue(err error) string {
-	if cloudprovider.IsInsufficientCapacityError(err) {
+	switch {
+	case cloudprovider.IsInsufficientCapacityError(err):
 		return InsufficientCapacityError
-	} else if cloudprovider.IsNodeClaimNotFoundError(err) {
+	case cloudprovider.IsNodeClaimNotFoundError(err):
 		return NodeClaimNotFoundError
+	case cloudprovider.IsNodeClassNotReadyError(err):
+		return NodeClassNotReadyError
+	default:
+		return MetricLabelErrorDefaultVal
 	}
-	return MetricLabelErrorDefaultVal
 }

--- a/pkg/cloudprovider/metrics/cloudprovider_test.go
+++ b/pkg/cloudprovider/metrics/cloudprovider_test.go
@@ -27,6 +27,7 @@ import (
 var _ = Describe("Cloudprovider", func() {
 	var nodeClaimNotFoundErr = cloudprovider.NewNodeClaimNotFoundError(errors.New("not found"))
 	var insufficientCapacityErr = cloudprovider.NewInsufficientCapacityError(errors.New("not enough capacity"))
+	var nodeClassNotReadyErr = cloudprovider.NewNodeClassNotReadyError(errors.New("not ready"))
 	var unknownErr = errors.New("this is an error we don't know about")
 
 	Describe("CloudProvider machine errors via GetErrorTypeLabelValue()", func() {
@@ -36,6 +37,9 @@ var _ = Describe("Cloudprovider", func() {
 			})
 			It("insufficient capacity should be recognized", func() {
 				Expect(metrics.GetErrorTypeLabelValue(insufficientCapacityErr)).To(Equal(metrics.InsufficientCapacityError))
+			})
+			It("nodeclass not ready should be recognized", func() {
+				Expect(metrics.GetErrorTypeLabelValue(nodeClassNotReadyErr)).To(Equal(metrics.NodeClassNotReadyError))
 			})
 		})
 		Context("when the error is unknown", func() {

--- a/pkg/cloudprovider/types.go
+++ b/pkg/cloudprovider/types.go
@@ -222,3 +222,33 @@ func IgnoreInsufficientCapacityError(err error) error {
 	}
 	return err
 }
+
+// NodeClassNotReadyError is an error type returned by CloudProviders when a NodeClass that is used by the launch process doesn't have all its resolved fields
+type NodeClassNotReadyError struct {
+	error
+}
+
+func NewNodeClassNotReadyError(err error) *NodeClassNotReadyError {
+	return &NodeClassNotReadyError{
+		error: err,
+	}
+}
+
+func (e *NodeClassNotReadyError) Error() string {
+	return fmt.Sprintf("NodeClass not ready, %s", e.error)
+}
+
+func IsNodeClassNotReadyError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var nrError *NodeClassNotReadyError
+	return errors.As(err, &nrError)
+}
+
+func IgnoreNodeClassNotReadyError(err error) error {
+	if IsNodeClassNotReadyError(err) {
+		return nil
+	}
+	return err
+}

--- a/pkg/controllers/nodeclaim/lifecycle/events.go
+++ b/pkg/controllers/nodeclaim/lifecycle/events.go
@@ -43,3 +43,23 @@ func InsufficientCapacityErrorEvent(nodeClaim *v1beta1.NodeClaim, err error) eve
 		DedupeValues:   []string{string(nodeClaim.UID)},
 	}
 }
+
+func NodeClassNotReadyEvent(nodeClaim *v1beta1.NodeClaim, err error) events.Event {
+	if nodeClaim.IsMachine {
+		machine := machineutil.NewFromNodeClaim(nodeClaim)
+		return events.Event{
+			InvolvedObject: machine,
+			Type:           v1.EventTypeWarning,
+			Reason:         "ProviderNotReady",
+			Message:        fmt.Sprintf("Machine %s event: %s", machine.Name, truncateMessage(err.Error())),
+			DedupeValues:   []string{string(machine.UID)},
+		}
+	}
+	return events.Event{
+		InvolvedObject: nodeClaim,
+		Type:           v1.EventTypeWarning,
+		Reason:         "NodeClassNotReady",
+		Message:        fmt.Sprintf("NodeClaim %s event: %s", nodeClaim.Name, truncateMessage(err.Error())),
+		DedupeValues:   []string{string(nodeClaim.UID)},
+	}
+}

--- a/pkg/controllers/nodeclaim/lifecycle/nodeclaim_launch_test.go
+++ b/pkg/controllers/nodeclaim/lifecycle/nodeclaim_launch_test.go
@@ -37,44 +37,54 @@ var _ = Describe("NodeClaim/Launch", func() {
 	BeforeEach(func() {
 		nodePool = test.NodePool()
 	})
-	It("should launch an instance when a new Machine is created", func() {
-		machine := test.NodeClaim(v1beta1.NodeClaim{
+	It("should launch an instance when a new NodeClaim is created", func() {
+		nodeClaim := test.NodeClaim(v1beta1.NodeClaim{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					v1beta1.NodePoolLabelKey: nodePool.Name,
 				},
 			},
 		})
-		ExpectApplied(ctx, env.Client, nodePool, machine)
-		ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(machine))
+		ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
+		ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(nodeClaim))
 
-		machine = ExpectExists(ctx, env.Client, machine)
+		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
 
 		Expect(cloudProvider.CreateCalls).To(HaveLen(1))
 		Expect(cloudProvider.CreatedNodeClaims).To(HaveLen(1))
-		_, err := cloudProvider.Get(ctx, machine.Status.ProviderID)
+		_, err := cloudProvider.Get(ctx, nodeClaim.Status.ProviderID)
 		Expect(err).ToNot(HaveOccurred())
 	})
-	It("should add the MachineLaunched status condition after creating the Machine", func() {
-		machine := test.NodeClaim(v1beta1.NodeClaim{
+	It("should add the MachineLaunched status condition after creating the NodeClaim", func() {
+		nodeClaim := test.NodeClaim(v1beta1.NodeClaim{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
 					v1alpha5.ProvisionerNameLabelKey: nodePool.Name,
 				},
 			},
 		})
-		ExpectApplied(ctx, env.Client, nodePool, machine)
-		ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(machine))
+		ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
+		ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(nodeClaim))
 
-		machine = ExpectExists(ctx, env.Client, machine)
-		Expect(ExpectStatusConditionExists(machine, v1beta1.Launched).Status).To(Equal(v1.ConditionTrue))
+		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Launched).Status).To(Equal(v1.ConditionTrue))
 	})
 	It("should delete the machine if InsufficientCapacity is returned from the cloudprovider", func() {
 		cloudProvider.NextCreateErr = cloudprovider.NewInsufficientCapacityError(fmt.Errorf("all instance types were unavailable"))
-		machine := test.NodeClaim()
-		ExpectApplied(ctx, env.Client, machine)
-		ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(machine))
-		ExpectFinalizersRemoved(ctx, env.Client, machine)
-		ExpectNotFound(ctx, env.Client, machine)
+		nodeClaim := test.NodeClaim()
+		ExpectApplied(ctx, env.Client, nodeClaim)
+		ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(nodeClaim))
+		ExpectFinalizersRemoved(ctx, env.Client, nodeClaim)
+		ExpectNotFound(ctx, env.Client, nodeClaim)
+	})
+	It("should requeue with no error if NodeClassNotReady is returned from the cloudprovider", func() {
+		cloudProvider.NextCreateErr = cloudprovider.NewNodeClassNotReadyError(fmt.Errorf("nodeClass isn't ready"))
+		nodeClaim := test.NodeClaim()
+		ExpectApplied(ctx, env.Client, nodeClaim)
+		res := ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(nodeClaim))
+		Expect(res.Requeue).To(BeTrue())
+
+		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
+		Expect(ExpectStatusConditionExists(nodeClaim, v1beta1.Launched).Status).To(Equal(v1.ConditionFalse))
 	})
 })


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

- Creates a `NodeClassNotReadyError` into the `NodeClaim` launch for handling cases where you want to declare that the launch should wait due to `NodeClass` readiness. The thinking is that this _may_ turn into a `statusCondition` on the `NodeClass` down the line.

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
