### PR TITLE
fix getDaemonSet to preserve pod affinity in daemonset template pod spec.

### DIFF
--- a/pkg/controllers/provisioning/nodepool_test.go
+++ b/pkg/controllers/provisioning/nodepool_test.go
@@ -553,6 +553,85 @@ var _ = Describe("Provisioning", func() {
 			Expect(*allocatable.Cpu()).To(Equal(resource.MustParse("4")))
 			Expect(*allocatable.Memory()).To(Equal(resource.MustParse("4Gi")))
 		})
+		It("should account for daemonset spec affinity", func() {
+			nodePool := test.NodePool(v1beta1.NodePool{
+				Spec: v1beta1.NodePoolSpec{
+					Template: v1beta1.NodeClaimTemplate{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								"foo": "voo",
+							},
+						},
+					},
+					Limits: v1beta1.Limits(v1.ResourceList{
+						v1.ResourceCPU: resource.MustParse("2"),
+					}),
+				},
+			})
+			nodePoolDaemonset := test.NodePool(v1beta1.NodePool{
+				Spec: v1beta1.NodePoolSpec{
+					Template: v1beta1.NodeClaimTemplate{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								"foo": "bar",
+							},
+						},
+					},
+				},
+			})
+			// Create a daemonset with large resource requests
+			daemonset := test.DaemonSet(
+				test.DaemonSetOptions{PodOptions: test.PodOptions{
+					NodeRequirements: []v1.NodeSelectorRequirement{
+						{
+							Key:      "foo",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"bar"},
+						},
+					},
+					ResourceRequirements: v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("4"), v1.ResourceMemory: resource.MustParse("4Gi")}},
+				}},
+			)
+			ExpectApplied(ctx, env.Client, nodePoolDaemonset, daemonset)
+			// Create the actual daemonSet pod with lower resource requests and expect to use the pod
+			daemonsetPod := test.UnschedulablePod(
+				test.PodOptions{
+					ObjectMeta: metav1.ObjectMeta{
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion:         "apps/v1",
+								Kind:               "DaemonSet",
+								Name:               daemonset.Name,
+								UID:                daemonset.UID,
+								Controller:         ptr.Bool(true),
+								BlockOwnerDeletion: ptr.Bool(true),
+							},
+						},
+					},
+					NodeRequirements: []v1.NodeSelectorRequirement{
+						{
+							Key:      metav1.ObjectNameField,
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"node-name"},
+						},
+					},
+					ResourceRequirements: v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("4"), v1.ResourceMemory: resource.MustParse("4Gi")}},
+				})
+			ExpectApplied(ctx, env.Client, daemonsetPod)
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, daemonsetPod)
+			ExpectReconcileSucceeded(ctx, daemonsetController, client.ObjectKeyFromObject(daemonset))
+
+			//Deploy pod
+			pod := test.UnschedulablePod(test.PodOptions{
+				ResourceRequirements: v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1"), v1.ResourceMemory: resource.MustParse("1Gi")}},
+				NodeSelector: map[string]string{
+					"foo": "voo",
+				},
+			})
+			ExpectApplied(ctx, env.Client, nodePool, pod)
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+			ExpectScheduled(ctx, env.Client, pod)
+		})
 	})
 	Context("Annotations", func() {
 		It("should annotate nodes", func() {

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -416,17 +416,15 @@ func (p *Provisioner) getDaemonSetPods(ctx context.Context) ([]*v1.Pod, error) {
 		pod := p.cluster.GetDaemonSetPod(&d)
 		if pod == nil {
 			pod = &v1.Pod{Spec: d.Spec.Template.Spec}
-		} else if pod.Spec.Affinity != nil && pod.Spec.Affinity.NodeAffinity != nil &&
-			d.Spec.Template.Spec.Affinity != nil &&
-			d.Spec.Template.Spec.Affinity.NodeAffinity != nil &&
-			d.Spec.Template.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution != nil {
-
-			nodeAffinity := pod.Spec.Affinity.NodeAffinity
-			if nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution != nil {
-				nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = d.Spec.Template.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms
-			} else {
-				nodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = d.Spec.Template.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
+		}
+		if d.Spec.Template.Spec.Affinity != nil && d.Spec.Template.Spec.Affinity.NodeAffinity != nil && d.Spec.Template.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution != nil {
+			if pod.Spec.Affinity == nil {
+				pod.Spec.Affinity = &v1.Affinity{}
 			}
+			if pod.Spec.Affinity.NodeAffinity == nil {
+				pod.Spec.Affinity.NodeAffinity = &v1.NodeAffinity{}
+			}
+			pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = d.Spec.Template.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution
 		}
 		return pod
 	}), nil

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -417,6 +417,9 @@ func (p *Provisioner) getDaemonSetPods(ctx context.Context) ([]*v1.Pod, error) {
 		if pod == nil {
 			pod = &v1.Pod{Spec: d.Spec.Template.Spec}
 		}
+		// Replacing retrieved pod affinity with daemonset pod template required node affinity since this is overridden
+		// by the daemonset controller during pod creation
+		// https://github.com/kubernetes/kubernetes/blob/c5cf0ac1889f55ab51749798bec684aed876709d/pkg/controller/daemon/util/daemonset_util.go#L176
 		if d.Spec.Template.Spec.Affinity != nil && d.Spec.Template.Spec.Affinity.NodeAffinity != nil && d.Spec.Template.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution != nil {
 			if pod.Spec.Affinity == nil {
 				pod.Spec.Affinity = &v1.Affinity{}

--- a/pkg/controllers/provisioning/provisioner_test.go
+++ b/pkg/controllers/provisioning/provisioner_test.go
@@ -536,10 +536,7 @@ var _ = Describe("Provisioning", func() {
 			Expect(*allocatable.Cpu()).To(Equal(resource.MustParse("4")))
 			Expect(*allocatable.Memory()).To(Equal(resource.MustParse("4Gi")))
 		})
-		It("should account for daemonset spec affinity ", func() {
-			ExpectCleanedUp(ctx, env.Client)
-			cluster.Reset()
-
+		It("should account for daemonset spec affinity", func() {
 			provisioner := test.Provisioner(test.ProvisionerOptions{
 				Labels: map[string]string{
 					"foo": "voo",

--- a/pkg/controllers/provisioning/provisioner_test.go
+++ b/pkg/controllers/provisioning/provisioner_test.go
@@ -17,6 +17,7 @@ package provisioning_test
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"

--- a/pkg/controllers/provisioning/provisioner_test.go
+++ b/pkg/controllers/provisioning/provisioner_test.go
@@ -584,6 +584,13 @@ var _ = Describe("Provisioning", func() {
 							},
 						},
 					},
+					NodeRequirements: []v1.NodeSelectorRequirement{
+						{
+							Key:      metav1.ObjectNameField,
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"node-name"},
+						},
+					},
 					ResourceRequirements: v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("4"), v1.ResourceMemory: resource.MustParse("4Gi")}},
 				})
 			ExpectApplied(ctx, env.Client, daemonsetPod)


### PR DESCRIPTION
Fixes #532  <!-- issue number -->

**Description**
Change getDaemonSetPods method to merge in daemon set template pod spec affinities with existing pod affinities to retain this information during scheduling. This would allow scheduler to not include daemonsets that would not be scheduled on a provisioner within their calculations of daemonset overhead

**How was this change tested?**
Unit tests included in the PR

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
