### PR TITLE
chore: Drop short names for NodeClaims and NodePools

### DIFF
--- a/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
@@ -13,9 +13,6 @@ spec:
     kind: NodeClaim
     listKind: NodeClaimList
     plural: nodeclaims
-    shortNames:
-    - nc
-    - ncs
     singular: nodeclaim
   scope: Cluster
   versions:

--- a/pkg/apis/crds/karpenter.sh_nodepools.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodepools.yaml
@@ -13,9 +13,6 @@ spec:
     kind: NodePool
     listKind: NodePoolList
     plural: nodepools
-    shortNames:
-    - np
-    - nps
     singular: nodepool
   scope: Cluster
   versions:
@@ -30,7 +27,7 @@ spec:
     name: v1beta1
     schema:
       openAPIV3Schema:
-        description: NodePool is the Schema for the Provisioners API
+        description: NodePool is the Schema for the NodePools API
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation

--- a/pkg/apis/v1beta1/nodeclaim.go
+++ b/pkg/apis/v1beta1/nodeclaim.go
@@ -140,7 +140,7 @@ type Provider = runtime.RawExtension
 
 // NodeClaim is the Schema for the NodeClaims API
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:path=nodeclaims,scope=Cluster,categories=karpenter,shortName={nc,ncs}
+// +kubebuilder:resource:path=nodeclaims,scope=Cluster,categories=karpenter
 // +kubebuilder:subresource:status
 // +kubebuilder:storageversion
 // +kubebuilder:printcolumn:name="Type",type="string",JSONPath=".metadata.labels.node\\.kubernetes\\.io/instance-type",description=""

--- a/pkg/apis/v1beta1/nodepool.go
+++ b/pkg/apis/v1beta1/nodepool.go
@@ -106,9 +106,9 @@ type NodeClaimTemplate struct {
 	Spec              NodeClaimSpec `json:"spec,omitempty"`
 }
 
-// NodePool is the Schema for the Provisioners API
+// NodePool is the Schema for the NodePools API
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:path=nodepools,scope=Cluster,categories=karpenter,shortName={np,nps}
+// +kubebuilder:resource:path=nodepools,scope=Cluster,categories=karpenter
 // +kubebuilder:printcolumn:name="NodeClass",type="string",JSONPath=".spec.template.spec.nodeClass.name",description=""
 // +kubebuilder:printcolumn:name="Weight",type="string",JSONPath=".spec.weight",priority=1,description=""
 // +kubebuilder:subresource:status


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change drops the shortnames for `v1beta1/NodeClaims` and `v1beta1/NodePools`. These were dropped since these would have to be supported long-term and they had some potential to conflict with other shortnames from other K8s resources.

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
