### PR TITLE
chore: Add `v1beta1/NodePool` drifted reason

### DIFF
--- a/pkg/controllers/nodeclaim/disruption/drift.go
+++ b/pkg/controllers/nodeclaim/disruption/drift.go
@@ -37,6 +37,7 @@ import (
 
 const (
 	ProvisionerDrifted  cloudprovider.DriftReason = "ProvisionerDrifted"
+	NodePoolDrifted     cloudprovider.DriftReason = "NodePoolDrifted"
 	RequirementsDrifted cloudprovider.DriftReason = "RequirementsDrifted"
 )
 
@@ -123,7 +124,10 @@ func areStaticFieldsDrifted(nodePool *v1beta1.NodePool, nodeClaim *v1beta1.NodeC
 		return ""
 	}
 	if nodePoolHash != nodeClaimHash {
-		return ProvisionerDrifted
+		if nodeClaim.IsMachine {
+			return ProvisionerDrifted
+		}
+		return NodePoolDrifted
 	}
 	return ""
 }

--- a/pkg/controllers/nodeclaim/disruption/nodeclaim_drift_test.go
+++ b/pkg/controllers/nodeclaim/disruption/nodeclaim_drift_test.go
@@ -74,7 +74,7 @@ var _ = Describe("NodeClaim/Drift", func() {
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)
 		Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Drifted).IsTrue()).To(BeTrue())
-		Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Drifted).Reason).To(Equal(string(disruption.ProvisionerDrifted)))
+		Expect(nodeClaim.StatusConditions().GetCondition(v1beta1.Drifted).Reason).To(Equal(string(disruption.NodePoolDrifted)))
 	})
 	It("should detect node requirement drift before cloud provider drift", func() {
 		cp.Drifted = "drifted"


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change adds `NodePoolDrifted` as one of the `Drifted` reasons within the `v1beta1/NodeClaim` API

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
