### PR TITLE
chore: karpenter-global-settings migration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	k8s.io/apimachinery v0.26.6
 	k8s.io/client-go v0.26.6
 	k8s.io/cloud-provider v0.26.6
+	k8s.io/component-base v0.26.6
 	k8s.io/csi-translation-lib v0.26.6
 	k8s.io/klog/v2 v2.100.1
 	k8s.io/utils v0.0.0-20230209194617-a36077c30491
@@ -62,6 +63,7 @@ require (
 	github.com/google/uuid v1.3.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.11.3 // indirect
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
+	github.com/inconshreveable/mousetrap v1.0.1 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kelseyhightower/envconfig v1.4.0 // indirect
@@ -74,6 +76,7 @@ require (
 	github.com/prometheus/common v0.44.0 // indirect
 	github.com/prometheus/procfs v0.11.1 // indirect
 	github.com/prometheus/statsd_exporter v0.21.0 // indirect
+	github.com/spf13/cobra v1.6.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.uber.org/atomic v1.9.0 // indirect
@@ -93,7 +96,6 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/component-base v0.26.6 // indirect
 	k8s.io/kube-openapi v0.0.0-20230501164219-8b0f38b5fd1f // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -67,6 +67,7 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
+github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -200,6 +201,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/imdario/mergo v0.3.16 h1:wwQJbIsHYGMUyLSPrEq1CT16AhnhNJQ51+4fdHUnCl4=
 github.com/imdario/mergo v0.3.16/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=
+github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
+github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
@@ -289,11 +292,14 @@ github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6L
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
 github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/samber/lo v1.38.1 h1:j2XEAqXKb09Am4ebOg31SpvzUTTs6EN3VfgeLUhPdXM=
 github.com/samber/lo v1.38.1/go.mod h1:+m/ZKRl6ClXCE2Lgf3MsQlWfh4bn1bz6CXEOxnEXnEA=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
+github.com/spf13/cobra v1.6.0 h1:42a0n6jwCot1pUmomAp4T7DeMD+20LFv4Q54pxLf2LI=
+github.com/spf13/cobra v1.6.0/go.mod h1:IOw/AERYS7UzyrGinqmz6HLUo219MORXGxhbaJUqzrY=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=

--- a/pkg/apis/settings/settings.go
+++ b/pkg/apis/settings/settings.go
@@ -30,7 +30,7 @@ var ContextKey = settingsKeyType{}
 
 var defaultSettings = &Settings{
 	BatchMaxDuration:  time.Second * 10,
-	BatchIdleDuration: time.Second * 1,
+	BatchIdleDuration: time.Second,
 	DriftEnabled:      false,
 }
 
@@ -49,7 +49,6 @@ func (*Settings) ConfigMap() string {
 // Inject creates a Settings from the supplied ConfigMap
 func (*Settings) Inject(ctx context.Context, cm *v1.ConfigMap) (context.Context, error) {
 	s := defaultSettings.DeepCopy()
-
 	if err := configmap.Parse(cm.Data,
 		configmap.AsDuration("batchMaxDuration", &s.BatchMaxDuration),
 		configmap.AsDuration("batchIdleDuration", &s.BatchIdleDuration),
@@ -80,8 +79,7 @@ func ToContext(ctx context.Context, s *Settings) context.Context {
 func FromContext(ctx context.Context) *Settings {
 	data := ctx.Value(ContextKey)
 	if data == nil {
-		// This is developer error if this happens, so we should panic
-		panic("settings doesn't exist in context")
+		return nil
 	}
 	return data.(*Settings)
 }

--- a/pkg/controllers/deprovisioning/drift.go
+++ b/pkg/controllers/deprovisioning/drift.go
@@ -25,13 +25,13 @@ import (
 
 	"github.com/samber/lo"
 
-	"github.com/aws/karpenter-core/pkg/apis/settings"
 	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
 	deprovisioningevents "github.com/aws/karpenter-core/pkg/controllers/deprovisioning/events"
 	"github.com/aws/karpenter-core/pkg/controllers/provisioning"
 	"github.com/aws/karpenter-core/pkg/controllers/state"
 	"github.com/aws/karpenter-core/pkg/events"
 	"github.com/aws/karpenter-core/pkg/metrics"
+	"github.com/aws/karpenter-core/pkg/operator/options"
 )
 
 // Drift is a subreconciler that deletes drifted candidates.
@@ -53,7 +53,7 @@ func NewDrift(kubeClient client.Client, cluster *state.Cluster, provisioner *pro
 
 // ShouldDeprovision is a predicate used to filter deprovisionable candidates
 func (d *Drift) ShouldDeprovision(ctx context.Context, c *Candidate) bool {
-	return settings.FromContext(ctx).DriftEnabled &&
+	return options.FromContext(ctx).FeatureGates.Drift &&
 		c.NodeClaim.StatusConditions().GetCondition(v1beta1.Drifted).IsTrue()
 }
 

--- a/pkg/controllers/deprovisioning/machine_drift_test.go
+++ b/pkg/controllers/deprovisioning/machine_drift_test.go
@@ -29,11 +29,11 @@ import (
 	"knative.dev/pkg/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/aws/karpenter-core/pkg/apis/settings"
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
 	"github.com/aws/karpenter-core/pkg/cloudprovider/fake"
+	"github.com/aws/karpenter-core/pkg/operator/options"
 	"github.com/aws/karpenter-core/pkg/test"
 	. "github.com/aws/karpenter-core/pkg/test/expectations"
 )
@@ -65,7 +65,7 @@ var _ = Describe("Machine/Drift", func() {
 		machine.StatusConditions().MarkTrue(v1alpha5.MachineDrifted)
 	})
 	It("should ignore drifted nodes if the feature flag is disabled", func() {
-		ctx = settings.ToContext(ctx, test.Settings(settings.Settings{DriftEnabled: false}))
+		ctx = options.ToContext(ctx, test.Options(test.OptionsFields{FeatureGates: test.FeatureGates{Drift: lo.ToPtr(false)}}))
 		ExpectApplied(ctx, env.Client, machine, node, provisioner)
 
 		// inform cluster state about nodes and machines

--- a/pkg/controllers/deprovisioning/nodeclaim_drift_test.go
+++ b/pkg/controllers/deprovisioning/nodeclaim_drift_test.go
@@ -29,11 +29,11 @@ import (
 	"knative.dev/pkg/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/aws/karpenter-core/pkg/apis/settings"
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
 	"github.com/aws/karpenter-core/pkg/cloudprovider/fake"
+	"github.com/aws/karpenter-core/pkg/operator/options"
 	"github.com/aws/karpenter-core/pkg/test"
 	. "github.com/aws/karpenter-core/pkg/test/expectations"
 )
@@ -72,7 +72,7 @@ var _ = Describe("NodeClaim/Drift", func() {
 		nodeClaim.StatusConditions().MarkTrue(v1beta1.Drifted)
 	})
 	It("should ignore drifted nodes if the feature flag is disabled", func() {
-		ctx = settings.ToContext(ctx, test.Settings(settings.Settings{DriftEnabled: false}))
+		ctx = options.ToContext(ctx, test.Options(test.OptionsFields{FeatureGates: test.FeatureGates{Drift: lo.ToPtr(false)}}))
 		ExpectApplied(ctx, env.Client, nodeClaim, node, nodePool)
 
 		// inform cluster state about nodes and nodeclaims

--- a/pkg/controllers/deprovisioning/suite_test.go
+++ b/pkg/controllers/deprovisioning/suite_test.go
@@ -37,7 +37,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aws/karpenter-core/pkg/apis"
-	"github.com/aws/karpenter-core/pkg/apis/settings"
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
@@ -47,6 +46,7 @@ import (
 	"github.com/aws/karpenter-core/pkg/controllers/state"
 	"github.com/aws/karpenter-core/pkg/controllers/state/informer"
 	"github.com/aws/karpenter-core/pkg/operator/controller"
+	"github.com/aws/karpenter-core/pkg/operator/options"
 	"github.com/aws/karpenter-core/pkg/operator/scheme"
 	"github.com/aws/karpenter-core/pkg/scheduling"
 	"github.com/aws/karpenter-core/pkg/test"
@@ -77,7 +77,7 @@ func TestAPIs(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	env = test.NewEnvironment(scheme.Scheme, test.WithCRDs(apis.CRDs...))
-	ctx = settings.ToContext(ctx, test.Settings(settings.Settings{DriftEnabled: true}))
+	ctx = options.ToContext(ctx, test.Options(test.OptionsFields{FeatureGates: test.FeatureGates{Drift: lo.ToPtr(true)}}))
 	cloudProvider = fake.NewCloudProvider()
 	fakeClock = clock.NewFakeClock(time.Now())
 	cluster = state.NewCluster(fakeClock, env.Client, cloudProvider)
@@ -108,7 +108,7 @@ var _ = BeforeEach(func() {
 	cluster.MarkUnconsolidated()
 
 	// Reset Feature Flags to test defaults
-	ctx = settings.ToContext(ctx, test.Settings(settings.Settings{DriftEnabled: true}))
+	ctx = options.ToContext(ctx, test.Options(test.OptionsFields{FeatureGates: test.FeatureGates{Drift: lo.ToPtr(true)}}))
 
 	onDemandInstances = lo.Filter(cloudProvider.InstanceTypes, func(i *cloudprovider.InstanceType, _ int) bool {
 		for _, o := range i.Offerings.Available() {

--- a/pkg/controllers/leasegarbagecollection/suite_test.go
+++ b/pkg/controllers/leasegarbagecollection/suite_test.go
@@ -26,9 +26,9 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/aws/karpenter-core/pkg/apis"
-	"github.com/aws/karpenter-core/pkg/apis/settings"
 	"github.com/aws/karpenter-core/pkg/controllers/leasegarbagecollection"
 	"github.com/aws/karpenter-core/pkg/operator/controller"
+	"github.com/aws/karpenter-core/pkg/operator/options"
 	"github.com/aws/karpenter-core/pkg/operator/scheme"
 	"github.com/aws/karpenter-core/pkg/test"
 
@@ -51,7 +51,7 @@ func TestAPIs(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	env = test.NewEnvironment(scheme.Scheme, test.WithCRDs(apis.CRDs...))
-	ctx = settings.ToContext(ctx, test.Settings())
+	ctx = options.ToContext(ctx, test.Options())
 
 	garbageCollectionController = leasegarbagecollection.NewController(env.Client)
 })

--- a/pkg/controllers/metrics/node/suite_test.go
+++ b/pkg/controllers/metrics/node/suite_test.go
@@ -28,11 +28,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aws/karpenter-core/pkg/apis"
-	"github.com/aws/karpenter-core/pkg/apis/settings"
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/controllers/metrics/node"
 	"github.com/aws/karpenter-core/pkg/controllers/state/informer"
 	"github.com/aws/karpenter-core/pkg/operator/controller"
+	"github.com/aws/karpenter-core/pkg/operator/options"
 	"github.com/aws/karpenter-core/pkg/operator/scheme"
 
 	"github.com/aws/karpenter-core/pkg/cloudprovider/fake"
@@ -64,7 +64,7 @@ func TestAPIs(t *testing.T) {
 var _ = BeforeSuite(func() {
 	env = test.NewEnvironment(scheme.Scheme, test.WithCRDs(apis.CRDs...))
 
-	ctx = settings.ToContext(ctx, test.Settings())
+	ctx = options.ToContext(ctx, test.Options())
 	cloudProvider = fake.NewCloudProvider()
 	cloudProvider.InstanceTypes = fake.InstanceTypesAssorted()
 	fakeClock = clock.NewFakeClock(time.Now())

--- a/pkg/controllers/nodeclaim/consistency/suite_test.go
+++ b/pkg/controllers/nodeclaim/consistency/suite_test.go
@@ -31,9 +31,9 @@ import (
 	. "github.com/aws/karpenter-core/pkg/test/expectations"
 
 	"github.com/aws/karpenter-core/pkg/apis"
-	"github.com/aws/karpenter-core/pkg/apis/settings"
 	"github.com/aws/karpenter-core/pkg/cloudprovider/fake"
 	"github.com/aws/karpenter-core/pkg/operator/controller"
+	"github.com/aws/karpenter-core/pkg/operator/options"
 	"github.com/aws/karpenter-core/pkg/operator/scheme"
 	"github.com/aws/karpenter-core/pkg/test"
 )
@@ -59,7 +59,7 @@ var _ = BeforeSuite(func() {
 			return []string{obj.(*v1.Node).Spec.ProviderID}
 		})
 	}))
-	ctx = settings.ToContext(ctx, test.Settings())
+	ctx = options.ToContext(ctx, test.Options())
 	cp = &fake.CloudProvider{}
 	recorder = test.NewEventRecorder()
 	machineConsistencyController = consistency.NewMachineController(fakeClock, env.Client, recorder, cp)

--- a/pkg/controllers/nodeclaim/disruption/drift.go
+++ b/pkg/controllers/nodeclaim/disruption/drift.go
@@ -26,11 +26,11 @@ import (
 
 	"github.com/samber/lo"
 
-	"github.com/aws/karpenter-core/pkg/apis/settings"
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
 	"github.com/aws/karpenter-core/pkg/metrics"
+	"github.com/aws/karpenter-core/pkg/operator/options"
 	"github.com/aws/karpenter-core/pkg/scheduling"
 	nodeclaimutil "github.com/aws/karpenter-core/pkg/utils/nodeclaim"
 )
@@ -51,7 +51,7 @@ func (d *Drift) Reconcile(ctx context.Context, nodePool *v1beta1.NodePool, nodeC
 
 	// From here there are three scenarios to handle:
 	// 1. If drift is not enabled but the NodeClaim is drifted, remove the status condition
-	if !settings.FromContext(ctx).DriftEnabled {
+	if !options.FromContext(ctx).FeatureGates.Drift {
 		_ = nodeClaim.StatusConditions().ClearCondition(v1beta1.Drifted)
 		if hasDriftedCondition {
 			logging.FromContext(ctx).Debugf("removing drift status condition, drift has been disabled")

--- a/pkg/controllers/nodeclaim/disruption/machine_drift_test.go
+++ b/pkg/controllers/nodeclaim/disruption/machine_drift_test.go
@@ -24,11 +24,11 @@ import (
 	"github.com/aws/karpenter-core/pkg/controllers/nodeclaim/disruption"
 	controllerprov "github.com/aws/karpenter-core/pkg/controllers/nodepool/hash"
 	"github.com/aws/karpenter-core/pkg/operator/controller"
+	"github.com/aws/karpenter-core/pkg/operator/options"
 	. "github.com/aws/karpenter-core/pkg/test/expectations"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/aws/karpenter-core/pkg/apis/settings"
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/test"
 
@@ -93,7 +93,7 @@ var _ = Describe("Machine/Drift", func() {
 	})
 	It("should not detect drift if the feature flag is disabled", func() {
 		cp.Drifted = "drifted"
-		ctx = settings.ToContext(ctx, test.Settings(settings.Settings{DriftEnabled: false}))
+		ctx = options.ToContext(ctx, test.Options(test.OptionsFields{FeatureGates: test.FeatureGates{Drift: lo.ToPtr(false)}}))
 		ExpectApplied(ctx, env.Client, provisioner, machine)
 		ExpectReconcileSucceeded(ctx, machineDisruptionController, client.ObjectKeyFromObject(machine))
 
@@ -102,7 +102,7 @@ var _ = Describe("Machine/Drift", func() {
 	})
 	It("should remove the status condition from the machine if the feature flag is disabled", func() {
 		cp.Drifted = "drifted"
-		ctx = settings.ToContext(ctx, test.Settings(settings.Settings{DriftEnabled: false}))
+		ctx = options.ToContext(ctx, test.Options(test.OptionsFields{FeatureGates: test.FeatureGates{Drift: lo.ToPtr(false)}}))
 		machine.StatusConditions().MarkTrue(v1alpha5.MachineDrifted)
 		ExpectApplied(ctx, env.Client, provisioner, machine)
 

--- a/pkg/controllers/nodeclaim/disruption/machine_test.go
+++ b/pkg/controllers/nodeclaim/disruption/machine_test.go
@@ -25,8 +25,8 @@ import (
 	"knative.dev/pkg/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/aws/karpenter-core/pkg/apis/settings"
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
+	"github.com/aws/karpenter-core/pkg/operator/options"
 	. "github.com/aws/karpenter-core/pkg/test/expectations"
 
 	"github.com/aws/karpenter-core/pkg/test"
@@ -73,7 +73,7 @@ var _ = Describe("Machine/Disruption", func() {
 		ExpectMakeMachinesInitialized(ctx, env.Client, machine)
 
 		// Drift, Expiration, and Emptiness are disabled through configuration
-		ctx = settings.ToContext(ctx, test.Settings(settings.Settings{DriftEnabled: false}))
+		ctx = options.ToContext(ctx, test.Options(test.OptionsFields{FeatureGates: test.FeatureGates{Drift: lo.ToPtr(false)}}))
 		ExpectReconcileSucceeded(ctx, machineDisruptionController, client.ObjectKeyFromObject(machine))
 
 		machine = ExpectExists(ctx, env.Client, machine)

--- a/pkg/controllers/nodeclaim/disruption/nodeclaim_drift_test.go
+++ b/pkg/controllers/nodeclaim/disruption/nodeclaim_drift_test.go
@@ -25,11 +25,11 @@ import (
 	"github.com/aws/karpenter-core/pkg/controllers/nodeclaim/disruption"
 	controllerprov "github.com/aws/karpenter-core/pkg/controllers/nodepool/hash"
 	"github.com/aws/karpenter-core/pkg/operator/controller"
+	"github.com/aws/karpenter-core/pkg/operator/options"
 	. "github.com/aws/karpenter-core/pkg/test/expectations"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/aws/karpenter-core/pkg/apis/settings"
 	"github.com/aws/karpenter-core/pkg/test"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -93,7 +93,7 @@ var _ = Describe("NodeClaim/Drift", func() {
 	})
 	It("should not detect drift if the feature flag is disabled", func() {
 		cp.Drifted = "drifted"
-		ctx = settings.ToContext(ctx, test.Settings(settings.Settings{DriftEnabled: false}))
+		ctx = options.ToContext(ctx, test.Options(test.OptionsFields{FeatureGates: test.FeatureGates{Drift: lo.ToPtr(false)}}))
 		ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
 		ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 
@@ -102,7 +102,7 @@ var _ = Describe("NodeClaim/Drift", func() {
 	})
 	It("should remove the status condition from the nodeClaim if the feature flag is disabled", func() {
 		cp.Drifted = "drifted"
-		ctx = settings.ToContext(ctx, test.Settings(settings.Settings{DriftEnabled: false}))
+		ctx = options.ToContext(ctx, test.Options(test.OptionsFields{FeatureGates: test.FeatureGates{Drift: lo.ToPtr(false)}}))
 		nodeClaim.StatusConditions().MarkTrue(v1beta1.Drifted)
 		ExpectApplied(ctx, env.Client, nodePool, nodeClaim)
 

--- a/pkg/controllers/nodeclaim/disruption/nodeclaim_test.go
+++ b/pkg/controllers/nodeclaim/disruption/nodeclaim_test.go
@@ -24,8 +24,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/aws/karpenter-core/pkg/apis/settings"
 	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
+	"github.com/aws/karpenter-core/pkg/operator/options"
 	. "github.com/aws/karpenter-core/pkg/test/expectations"
 
 	"github.com/aws/karpenter-core/pkg/test"
@@ -73,7 +73,7 @@ var _ = Describe("NodeClaim/Disruption", func() {
 		ExpectMakeNodeClaimsInitialized(ctx, env.Client, nodeClaim)
 
 		// Drift, Expiration, and Emptiness are disabled through configuration
-		ctx = settings.ToContext(ctx, test.Settings(settings.Settings{DriftEnabled: false}))
+		ctx = options.ToContext(ctx, test.Options(test.OptionsFields{FeatureGates: test.FeatureGates{Drift: lo.ToPtr(false)}}))
 		ExpectReconcileSucceeded(ctx, nodeClaimDisruptionController, client.ObjectKeyFromObject(nodeClaim))
 
 		nodeClaim = ExpectExists(ctx, env.Client, nodeClaim)

--- a/pkg/controllers/nodeclaim/disruption/suite_test.go
+++ b/pkg/controllers/nodeclaim/disruption/suite_test.go
@@ -21,6 +21,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 	clock "k8s.io/utils/clock/testing"
 	. "knative.dev/pkg/logging/testing"
@@ -28,11 +29,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aws/karpenter-core/pkg/apis"
-	"github.com/aws/karpenter-core/pkg/apis/settings"
 	"github.com/aws/karpenter-core/pkg/cloudprovider/fake"
 	nodeclaimdisruption "github.com/aws/karpenter-core/pkg/controllers/nodeclaim/disruption"
 	"github.com/aws/karpenter-core/pkg/controllers/state"
 	"github.com/aws/karpenter-core/pkg/operator/controller"
+	"github.com/aws/karpenter-core/pkg/operator/options"
 	"github.com/aws/karpenter-core/pkg/operator/scheme"
 	. "github.com/aws/karpenter-core/pkg/test/expectations"
 
@@ -60,7 +61,7 @@ var _ = BeforeSuite(func() {
 			return []string{obj.(*v1.Node).Spec.ProviderID}
 		})
 	}))
-	ctx = settings.ToContext(ctx, test.Settings())
+	ctx = options.ToContext(ctx, test.Options())
 	cp = fake.NewCloudProvider()
 	cluster = state.NewCluster(fakeClock, env.Client, cp)
 	machineDisruptionController = nodeclaimdisruption.NewMachineController(fakeClock, env.Client, cluster, cp)
@@ -72,7 +73,7 @@ var _ = AfterSuite(func() {
 })
 
 var _ = BeforeEach(func() {
-	ctx = settings.ToContext(ctx, test.Settings(settings.Settings{DriftEnabled: true}))
+	ctx = options.ToContext(ctx, test.Options(test.OptionsFields{FeatureGates: test.FeatureGates{Drift: lo.ToPtr(true)}}))
 })
 
 var _ = AfterEach(func() {

--- a/pkg/controllers/nodeclaim/garbagecollection/suite_test.go
+++ b/pkg/controllers/nodeclaim/garbagecollection/suite_test.go
@@ -31,7 +31,6 @@ import (
 	. "knative.dev/pkg/logging/testing"
 
 	"github.com/aws/karpenter-core/pkg/apis"
-	"github.com/aws/karpenter-core/pkg/apis/settings"
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-core/pkg/cloudprovider/fake"
@@ -39,6 +38,7 @@ import (
 	nodeclaimlifcycle "github.com/aws/karpenter-core/pkg/controllers/nodeclaim/lifecycle"
 	"github.com/aws/karpenter-core/pkg/events"
 	"github.com/aws/karpenter-core/pkg/operator/controller"
+	"github.com/aws/karpenter-core/pkg/operator/options"
 	"github.com/aws/karpenter-core/pkg/operator/scheme"
 	"github.com/aws/karpenter-core/pkg/test"
 	nodeclaimutil "github.com/aws/karpenter-core/pkg/utils/nodeclaim"
@@ -67,7 +67,7 @@ var _ = BeforeSuite(func() {
 			return []string{obj.(*v1.Node).Spec.ProviderID}
 		})
 	}))
-	ctx = settings.ToContext(ctx, test.Settings())
+	ctx = options.ToContext(ctx, test.Options())
 	cloudProvider = fake.NewCloudProvider()
 	garbageCollectionController = nodeclaimgarbagecollection.NewController(fakeClock, env.Client, cloudProvider)
 	machineController = nodeclaimlifcycle.NewMachineController(fakeClock, env.Client, cloudProvider, events.NewRecorder(&record.FakeRecorder{}))

--- a/pkg/controllers/nodeclaim/lifecycle/suite_test.go
+++ b/pkg/controllers/nodeclaim/lifecycle/suite_test.go
@@ -29,11 +29,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aws/karpenter-core/pkg/apis"
-	"github.com/aws/karpenter-core/pkg/apis/settings"
 	"github.com/aws/karpenter-core/pkg/cloudprovider/fake"
 	nodeclaimlifecycle "github.com/aws/karpenter-core/pkg/controllers/nodeclaim/lifecycle"
 	"github.com/aws/karpenter-core/pkg/events"
 	"github.com/aws/karpenter-core/pkg/operator/controller"
+	"github.com/aws/karpenter-core/pkg/operator/options"
 	"github.com/aws/karpenter-core/pkg/operator/scheme"
 	. "github.com/aws/karpenter-core/pkg/test/expectations"
 
@@ -60,7 +60,7 @@ var _ = BeforeSuite(func() {
 			return []string{obj.(*v1.Node).Spec.ProviderID}
 		})
 	}))
-	ctx = settings.ToContext(ctx, test.Settings())
+	ctx = options.ToContext(ctx, test.Options())
 
 	cloudProvider = fake.NewCloudProvider()
 	machineController = nodeclaimlifecycle.NewMachineController(fakeClock, env.Client, cloudProvider, events.NewRecorder(&record.FakeRecorder{}))

--- a/pkg/controllers/nodeclaim/termination/suite_test.go
+++ b/pkg/controllers/nodeclaim/termination/suite_test.go
@@ -29,12 +29,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aws/karpenter-core/pkg/apis"
-	"github.com/aws/karpenter-core/pkg/apis/settings"
 	"github.com/aws/karpenter-core/pkg/cloudprovider/fake"
 	nodeclaimlifecycle "github.com/aws/karpenter-core/pkg/controllers/nodeclaim/lifecycle"
 	nodeclaimtermination "github.com/aws/karpenter-core/pkg/controllers/nodeclaim/termination"
 	"github.com/aws/karpenter-core/pkg/events"
 	"github.com/aws/karpenter-core/pkg/operator/controller"
+	"github.com/aws/karpenter-core/pkg/operator/options"
 	"github.com/aws/karpenter-core/pkg/operator/scheme"
 	. "github.com/aws/karpenter-core/pkg/test/expectations"
 
@@ -63,7 +63,7 @@ var _ = BeforeSuite(func() {
 			return []string{obj.(*v1.Node).Spec.ProviderID}
 		})
 	}))
-	ctx = settings.ToContext(ctx, test.Settings())
+	ctx = options.ToContext(ctx, test.Options())
 	cloudProvider = fake.NewCloudProvider()
 	machineController = nodeclaimlifecycle.NewMachineController(fakeClock, env.Client, cloudProvider, events.NewRecorder(&record.FakeRecorder{}))
 	machineTerminationController = nodeclaimtermination.NewMachineController(env.Client, cloudProvider)

--- a/pkg/controllers/provisioning/batcher.go
+++ b/pkg/controllers/provisioning/batcher.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/aws/karpenter-core/pkg/apis/settings"
+	"github.com/aws/karpenter-core/pkg/operator/options"
 )
 
 // Batcher separates a stream of Trigger() calls into windowed slices. The
@@ -55,8 +55,8 @@ func (b *Batcher) Wait(ctx context.Context) bool {
 		// If no pods, bail to the outer controller framework to refresh the context
 		return false
 	}
-	timeout := time.NewTimer(settings.FromContext(ctx).BatchMaxDuration)
-	idle := time.NewTimer(settings.FromContext(ctx).BatchIdleDuration)
+	timeout := time.NewTimer(options.FromContext(ctx).BatchMaxDuration)
+	idle := time.NewTimer(options.FromContext(ctx).BatchIdleDuration)
 	for {
 		select {
 		case <-b.trigger:
@@ -64,7 +64,7 @@ func (b *Batcher) Wait(ctx context.Context) bool {
 			if !idle.Stop() {
 				<-idle.C
 			}
-			idle.Reset(settings.FromContext(ctx).BatchIdleDuration)
+			idle.Reset(options.FromContext(ctx).BatchIdleDuration)
 		case <-timeout.C:
 			return true
 		case <-idle.C:

--- a/pkg/controllers/provisioning/scheduling/suite_test.go
+++ b/pkg/controllers/provisioning/scheduling/suite_test.go
@@ -29,7 +29,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aws/karpenter-core/pkg/apis"
-	"github.com/aws/karpenter-core/pkg/apis/settings"
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
@@ -40,6 +39,7 @@ import (
 	"github.com/aws/karpenter-core/pkg/controllers/state/informer"
 	"github.com/aws/karpenter-core/pkg/events"
 	"github.com/aws/karpenter-core/pkg/operator/controller"
+	"github.com/aws/karpenter-core/pkg/operator/options"
 	"github.com/aws/karpenter-core/pkg/operator/scheme"
 	pscheduling "github.com/aws/karpenter-core/pkg/scheduling"
 	"github.com/aws/karpenter-core/pkg/test"
@@ -72,7 +72,7 @@ func TestScheduling(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	env = test.NewEnvironment(scheme.Scheme, test.WithCRDs(apis.CRDs...))
-	ctx = settings.ToContext(ctx, test.Settings())
+	ctx = options.ToContext(ctx, test.Options())
 	cloudProvider = fake.NewCloudProvider()
 	instanceTypes, _ := cloudProvider.GetInstanceTypes(ctx, nil)
 	// set these on the cloud provider, so we can manipulate them if needed

--- a/pkg/controllers/provisioning/suite_test.go
+++ b/pkg/controllers/provisioning/suite_test.go
@@ -33,7 +33,6 @@ import (
 	. "knative.dev/pkg/logging/testing"
 
 	"github.com/aws/karpenter-core/pkg/apis"
-	"github.com/aws/karpenter-core/pkg/apis/settings"
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
@@ -43,6 +42,7 @@ import (
 	"github.com/aws/karpenter-core/pkg/controllers/state/informer"
 	"github.com/aws/karpenter-core/pkg/events"
 	"github.com/aws/karpenter-core/pkg/operator/controller"
+	"github.com/aws/karpenter-core/pkg/operator/options"
 	"github.com/aws/karpenter-core/pkg/operator/scheme"
 	"github.com/aws/karpenter-core/pkg/test"
 	. "github.com/aws/karpenter-core/pkg/test/expectations"
@@ -66,7 +66,7 @@ func TestAPIs(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	env = test.NewEnvironment(scheme.Scheme, test.WithCRDs(apis.CRDs...))
-	ctx = settings.ToContext(ctx, test.Settings())
+	ctx = options.ToContext(ctx, test.Options())
 	cloudProvider = fake.NewCloudProvider()
 	fakeClock = clock.NewFakeClock(time.Now())
 	cluster = state.NewCluster(fakeClock, env.Client, cloudProvider)
@@ -81,7 +81,7 @@ var _ = BeforeSuite(func() {
 })
 
 var _ = BeforeEach(func() {
-	ctx = settings.ToContext(ctx, test.Settings())
+	ctx = options.ToContext(ctx, test.Options())
 	cloudProvider.Reset()
 })
 

--- a/pkg/controllers/state/statenode.go
+++ b/pkg/controllers/state/statenode.go
@@ -25,9 +25,9 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/aws/karpenter-core/pkg/apis/settings"
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
+	"github.com/aws/karpenter-core/pkg/operator/options"
 	"github.com/aws/karpenter-core/pkg/scheduling"
 	nodeutils "github.com/aws/karpenter-core/pkg/utils/node"
 	nodepoolutil "github.com/aws/karpenter-core/pkg/utils/nodepool"
@@ -391,7 +391,7 @@ func (in *StateNode) cleanupForPod(podKey types.NamespacedName) {
 }
 
 func nominationWindow(ctx context.Context) time.Duration {
-	nominationPeriod := 2 * settings.FromContext(ctx).BatchMaxDuration
+	nominationPeriod := 2 * options.FromContext(ctx).BatchMaxDuration
 	if nominationPeriod < 10*time.Second {
 		nominationPeriod = 10 * time.Second
 	}

--- a/pkg/controllers/state/suite_test.go
+++ b/pkg/controllers/state/suite_test.go
@@ -29,12 +29,12 @@ import (
 	"knative.dev/pkg/ptr"
 
 	"github.com/aws/karpenter-core/pkg/apis"
-	"github.com/aws/karpenter-core/pkg/apis/settings"
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-core/pkg/cloudprovider/fake"
 	"github.com/aws/karpenter-core/pkg/controllers/state/informer"
 	"github.com/aws/karpenter-core/pkg/operator/controller"
+	"github.com/aws/karpenter-core/pkg/operator/options"
 	"github.com/aws/karpenter-core/pkg/operator/scheme"
 	"github.com/aws/karpenter-core/pkg/scheduling"
 
@@ -78,7 +78,7 @@ func TestAPIs(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	env = test.NewEnvironment(scheme.Scheme, test.WithCRDs(apis.CRDs...))
-	ctx = settings.ToContext(ctx, test.Settings())
+	ctx = options.ToContext(ctx, test.Options())
 	cloudProvider = fake.NewCloudProvider()
 	fakeClock = clock.NewFakeClock(time.Now())
 	cluster = state.NewCluster(fakeClock, env.Client, cloudProvider)

--- a/pkg/controllers/termination/terminator/suite_test.go
+++ b/pkg/controllers/termination/terminator/suite_test.go
@@ -20,6 +20,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -31,7 +32,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 
 	"github.com/aws/karpenter-core/pkg/apis"
-	"github.com/aws/karpenter-core/pkg/apis/settings"
+	"github.com/aws/karpenter-core/pkg/operator/options"
 	"github.com/aws/karpenter-core/pkg/operator/scheme"
 	"github.com/aws/karpenter-core/pkg/test"
 	. "github.com/aws/karpenter-core/pkg/test/expectations"
@@ -52,7 +53,7 @@ func TestAPIs(t *testing.T) {
 
 var _ = BeforeSuite(func() {
 	env = test.NewEnvironment(scheme.Scheme, test.WithCRDs(apis.CRDs...))
-	ctx = settings.ToContext(ctx, test.Settings(settings.Settings{DriftEnabled: true}))
+	ctx = options.ToContext(ctx, test.Options(test.OptionsFields{FeatureGates: test.FeatureGates{Drift: lo.ToPtr(true)}}))
 	recorder = test.NewEventRecorder()
 	queue = terminator.NewQueue(env.KubernetesInterface.CoreV1(), recorder)
 })

--- a/pkg/operator/injection/fake/settings.go
+++ b/pkg/operator/injection/fake/settings.go
@@ -20,6 +20,8 @@ import (
 
 	v1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/configmap"
+
+	"github.com/aws/karpenter-core/pkg/apis/settings"
 )
 
 type settingsKeyType struct{}
@@ -47,6 +49,10 @@ func (*Settings) Inject(ctx context.Context, cm *v1.ConfigMap) (context.Context,
 		return ctx, fmt.Errorf("parsing config data, %w", err)
 	}
 	return ToContext(ctx, s), nil
+}
+
+func (*Settings) FromContext(ctx context.Context) settings.Injectable {
+	return FromContext(ctx)
 }
 
 func ToContext(ctx context.Context, s *Settings) context.Context {

--- a/pkg/operator/logging/logging.go
+++ b/pkg/operator/logging/logging.go
@@ -40,6 +40,7 @@ import (
 	"knative.dev/pkg/system"
 
 	"github.com/aws/karpenter-core/pkg/operator/injection"
+	"github.com/aws/karpenter-core/pkg/operator/options"
 )
 
 const (
@@ -107,7 +108,7 @@ func WithCommit(logger *zap.SugaredLogger) *zap.SugaredLogger {
 
 func defaultLogger(ctx context.Context, component string) *zap.SugaredLogger {
 	cfg := DefaultZapConfig(component)
-	if l := injection.GetOptions(ctx).LogLevel; l != "" {
+	if l := options.FromContext(ctx).LogLevel; l != "" {
 		// Webhook log level can only be configured directly through the zap-config
 		// Webhooks are deprecated, so support for changing their log level is also deprecated
 		if component != "webhook" {
@@ -135,7 +136,7 @@ func loggerFromFile(ctx context.Context, component string) *zap.SugaredLogger {
 	if raw != nil {
 		cfg.Level = lo.Must(zap.ParseAtomicLevel(string(raw)))
 	}
-	if l := injection.GetOptions(ctx).LogLevel; l != "" {
+	if l := options.FromContext(ctx).LogLevel; l != "" {
 		// Webhook log level can only be configured directly through the zap-config
 		// Webhooks are deprecated, so support for changing their log level is also deprecated
 		if component != "webhook" {
@@ -166,7 +167,7 @@ func loggerFromConfigMap(ctx context.Context, component string, kubernetesInterf
 	if v := cm.Data[fmt.Sprintf("loglevel.%s", component)]; v != "" {
 		cfg.Level = lo.Must(zap.ParseAtomicLevel(v))
 	}
-	if l := injection.GetOptions(ctx).LogLevel; l != "" {
+	if l := options.FromContext(ctx).LogLevel; l != "" {
 		// Webhook log level can only be configured directly through the zap-config
 		// Webhooks are deprecated, so support for changing their log level is also deprecated
 		if component != "webhook" {

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
+	"runtime/debug"
 	"sync"
 	"time"
 
@@ -42,6 +44,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	"github.com/aws/karpenter-core/pkg/apis"
+	"github.com/aws/karpenter-core/pkg/apis/settings"
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/events"
 	"github.com/aws/karpenter-core/pkg/operator/controller"
@@ -74,8 +77,13 @@ func NewOperator() (context.Context, *Operator) {
 	ctx = knativeinjection.WithNamespaceScope(ctx, system.Namespace())
 
 	// Options
-	opts := options.New().MustParse()
-	ctx = injection.WithOptions(ctx, *opts)
+	opts := options.New().MustParse(os.Args[1:]...)
+	ctx = options.ToContext(ctx, opts)
+
+	if opts.MemoryLimit > 0 {
+		newLimit := int64(float64(opts.MemoryLimit) * 0.9)
+		debug.SetMemoryLimit(newLimit)
+	}
 
 	// Webhook
 	ctx = webhook.WithOptions(ctx, webhook.Options{
@@ -100,6 +108,7 @@ func NewOperator() (context.Context, *Operator) {
 
 	// Inject settings from the ConfigMap(s) into the context
 	ctx = injection.WithSettingsOrDie(ctx, kubernetesInterface, apis.Settings...)
+	opts.MergeSettings(settings.FromContext(ctx))
 
 	// Manager
 	mgr, err := controllerruntime.NewManager(config, controllerruntime.Options{
@@ -114,8 +123,8 @@ func NewOperator() (context.Context, *Operator) {
 		BaseContext: func() context.Context {
 			ctx := context.Background()
 			ctx = knativelogging.WithLogger(ctx, logger)
+			ctx = options.ToContext(ctx, opts)
 			ctx = injection.WithSettingsOrDie(ctx, kubernetesInterface, apis.Settings...)
-			ctx = injection.WithOptions(ctx, *opts)
 			return ctx
 		},
 		NewCache: cache.BuilderWithOptions(cache.Options{
@@ -163,7 +172,7 @@ func (o *Operator) WithControllers(ctx context.Context, controllers ...controlle
 }
 
 func (o *Operator) WithWebhooks(ctx context.Context, ctors ...knativeinjection.ControllerConstructor) *Operator {
-	if !injection.GetOptions(ctx).DisableWebhook {
+	if !options.FromContext(ctx).DisableWebhook {
 		o.webhooks = append(o.webhooks, ctors...)
 		lo.Must0(o.Manager.AddReadyzCheck("webhooks", webhooks.HealthProbe(ctx)))
 		lo.Must0(o.Manager.AddHealthzCheck("webhooks", webhooks.HealthProbe(ctx)))
@@ -178,7 +187,7 @@ func (o *Operator) Start(ctx context.Context) {
 		defer wg.Done()
 		lo.Must0(o.Manager.Start(ctx))
 	}()
-	if injection.GetOptions(ctx).DisableWebhook {
+	if options.FromContext(ctx).DisableWebhook {
 		knativelogging.FromContext(ctx).Infof("webhook disabled")
 	} else {
 		wg.Add(1)

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -139,9 +139,9 @@ func (o *Options) MustParse(args ...string) *Options {
 
 // MergeSettings applies settings specified in the v1alpha5 configmap to options. If the value was already specified by
 // a CLI argument or environment variable, that value will be used.
-func (o *Options) MergeSettings(s *settings.Settings) {
+func (o *Options) MergeSettings(s *settings.Settings) *Options {
 	if s == nil {
-		return
+		return o
 	}
 
 	// Note: settings also has default values applied to it. If the option is specified by neither Settings nor Options,
@@ -149,6 +149,7 @@ func (o *Options) MergeSettings(s *settings.Settings) {
 	mergeField(&o.BatchMaxDuration, s.BatchMaxDuration, o.BatchMaxDurationSet)
 	mergeField(&o.BatchIdleDuration, s.BatchIdleDuration, o.BatchIdleDurationSet)
 	mergeField(&o.FeatureGates.Drift, s.DriftEnabled, o.FeatureGatesSet)
+	return o
 }
 
 func MustParseFeatureGates(gateStr string) FeatureGates {

--- a/pkg/operator/options/suite_test.go
+++ b/pkg/operator/options/suite_test.go
@@ -91,4 +91,17 @@ var _ = Describe("Options", func() {
 			Expect(opts.BatchIdleDuration).To(Equal(50 * time.Second))
 		})
 	})
+
+	Context("Validation", func() {
+		It("should parse valid log levels successfully", func() {
+			for _, lvl := range []string{"", "debug", "info", "error"} {
+				Expect(options.New().MustParse("--log-level", lvl)).ShouldNot(Panic())
+			}
+		})
+		It("should panic for invalid log levels", func() {
+			for _, lvl := range []string{"test", "dbug", "trace", "warn"} {
+				Expect(options.New().MustParse("--log-level", lvl)).Should(Panic())
+			}
+		})
+	})
 })

--- a/pkg/operator/options/suite_test.go
+++ b/pkg/operator/options/suite_test.go
@@ -29,22 +29,25 @@ import (
 
 var ctx context.Context
 
-func TestSettings(t *testing.T) {
+func TestOptions(t *testing.T) {
 	ctx = TestContextWithLogger(t)
 	RegisterFailHandler(Fail)
-	RunSpecs(t, "Settings")
+	RunSpecs(t, "Options")
 }
 
 var _ = Describe("Options", func() {
 	Context("Parse", func() {
 		It("should correctly parse feature gates", func() {
-			opts := options.New().MustParse("--feature-gates", "Drift=true")
+			opts, err := options.New().Parse("--feature-gates", "Drift=true")
+			Expect(err).To(BeNil())
 			Expect(opts.FeatureGates.Drift).To(BeTrue())
-			opts = options.New().MustParse("--feature-gates", "Drift=false")
+			opts, err = options.New().Parse("--feature-gates", "Drift=false")
+			Expect(err).To(BeNil())
 			Expect(opts.FeatureGates.Drift).To(BeFalse())
 		})
 		It("should use the correct default values", func() {
-			opts := options.New().MustParse()
+			opts, err := options.New().Parse()
+			Expect(err).To(BeNil())
 			Expect(opts.ServiceName).To(Equal(""))
 			Expect(opts.DisableWebhook).To(BeFalse())
 			Expect(opts.WebhookPort).To(Equal(8443))
@@ -71,22 +74,26 @@ var _ = Describe("Options", func() {
 		}
 
 		It("shouldn't overwrite BatchMaxDuration when specified by CLI", func() {
-			opts := options.New().MustParse("--batch-max-duration", "1s")
+			opts, err := options.New().Parse("--batch-max-duration", "1s")
+			Expect(err).To(BeNil())
 			opts.MergeSettings(settings)
 			Expect(opts.BatchMaxDuration).To(Equal(time.Second))
 		})
 		It("shouldn't overwrite BatchIdleDuration when specified by CLI", func() {
-			opts := options.New().MustParse("--batch-idle-duration", "1s")
+			opts, err := options.New().Parse("--batch-idle-duration", "1s")
+			Expect(err).To(BeNil())
 			opts.MergeSettings(settings)
 			Expect(opts.BatchIdleDuration).To(Equal(time.Second))
 		})
 		It("shouldn't overwrite FeatureGates.Drift when specified by CLI", func() {
-			opts := options.New().MustParse("--feature-gates", "Drift=false")
+			opts, err := options.New().Parse("--feature-gates", "Drift=false")
+			Expect(err).To(BeNil())
 			opts.MergeSettings(settings)
 			Expect(opts.FeatureGates.Drift).To(BeFalse())
 		})
 		It("should use values from settings when not specified", func() {
-			opts := options.New().MustParse("--batch-max-duration", "1s", "--feature-gates", "Drift=false")
+			opts, err := options.New().Parse("--batch-max-duration", "1s", "--feature-gates", "Drift=false")
+			Expect(err).To(BeNil())
 			opts.MergeSettings(settings)
 			Expect(opts.BatchIdleDuration).To(Equal(50 * time.Second))
 		})
@@ -95,12 +102,14 @@ var _ = Describe("Options", func() {
 	Context("Validation", func() {
 		It("should parse valid log levels successfully", func() {
 			for _, lvl := range []string{"", "debug", "info", "error"} {
-				Expect(options.New().MustParse("--log-level", lvl)).ShouldNot(Panic())
+				_, err := options.New().Parse("--log-level", lvl)
+				Expect(err).To(BeNil())
 			}
 		})
 		It("should panic for invalid log levels", func() {
 			for _, lvl := range []string{"test", "dbug", "trace", "warn"} {
-				Expect(options.New().MustParse("--log-level", lvl)).Should(Panic())
+				_, err := options.New().Parse("--log-level", lvl)
+				Expect(err).ToNot(BeNil())
 			}
 		})
 	})

--- a/pkg/operator/options/suite_test.go
+++ b/pkg/operator/options/suite_test.go
@@ -1,0 +1,94 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package options_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	. "knative.dev/pkg/logging/testing"
+
+	"github.com/aws/karpenter-core/pkg/apis/settings"
+	"github.com/aws/karpenter-core/pkg/operator/options"
+)
+
+var ctx context.Context
+
+func TestSettings(t *testing.T) {
+	ctx = TestContextWithLogger(t)
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Settings")
+}
+
+var _ = Describe("Options", func() {
+	Context("Parse", func() {
+		It("should correctly parse feature gates", func() {
+			opts := options.New().MustParse("--feature-gates", "Drift=true")
+			Expect(opts.FeatureGates.Drift).To(BeTrue())
+			opts = options.New().MustParse("--feature-gates", "Drift=false")
+			Expect(opts.FeatureGates.Drift).To(BeFalse())
+		})
+		It("should use the correct default values", func() {
+			opts := options.New().MustParse()
+			Expect(opts.ServiceName).To(Equal(""))
+			Expect(opts.DisableWebhook).To(BeFalse())
+			Expect(opts.WebhookPort).To(Equal(8443))
+			Expect(opts.MetricsPort).To(Equal(8000))
+			Expect(opts.WebhookMetricsPort).To(Equal(8001))
+			Expect(opts.HealthProbePort).To(Equal(8081))
+			Expect(opts.KubeClientQPS).To(Equal(200))
+			Expect(opts.KubeClientBurst).To(Equal(300))
+			Expect(opts.EnableProfiling).To(BeFalse())
+			Expect(opts.EnableLeaderElection).To(BeTrue())
+			Expect(opts.MemoryLimit).To(Equal(int64(-1)))
+			Expect(opts.LogLevel).To(Equal(""))
+			Expect(opts.BatchMaxDuration).To(Equal(10 * time.Second))
+			Expect(opts.BatchIdleDuration).To(Equal(time.Second))
+			Expect(opts.FeatureGates.Drift).To(BeFalse())
+		})
+	})
+
+	Context("Merge", func() {
+		settings := &settings.Settings{
+			BatchMaxDuration:  50 * time.Second,
+			BatchIdleDuration: 50 * time.Second,
+			DriftEnabled:      true,
+		}
+
+		It("shouldn't overwrite BatchMaxDuration when specified by CLI", func() {
+			opts := options.New().MustParse("--batch-max-duration", "1s")
+			opts.MergeSettings(settings)
+			Expect(opts.BatchMaxDuration).To(Equal(time.Second))
+		})
+		It("shouldn't overwrite BatchIdleDuration when specified by CLI", func() {
+			opts := options.New().MustParse("--batch-idle-duration", "1s")
+			opts.MergeSettings(settings)
+			Expect(opts.BatchIdleDuration).To(Equal(time.Second))
+		})
+		It("shouldn't overwrite FeatureGates.Drift when specified by CLI", func() {
+			opts := options.New().MustParse("--feature-gates", "Drift=false")
+			opts.MergeSettings(settings)
+			Expect(opts.FeatureGates.Drift).To(BeFalse())
+		})
+		It("should use values from settings when not specified", func() {
+			opts := options.New().MustParse("--batch-max-duration", "1s", "--feature-gates", "Drift=false")
+			opts.MergeSettings(settings)
+			Expect(opts.BatchIdleDuration).To(Equal(50 * time.Second))
+		})
+	})
+})

--- a/pkg/test/options.go
+++ b/pkg/test/options.go
@@ -1,0 +1,79 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/imdario/mergo"
+	"github.com/samber/lo"
+
+	"github.com/aws/karpenter-core/pkg/operator/options"
+)
+
+type OptionsFields struct {
+	// Vendor Neutral
+	ServiceName          *string
+	DisableWebhook       *bool
+	WebhookPort          *int
+	MetricsPort          *int
+	WebhookMetricsPort   *int
+	HealthProbePort      *int
+	KubeClientQPS        *int
+	KubeClientBurst      *int
+	EnableProfiling      *bool
+	EnableLeaderElection *bool
+	MemoryLimit          *int64
+	LogLevel             *string
+	BatchMaxDuration     *time.Duration
+	BatchIdleDuration    *time.Duration
+	FeatureGates         FeatureGates
+}
+
+type FeatureGates struct {
+	Drift *bool
+}
+
+func Options(overrides ...OptionsFields) *options.Options {
+	opts := OptionsFields{}
+	for _, override := range overrides {
+		if err := mergo.Merge(&opts, override, mergo.WithOverride); err != nil {
+			panic(fmt.Sprintf("Failed to merge pod options: %s", err))
+		}
+	}
+
+	return &options.Options{
+		OptionFields: options.OptionFields{
+			ServiceName:          lo.FromPtrOr(opts.ServiceName, ""),
+			DisableWebhook:       lo.FromPtrOr(opts.DisableWebhook, false),
+			WebhookPort:          lo.FromPtrOr(opts.WebhookPort, 8443),
+			MetricsPort:          lo.FromPtrOr(opts.MetricsPort, 8000),
+			WebhookMetricsPort:   lo.FromPtrOr(opts.WebhookMetricsPort, 8001),
+			HealthProbePort:      lo.FromPtrOr(opts.HealthProbePort, 8081),
+			KubeClientQPS:        lo.FromPtrOr(opts.KubeClientQPS, 200),
+			KubeClientBurst:      lo.FromPtrOr(opts.KubeClientBurst, 300),
+			EnableProfiling:      lo.FromPtrOr(opts.EnableProfiling, false),
+			EnableLeaderElection: lo.FromPtrOr(opts.EnableLeaderElection, true),
+			MemoryLimit:          lo.FromPtrOr(opts.MemoryLimit, -1),
+			LogLevel:             lo.FromPtrOr(opts.LogLevel, ""),
+			BatchMaxDuration:     lo.FromPtrOr(opts.BatchMaxDuration, 10*time.Second),
+			BatchIdleDuration:    lo.FromPtrOr(opts.BatchIdleDuration, time.Second),
+			FeatureGates: options.FeatureGates{
+				Drift: lo.FromPtrOr(opts.FeatureGates.Drift, false),
+			},
+		},
+	}
+}

--- a/pkg/utils/env/env.go
+++ b/pkg/utils/env/env.go
@@ -17,6 +17,7 @@ package env
 import (
 	"os"
 	"strconv"
+	"time"
 )
 
 // WithDefaultInt returns the int value of the supplied environment variable or, if not present,
@@ -79,6 +80,20 @@ func WithDefaultBool(key string, def bool) bool {
 		return def
 	}
 	parsedVal, err := strconv.ParseBool(val)
+	if err != nil {
+		return def
+	}
+	return parsedVal
+}
+
+// WithDefaultDuration returns the duration value of the supplied environment variable or, if not present,
+// the supplied default value.
+func WithDefaultDuration(key string, def time.Duration) time.Duration {
+	val, ok := os.LookupEnv(key)
+	if !ok {
+		return def
+	}
+	parsedVal, err := time.ParseDuration(val)
 	if err != nil {
 		return def
 	}

--- a/pkg/webhooks/webhooks.go
+++ b/pkg/webhooks/webhooks.go
@@ -42,8 +42,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
-	"github.com/aws/karpenter-core/pkg/operator/injection"
 	"github.com/aws/karpenter-core/pkg/operator/logging"
+	"github.com/aws/karpenter-core/pkg/operator/options"
 )
 
 const component = "webhook"
@@ -109,7 +109,7 @@ func Start(ctx context.Context, cfg *rest.Config, kubernetesInterface kubernetes
 			Component:      strings.ReplaceAll(component, "-", "_"),
 			ConfigMap:      lo.Must(metrics.NewObservabilityConfigFromConfigMap(nil)).GetConfigMap().Data,
 			Secrets:        sharedmain.SecretFetcher(ctx),
-			PrometheusPort: injection.GetOptions(ctx).WebhookMetricsPort,
+			PrometheusPort: options.FromContext(ctx).WebhookMetricsPort,
 		}, logger))
 		// Register webhook metrics
 		webhook.RegisterMetrics()
@@ -148,7 +148,7 @@ func HealthProbe(ctx context.Context) healthz.Checker {
 	// TODO: Add knative health check port for webhooks when health port can be configured
 	// Issue: https://github.com/knative/pkg/issues/2765
 	return func(req *http.Request) (err error) {
-		res, err := http.Get(fmt.Sprintf("http://localhost:%d", injection.GetOptions(ctx).WebhookPort))
+		res, err := http.Get(fmt.Sprintf("http://localhost:%d", options.FromContext(ctx).WebhookPort))
 		// If the webhook connection errors out, liveness/readiness should fail
 		if err != nil {
 			return err


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
This PR is the first step in removing the karpenter-global-config configuration map in favor of CLI flags and environment variables as part of v1beta1. It currently respects both values set by the cli flags / env and the configmap, but cli flags / env take precedent.

**How was this change tested?**
Manual testing with Karpenter deployment and `make test`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
