### PR TITLE
fix: don't allow a single bad provisioner to stop deprovisioning

### DIFF
--- a/pkg/controllers/deprovisioning/helpers.go
+++ b/pkg/controllers/deprovisioning/helpers.go
@@ -202,7 +202,10 @@ func buildNodePoolMap(ctx context.Context, kubeClient client.Client, cloudProvid
 
 		nodePoolInstanceTypes, err := cloudProvider.GetInstanceTypes(ctx, np)
 		if err != nil {
-			return nil, nil, fmt.Errorf("listing instance types for %s, %w", np.Name, err)
+			// don't error out on building the node pool, we just won't be able to handle any nodes that
+			// were created by it
+			logging.FromContext(ctx).Errorf("listing instance types for %s, %s", np.Name, err)
+			continue
 		}
 		if len(nodePoolInstanceTypes) == 0 {
 			continue


### PR DESCRIPTION
Fixes https://github.com/aws/karpenter/issues/4723

**Description**

If you misconfigure a provisioner (e.g. delete its node template), we
- should log and let you know (fixed earlier)
- still be able to deprovision any nodes that were not created by that provisioner


**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
