### PR TITLE
fix: Topology domains should be constrained on labels

### DIFF
--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -246,13 +246,14 @@ func (p *Provisioner) NewScheduler(ctx context.Context, pods []*v1.Pod, stateNod
 			// We need to intersect the instance type requirements with the current nodePool requirements.  This
 			// ensures that something like zones from an instance type don't expand the universe of valid domains.
 			requirements := scheduling.NewNodeSelectorRequirements(nodePool.Spec.Template.Spec.Requirements...)
+			requirements.Add(scheduling.NewLabelRequirements(nodePool.Spec.Template.Labels).Values()...)
 			requirements.Add(instanceType.Requirements.Values()...)
 
 			for key, requirement := range requirements {
-				//This code used to execute a Union between domains[key] and requirement.Values().
-				//The downside of this is that Union is immutable and takes a copy of the set it is executed upon.
-				//This resulted in a lot of memory pressure on the heap and poor performance
-				//https://github.com/aws/karpenter/issues/3565
+				// This code used to execute a Union between domains[key] and requirement.Values().
+				// The downside of this is that Union is immutable and takes a copy of the set it is executed upon.
+				// This resulted in a lot of memory pressure on the heap and poor performance
+				// https://github.com/aws/karpenter/issues/3565
 				if domains[key] == nil {
 					domains[key] = sets.New(requirement.Values()...)
 				} else {
@@ -261,7 +262,9 @@ func (p *Provisioner) NewScheduler(ctx context.Context, pods []*v1.Pod, stateNod
 			}
 		}
 
-		for key, requirement := range scheduling.NewNodeSelectorRequirements(nodePool.Spec.Template.Spec.Requirements...) {
+		requirements := scheduling.NewNodeSelectorRequirements(nodePool.Spec.Template.Spec.Requirements...)
+		requirements.Add(scheduling.NewLabelRequirements(nodePool.Spec.Template.Labels).Values()...)
+		for key, requirement := range requirements {
 			if requirement.Operator() == v1.NodeSelectorOpIn {
 				//The following is a performance optimisation, for the explanation see the comment above
 				if domains[key] == nil {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Topology Domains [currently observe the constraints of the Provisioner they are under](https://github.com/aws/karpenter-core/blob/main/pkg/controllers/provisioning/provisioner.go#L249) so that the scheduler uses as much spread as is possible within the full set of topology options that are available on the cluster and within the set of options that Provisioners offer. 

Prior to this change, we were not respecting labels for constraining the domain set. This meant that if there was a label on a NodePool that also had a topologyConstraint on a pod and you didn't have Provisioners that covered the full set of domains that were returned by the instance types, scheduling would hang. 

This change ensures that the domain values are constrained by NodePool labels as well as NodePool requirements.

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
