### PR TITLE
test: Add testing to handle Provisioner/NodePool combined provisioning

### DIFF
--- a/pkg/cloudprovider/fake/cloudprovider.go
+++ b/pkg/cloudprovider/fake/cloudprovider.go
@@ -67,8 +67,9 @@ func NewCloudProvider() *CloudProvider {
 func (c *CloudProvider) Reset() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.CreateCalls = []*v1beta1.NodeClaim{}
+	c.CreateCalls = nil
 	c.CreatedNodeClaims = map[string]*v1beta1.NodeClaim{}
+	c.InstanceTypes = nil
 	c.InstanceTypesForNodePool = map[string][]*cloudprovider.InstanceType{}
 	c.ErrorsForNodePool = map[string]error{}
 	c.AllowedCreateCalls = math.MaxInt

--- a/pkg/controllers/provisioning/provisioner_test.go
+++ b/pkg/controllers/provisioning/provisioner_test.go
@@ -38,7 +38,7 @@ import (
 	. "github.com/aws/karpenter-core/pkg/test/expectations"
 )
 
-var _ = Describe("Provisioning", func() {
+var _ = Describe("Provisioner/Provisioning", func() {
 	It("should provision nodes", func() {
 		ExpectApplied(ctx, env.Client, test.Provisioner())
 		pod := test.UnschedulablePod()
@@ -149,7 +149,7 @@ var _ = Describe("Provisioning", func() {
 			ExpectScheduled(ctx, env.Client, pod)
 		}
 	})
-	It("should schedule all pods on one node when node is in deleting state", func() {
+	It("should schedule all pods on one inflight node while node is in deleting state", func() {
 		provisioner := test.Provisioner()
 		its, err := cloudProvider.GetInstanceTypes(ctx, nodepoolutil.New(provisioner))
 		Expect(err).To(BeNil())
@@ -546,13 +546,11 @@ var _ = Describe("Provisioning", func() {
 					v1.ResourceCPU: resource.MustParse("2"),
 				},
 			})
-
 			provisionerDaemonset := test.Provisioner(test.ProvisionerOptions{
 				Labels: map[string]string{
 					"foo": "bar",
 				},
 			})
-
 			// Create a daemonset with large resource requests
 			daemonset := test.DaemonSet(
 				test.DaemonSetOptions{PodOptions: test.PodOptions{
@@ -969,398 +967,395 @@ var _ = Describe("Provisioning", func() {
 			ExpectScheduled(ctx, env.Client, pod)
 		})
 	})
-})
-
-var _ = Describe("Volume Topology Requirements", func() {
-	var storageClass *storagev1.StorageClass
-	BeforeEach(func() {
-		storageClass = test.StorageClass(test.StorageClassOptions{Zones: []string{"test-zone-2", "test-zone-3"}})
-	})
-	It("should not schedule if invalid pvc", func() {
-		ExpectApplied(ctx, env.Client, test.Provisioner())
-		pod := test.UnschedulablePod(test.PodOptions{
-			PersistentVolumeClaims: []string{"invalid"},
+	Context("Volume Topology Requirements", func() {
+		var storageClass *storagev1.StorageClass
+		BeforeEach(func() {
+			storageClass = test.StorageClass(test.StorageClassOptions{Zones: []string{"test-zone-2", "test-zone-3"}})
 		})
-		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
-		ExpectNotScheduled(ctx, env.Client, pod)
-	})
-	It("should schedule with an empty storage class", func() {
-		storageClass := ""
-		persistentVolumeClaim := test.PersistentVolumeClaim(test.PersistentVolumeClaimOptions{StorageClassName: &storageClass})
-		ExpectApplied(ctx, env.Client, test.Provisioner(), persistentVolumeClaim)
-		pod := test.UnschedulablePod(test.PodOptions{
-			PersistentVolumeClaims: []string{persistentVolumeClaim.Name},
-		})
-		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
-		ExpectScheduled(ctx, env.Client, pod)
-	})
-	It("should schedule valid pods when a pod with an invalid pvc is encountered (pvc)", func() {
-		ExpectApplied(ctx, env.Client, test.Provisioner())
-		invalidPod := test.UnschedulablePod(test.PodOptions{
-			PersistentVolumeClaims: []string{"invalid"},
-		})
-		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, invalidPod)
-		pod := test.UnschedulablePod()
-		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
-		ExpectNotScheduled(ctx, env.Client, invalidPod)
-		ExpectScheduled(ctx, env.Client, pod)
-	})
-	It("should schedule valid pods when a pod with an invalid pvc is encountered (storage class)", func() {
-		invalidStorageClass := "invalid-storage-class"
-		persistentVolumeClaim := test.PersistentVolumeClaim(test.PersistentVolumeClaimOptions{StorageClassName: &invalidStorageClass})
-		ExpectApplied(ctx, env.Client, test.Provisioner(), persistentVolumeClaim)
-		invalidPod := test.UnschedulablePod(test.PodOptions{
-			PersistentVolumeClaims: []string{persistentVolumeClaim.Name},
-		})
-		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, invalidPod)
-		pod := test.UnschedulablePod()
-		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
-		ExpectNotScheduled(ctx, env.Client, invalidPod)
-		ExpectScheduled(ctx, env.Client, pod)
-	})
-	It("should schedule valid pods when a pod with an invalid pvc is encountered (volume name)", func() {
-		invalidVolumeName := "invalid-volume-name"
-		persistentVolumeClaim := test.PersistentVolumeClaim(test.PersistentVolumeClaimOptions{VolumeName: invalidVolumeName})
-		ExpectApplied(ctx, env.Client, test.Provisioner(), persistentVolumeClaim)
-		invalidPod := test.UnschedulablePod(test.PodOptions{
-			PersistentVolumeClaims: []string{persistentVolumeClaim.Name},
-		})
-		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, invalidPod)
-		pod := test.UnschedulablePod()
-		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
-		ExpectNotScheduled(ctx, env.Client, invalidPod)
-		ExpectScheduled(ctx, env.Client, pod)
-	})
-	It("should schedule to storage class zones if volume does not exist", func() {
-		persistentVolumeClaim := test.PersistentVolumeClaim(test.PersistentVolumeClaimOptions{StorageClassName: &storageClass.Name})
-		ExpectApplied(ctx, env.Client, test.Provisioner(), storageClass, persistentVolumeClaim)
-		pod := test.UnschedulablePod(test.PodOptions{
-			PersistentVolumeClaims: []string{persistentVolumeClaim.Name},
-			NodeRequirements: []v1.NodeSelectorRequirement{{
-				Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-1", "test-zone-3"},
-			}},
-		})
-		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
-		node := ExpectScheduled(ctx, env.Client, pod)
-		Expect(node.Labels).To(HaveKeyWithValue(v1.LabelTopologyZone, "test-zone-3"))
-	})
-	It("should schedule to storage class zones if volume does not exist (ephemeral volume)", func() {
-		pod := test.UnschedulablePod(test.PodOptions{
-			EphemeralVolumeTemplates: []test.EphemeralVolumeTemplateOptions{
-				{
-					StorageClassName: &storageClass.Name,
-				},
-			},
-			NodeRequirements: []v1.NodeSelectorRequirement{{
-				Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-1", "test-zone-3"},
-			}},
-		})
-		persistentVolumeClaim := test.PersistentVolumeClaim(test.PersistentVolumeClaimOptions{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: fmt.Sprintf("%s-%s", pod.Name, pod.Spec.Volumes[0].Name),
-			},
-			StorageClassName: &storageClass.Name,
-		})
-		ExpectApplied(ctx, env.Client, test.Provisioner(), storageClass, persistentVolumeClaim)
-		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
-		node := ExpectScheduled(ctx, env.Client, pod)
-		Expect(node.Labels).To(HaveKeyWithValue(v1.LabelTopologyZone, "test-zone-3"))
-	})
-	It("should not schedule if storage class zones are incompatible", func() {
-		persistentVolumeClaim := test.PersistentVolumeClaim(test.PersistentVolumeClaimOptions{StorageClassName: &storageClass.Name})
-		ExpectApplied(ctx, env.Client, test.Provisioner(), storageClass, persistentVolumeClaim)
-		pod := test.UnschedulablePod(test.PodOptions{
-			PersistentVolumeClaims: []string{persistentVolumeClaim.Name},
-			NodeRequirements: []v1.NodeSelectorRequirement{{
-				Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-1"},
-			}},
-		})
-		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
-		ExpectNotScheduled(ctx, env.Client, pod)
-	})
-	It("should not schedule if storage class zones are incompatible (ephemeral volume)", func() {
-		pod := test.UnschedulablePod(test.PodOptions{
-			EphemeralVolumeTemplates: []test.EphemeralVolumeTemplateOptions{
-				{
-					StorageClassName: &storageClass.Name,
-				},
-			},
-			NodeRequirements: []v1.NodeSelectorRequirement{{
-				Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-1"},
-			}},
-		})
-		persistentVolumeClaim := test.PersistentVolumeClaim(test.PersistentVolumeClaimOptions{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: fmt.Sprintf("%s-%s", pod.Name, pod.Spec.Volumes[0].Name),
-			},
-			StorageClassName: &storageClass.Name,
-		})
-		ExpectApplied(ctx, env.Client, test.Provisioner(), storageClass, persistentVolumeClaim)
-		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
-		ExpectNotScheduled(ctx, env.Client, pod)
-	})
-	It("should schedule to volume zones if volume already bound", func() {
-		persistentVolume := test.PersistentVolume(test.PersistentVolumeOptions{Zones: []string{"test-zone-3"}})
-		persistentVolumeClaim := test.PersistentVolumeClaim(test.PersistentVolumeClaimOptions{VolumeName: persistentVolume.Name, StorageClassName: &storageClass.Name})
-		ExpectApplied(ctx, env.Client, test.Provisioner(), storageClass, persistentVolumeClaim, persistentVolume)
-		pod := test.UnschedulablePod(test.PodOptions{
-			PersistentVolumeClaims: []string{persistentVolumeClaim.Name},
-		})
-		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
-		node := ExpectScheduled(ctx, env.Client, pod)
-		Expect(node.Labels).To(HaveKeyWithValue(v1.LabelTopologyZone, "test-zone-3"))
-	})
-	It("should schedule to volume zones if volume already bound (ephemeral volume)", func() {
-		pod := test.UnschedulablePod(test.PodOptions{
-			EphemeralVolumeTemplates: []test.EphemeralVolumeTemplateOptions{
-				{
-					StorageClassName: &storageClass.Name,
-				},
-			},
-		})
-		persistentVolume := test.PersistentVolume(test.PersistentVolumeOptions{Zones: []string{"test-zone-3"}})
-		persistentVolumeClaim := test.PersistentVolumeClaim(test.PersistentVolumeClaimOptions{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: fmt.Sprintf("%s-%s", pod.Name, pod.Spec.Volumes[0].Name),
-			},
-			VolumeName:       persistentVolume.Name,
-			StorageClassName: &storageClass.Name,
-		})
-		ExpectApplied(ctx, env.Client, test.Provisioner(), storageClass, pod, persistentVolumeClaim, persistentVolume)
-		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
-		node := ExpectScheduled(ctx, env.Client, pod)
-		Expect(node.Labels).To(HaveKeyWithValue(v1.LabelTopologyZone, "test-zone-3"))
-	})
-	It("should not schedule if volume zones are incompatible", func() {
-		persistentVolume := test.PersistentVolume(test.PersistentVolumeOptions{Zones: []string{"test-zone-3"}})
-		persistentVolumeClaim := test.PersistentVolumeClaim(test.PersistentVolumeClaimOptions{VolumeName: persistentVolume.Name, StorageClassName: &storageClass.Name})
-		ExpectApplied(ctx, env.Client, test.Provisioner(), storageClass, persistentVolumeClaim, persistentVolume)
-		pod := test.UnschedulablePod(test.PodOptions{
-			PersistentVolumeClaims: []string{persistentVolumeClaim.Name},
-			NodeRequirements: []v1.NodeSelectorRequirement{{
-				Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-1"},
-			}},
-		})
-		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
-		ExpectNotScheduled(ctx, env.Client, pod)
-	})
-	It("should not schedule if volume zones are incompatible (ephemeral volume)", func() {
-		pod := test.UnschedulablePod(test.PodOptions{
-			EphemeralVolumeTemplates: []test.EphemeralVolumeTemplateOptions{
-				{
-					StorageClassName: &storageClass.Name,
-				},
-			},
-			NodeRequirements: []v1.NodeSelectorRequirement{{
-				Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-1"},
-			}},
-		})
-		persistentVolume := test.PersistentVolume(test.PersistentVolumeOptions{Zones: []string{"test-zone-3"}})
-		persistentVolumeClaim := test.PersistentVolumeClaim(test.PersistentVolumeClaimOptions{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: fmt.Sprintf("%s-%s", pod.Name, pod.Spec.Volumes[0].Name),
-			},
-			VolumeName:       persistentVolume.Name,
-			StorageClassName: &storageClass.Name,
-		})
-		ExpectApplied(ctx, env.Client, test.Provisioner(), storageClass, pod, persistentVolumeClaim, persistentVolume)
-		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
-		ExpectNotScheduled(ctx, env.Client, pod)
-	})
-	It("should not relax an added volume topology zone node-selector away", func() {
-		persistentVolume := test.PersistentVolume(test.PersistentVolumeOptions{Zones: []string{"test-zone-3"}})
-		persistentVolumeClaim := test.PersistentVolumeClaim(test.PersistentVolumeClaimOptions{VolumeName: persistentVolume.Name, StorageClassName: &storageClass.Name})
-		ExpectApplied(ctx, env.Client, test.Provisioner(), storageClass, persistentVolumeClaim, persistentVolume)
-
-		pod := test.UnschedulablePod(test.PodOptions{
-			PersistentVolumeClaims: []string{persistentVolumeClaim.Name},
-			NodeRequirements: []v1.NodeSelectorRequirement{
-				{
-					Key:      "example.com/label",
-					Operator: v1.NodeSelectorOpIn,
-					Values:   []string{"unsupported"},
-				},
-			},
-		})
-
-		// Add the second capacity type that is OR'd with the first. Previously we only added the volume topology requirement
-		// to a single node selector term which would sometimes get relaxed away.  Now we add it to all of them to AND
-		// it with each existing term.
-		pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = append(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms,
-			v1.NodeSelectorTerm{
-				MatchExpressions: []v1.NodeSelectorRequirement{
-					{
-						Key:      v1alpha5.LabelCapacityType,
-						Operator: v1.NodeSelectorOpIn,
-						Values:   []string{v1alpha5.CapacityTypeOnDemand},
-					},
-				},
+		It("should not schedule if invalid pvc", func() {
+			ExpectApplied(ctx, env.Client, test.Provisioner())
+			pod := test.UnschedulablePod(test.PodOptions{
+				PersistentVolumeClaims: []string{"invalid"},
 			})
-		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
-		node := ExpectScheduled(ctx, env.Client, pod)
-		Expect(node.Labels).To(HaveKeyWithValue(v1.LabelTopologyZone, "test-zone-3"))
-	})
-})
-
-var _ = Describe("Preferential Fallback", func() {
-	Context("Required", func() {
-		It("should not relax the final term", func() {
-			pod := test.UnschedulablePod()
-			pod.Spec.Affinity = &v1.Affinity{NodeAffinity: &v1.NodeAffinity{RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{NodeSelectorTerms: []v1.NodeSelectorTerm{
-				{MatchExpressions: []v1.NodeSelectorRequirement{
-					{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"invalid"}}, // Should not be relaxed
-				}},
-			}}}}
-			// Don't relax
-			ExpectApplied(ctx, env.Client, test.Provisioner(test.ProvisionerOptions{Requirements: []v1.NodeSelectorRequirement{{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-1"}}}}))
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
 			ExpectNotScheduled(ctx, env.Client, pod)
 		})
-		It("should relax multiple terms", func() {
-			pod := test.UnschedulablePod()
-			pod.Spec.Affinity = &v1.Affinity{NodeAffinity: &v1.NodeAffinity{RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{NodeSelectorTerms: []v1.NodeSelectorTerm{
-				{MatchExpressions: []v1.NodeSelectorRequirement{
-					{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"invalid"}},
-				}},
-				{MatchExpressions: []v1.NodeSelectorRequirement{
-					{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"invalid"}},
-				}},
-				{MatchExpressions: []v1.NodeSelectorRequirement{
-					{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-1"}},
-				}},
-				{MatchExpressions: []v1.NodeSelectorRequirement{
-					{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-2"}}, // OR operator, never get to this one
-				}},
-			}}}}
-			// Success
-			ExpectApplied(ctx, env.Client, test.Provisioner())
-			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
-			node := ExpectScheduled(ctx, env.Client, pod)
-			Expect(node.Labels).To(HaveKeyWithValue(v1.LabelTopologyZone, "test-zone-1"))
-		})
-	})
-	Context("Preferences", func() {
-		It("should relax all node affinity terms", func() {
-			pod := test.UnschedulablePod()
-			pod.Spec.Affinity = &v1.Affinity{NodeAffinity: &v1.NodeAffinity{PreferredDuringSchedulingIgnoredDuringExecution: []v1.PreferredSchedulingTerm{
-				{
-					Weight: 1, Preference: v1.NodeSelectorTerm{MatchExpressions: []v1.NodeSelectorRequirement{
-						{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"invalid"}},
-					}},
-				},
-				{
-					Weight: 1, Preference: v1.NodeSelectorTerm{MatchExpressions: []v1.NodeSelectorRequirement{
-						{Key: v1.LabelInstanceTypeStable, Operator: v1.NodeSelectorOpIn, Values: []string{"invalid"}},
-					}},
-				},
-			}}}
-			// Success
-			ExpectApplied(ctx, env.Client, test.Provisioner())
+		It("should schedule with an empty storage class", func() {
+			storageClass := ""
+			persistentVolumeClaim := test.PersistentVolumeClaim(test.PersistentVolumeClaimOptions{StorageClassName: &storageClass})
+			ExpectApplied(ctx, env.Client, test.Provisioner(), persistentVolumeClaim)
+			pod := test.UnschedulablePod(test.PodOptions{
+				PersistentVolumeClaims: []string{persistentVolumeClaim.Name},
+			})
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
 			ExpectScheduled(ctx, env.Client, pod)
 		})
-		It("should relax to use lighter weights", func() {
+		It("should schedule valid pods when a pod with an invalid pvc is encountered (pvc)", func() {
+			ExpectApplied(ctx, env.Client, test.Provisioner())
+			invalidPod := test.UnschedulablePod(test.PodOptions{
+				PersistentVolumeClaims: []string{"invalid"},
+			})
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, invalidPod)
 			pod := test.UnschedulablePod()
-			pod.Spec.Affinity = &v1.Affinity{NodeAffinity: &v1.NodeAffinity{PreferredDuringSchedulingIgnoredDuringExecution: []v1.PreferredSchedulingTerm{
-				{
-					Weight: 100, Preference: v1.NodeSelectorTerm{MatchExpressions: []v1.NodeSelectorRequirement{
-						{Key: v1.LabelInstanceTypeStable, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-3"}},
-					}},
-				},
-				{
-					Weight: 50, Preference: v1.NodeSelectorTerm{MatchExpressions: []v1.NodeSelectorRequirement{
-						{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-2"}},
-					}},
-				},
-				{
-					Weight: 1, Preference: v1.NodeSelectorTerm{MatchExpressions: []v1.NodeSelectorRequirement{ // OR operator, never get to this one
-						{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-1"}},
-					}},
-				},
-			}}}
-			// Success
-			ExpectApplied(ctx, env.Client, test.Provisioner(test.ProvisionerOptions{Requirements: []v1.NodeSelectorRequirement{{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-1", "test-zone-2"}}}}))
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+			ExpectNotScheduled(ctx, env.Client, invalidPod)
+			ExpectScheduled(ctx, env.Client, pod)
+		})
+		It("should schedule valid pods when a pod with an invalid pvc is encountered (storage class)", func() {
+			invalidStorageClass := "invalid-storage-class"
+			persistentVolumeClaim := test.PersistentVolumeClaim(test.PersistentVolumeClaimOptions{StorageClassName: &invalidStorageClass})
+			ExpectApplied(ctx, env.Client, test.Provisioner(), persistentVolumeClaim)
+			invalidPod := test.UnschedulablePod(test.PodOptions{
+				PersistentVolumeClaims: []string{persistentVolumeClaim.Name},
+			})
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, invalidPod)
+			pod := test.UnschedulablePod()
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+			ExpectNotScheduled(ctx, env.Client, invalidPod)
+			ExpectScheduled(ctx, env.Client, pod)
+		})
+		It("should schedule valid pods when a pod with an invalid pvc is encountered (volume name)", func() {
+			invalidVolumeName := "invalid-volume-name"
+			persistentVolumeClaim := test.PersistentVolumeClaim(test.PersistentVolumeClaimOptions{VolumeName: invalidVolumeName})
+			ExpectApplied(ctx, env.Client, test.Provisioner(), persistentVolumeClaim)
+			invalidPod := test.UnschedulablePod(test.PodOptions{
+				PersistentVolumeClaims: []string{persistentVolumeClaim.Name},
+			})
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, invalidPod)
+			pod := test.UnschedulablePod()
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+			ExpectNotScheduled(ctx, env.Client, invalidPod)
+			ExpectScheduled(ctx, env.Client, pod)
+		})
+		It("should schedule to storage class zones if volume does not exist", func() {
+			persistentVolumeClaim := test.PersistentVolumeClaim(test.PersistentVolumeClaimOptions{StorageClassName: &storageClass.Name})
+			ExpectApplied(ctx, env.Client, test.Provisioner(), storageClass, persistentVolumeClaim)
+			pod := test.UnschedulablePod(test.PodOptions{
+				PersistentVolumeClaims: []string{persistentVolumeClaim.Name},
+				NodeRequirements: []v1.NodeSelectorRequirement{{
+					Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-1", "test-zone-3"},
+				}},
+			})
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
 			node := ExpectScheduled(ctx, env.Client, pod)
-			Expect(node.Labels).To(HaveKeyWithValue(v1.LabelTopologyZone, "test-zone-2"))
+			Expect(node.Labels).To(HaveKeyWithValue(v1.LabelTopologyZone, "test-zone-3"))
 		})
-		It("should tolerate PreferNoSchedule taint only after trying to relax Affinity terms", func() {
-			pod := test.UnschedulablePod()
-			pod.Spec.Affinity = &v1.Affinity{NodeAffinity: &v1.NodeAffinity{PreferredDuringSchedulingIgnoredDuringExecution: []v1.PreferredSchedulingTerm{
-				{
-					Weight: 1, Preference: v1.NodeSelectorTerm{MatchExpressions: []v1.NodeSelectorRequirement{
+		It("should schedule to storage class zones if volume does not exist (ephemeral volume)", func() {
+			pod := test.UnschedulablePod(test.PodOptions{
+				EphemeralVolumeTemplates: []test.EphemeralVolumeTemplateOptions{
+					{
+						StorageClassName: &storageClass.Name,
+					},
+				},
+				NodeRequirements: []v1.NodeSelectorRequirement{{
+					Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-1", "test-zone-3"},
+				}},
+			})
+			persistentVolumeClaim := test.PersistentVolumeClaim(test.PersistentVolumeClaimOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: fmt.Sprintf("%s-%s", pod.Name, pod.Spec.Volumes[0].Name),
+				},
+				StorageClassName: &storageClass.Name,
+			})
+			ExpectApplied(ctx, env.Client, test.Provisioner(), storageClass, persistentVolumeClaim)
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+			node := ExpectScheduled(ctx, env.Client, pod)
+			Expect(node.Labels).To(HaveKeyWithValue(v1.LabelTopologyZone, "test-zone-3"))
+		})
+		It("should not schedule if storage class zones are incompatible", func() {
+			persistentVolumeClaim := test.PersistentVolumeClaim(test.PersistentVolumeClaimOptions{StorageClassName: &storageClass.Name})
+			ExpectApplied(ctx, env.Client, test.Provisioner(), storageClass, persistentVolumeClaim)
+			pod := test.UnschedulablePod(test.PodOptions{
+				PersistentVolumeClaims: []string{persistentVolumeClaim.Name},
+				NodeRequirements: []v1.NodeSelectorRequirement{{
+					Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-1"},
+				}},
+			})
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+			ExpectNotScheduled(ctx, env.Client, pod)
+		})
+		It("should not schedule if storage class zones are incompatible (ephemeral volume)", func() {
+			pod := test.UnschedulablePod(test.PodOptions{
+				EphemeralVolumeTemplates: []test.EphemeralVolumeTemplateOptions{
+					{
+						StorageClassName: &storageClass.Name,
+					},
+				},
+				NodeRequirements: []v1.NodeSelectorRequirement{{
+					Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-1"},
+				}},
+			})
+			persistentVolumeClaim := test.PersistentVolumeClaim(test.PersistentVolumeClaimOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: fmt.Sprintf("%s-%s", pod.Name, pod.Spec.Volumes[0].Name),
+				},
+				StorageClassName: &storageClass.Name,
+			})
+			ExpectApplied(ctx, env.Client, test.Provisioner(), storageClass, persistentVolumeClaim)
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+			ExpectNotScheduled(ctx, env.Client, pod)
+		})
+		It("should schedule to volume zones if volume already bound", func() {
+			persistentVolume := test.PersistentVolume(test.PersistentVolumeOptions{Zones: []string{"test-zone-3"}})
+			persistentVolumeClaim := test.PersistentVolumeClaim(test.PersistentVolumeClaimOptions{VolumeName: persistentVolume.Name, StorageClassName: &storageClass.Name})
+			ExpectApplied(ctx, env.Client, test.Provisioner(), storageClass, persistentVolumeClaim, persistentVolume)
+			pod := test.UnschedulablePod(test.PodOptions{
+				PersistentVolumeClaims: []string{persistentVolumeClaim.Name},
+			})
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+			node := ExpectScheduled(ctx, env.Client, pod)
+			Expect(node.Labels).To(HaveKeyWithValue(v1.LabelTopologyZone, "test-zone-3"))
+		})
+		It("should schedule to volume zones if volume already bound (ephemeral volume)", func() {
+			pod := test.UnschedulablePod(test.PodOptions{
+				EphemeralVolumeTemplates: []test.EphemeralVolumeTemplateOptions{
+					{
+						StorageClassName: &storageClass.Name,
+					},
+				},
+			})
+			persistentVolume := test.PersistentVolume(test.PersistentVolumeOptions{Zones: []string{"test-zone-3"}})
+			persistentVolumeClaim := test.PersistentVolumeClaim(test.PersistentVolumeClaimOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: fmt.Sprintf("%s-%s", pod.Name, pod.Spec.Volumes[0].Name),
+				},
+				VolumeName:       persistentVolume.Name,
+				StorageClassName: &storageClass.Name,
+			})
+			ExpectApplied(ctx, env.Client, test.Provisioner(), storageClass, pod, persistentVolumeClaim, persistentVolume)
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+			node := ExpectScheduled(ctx, env.Client, pod)
+			Expect(node.Labels).To(HaveKeyWithValue(v1.LabelTopologyZone, "test-zone-3"))
+		})
+		It("should not schedule if volume zones are incompatible", func() {
+			persistentVolume := test.PersistentVolume(test.PersistentVolumeOptions{Zones: []string{"test-zone-3"}})
+			persistentVolumeClaim := test.PersistentVolumeClaim(test.PersistentVolumeClaimOptions{VolumeName: persistentVolume.Name, StorageClassName: &storageClass.Name})
+			ExpectApplied(ctx, env.Client, test.Provisioner(), storageClass, persistentVolumeClaim, persistentVolume)
+			pod := test.UnschedulablePod(test.PodOptions{
+				PersistentVolumeClaims: []string{persistentVolumeClaim.Name},
+				NodeRequirements: []v1.NodeSelectorRequirement{{
+					Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-1"},
+				}},
+			})
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+			ExpectNotScheduled(ctx, env.Client, pod)
+		})
+		It("should not schedule if volume zones are incompatible (ephemeral volume)", func() {
+			pod := test.UnschedulablePod(test.PodOptions{
+				EphemeralVolumeTemplates: []test.EphemeralVolumeTemplateOptions{
+					{
+						StorageClassName: &storageClass.Name,
+					},
+				},
+				NodeRequirements: []v1.NodeSelectorRequirement{{
+					Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-1"},
+				}},
+			})
+			persistentVolume := test.PersistentVolume(test.PersistentVolumeOptions{Zones: []string{"test-zone-3"}})
+			persistentVolumeClaim := test.PersistentVolumeClaim(test.PersistentVolumeClaimOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: fmt.Sprintf("%s-%s", pod.Name, pod.Spec.Volumes[0].Name),
+				},
+				VolumeName:       persistentVolume.Name,
+				StorageClassName: &storageClass.Name,
+			})
+			ExpectApplied(ctx, env.Client, test.Provisioner(), storageClass, pod, persistentVolumeClaim, persistentVolume)
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+			ExpectNotScheduled(ctx, env.Client, pod)
+		})
+		It("should not relax an added volume topology zone node-selector away", func() {
+			persistentVolume := test.PersistentVolume(test.PersistentVolumeOptions{Zones: []string{"test-zone-3"}})
+			persistentVolumeClaim := test.PersistentVolumeClaim(test.PersistentVolumeClaimOptions{VolumeName: persistentVolume.Name, StorageClassName: &storageClass.Name})
+			ExpectApplied(ctx, env.Client, test.Provisioner(), storageClass, persistentVolumeClaim, persistentVolume)
+
+			pod := test.UnschedulablePod(test.PodOptions{
+				PersistentVolumeClaims: []string{persistentVolumeClaim.Name},
+				NodeRequirements: []v1.NodeSelectorRequirement{
+					{
+						Key:      "example.com/label",
+						Operator: v1.NodeSelectorOpIn,
+						Values:   []string{"unsupported"},
+					},
+				},
+			})
+
+			// Add the second capacity type that is OR'd with the first. Previously we only added the volume topology requirement
+			// to a single node selector term which would sometimes get relaxed away.  Now we add it to all of them to AND
+			// it with each existing term.
+			pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = append(pod.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms,
+				v1.NodeSelectorTerm{
+					MatchExpressions: []v1.NodeSelectorRequirement{
+						{
+							Key:      v1alpha5.LabelCapacityType,
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{v1alpha5.CapacityTypeOnDemand},
+						},
+					},
+				})
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+			node := ExpectScheduled(ctx, env.Client, pod)
+			Expect(node.Labels).To(HaveKeyWithValue(v1.LabelTopologyZone, "test-zone-3"))
+		})
+	})
+	Context("Preferential Fallback", func() {
+		Context("Required", func() {
+			It("should not relax the final term", func() {
+				pod := test.UnschedulablePod()
+				pod.Spec.Affinity = &v1.Affinity{NodeAffinity: &v1.NodeAffinity{RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{NodeSelectorTerms: []v1.NodeSelectorTerm{
+					{MatchExpressions: []v1.NodeSelectorRequirement{
+						{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"invalid"}}, // Should not be relaxed
+					}},
+				}}}}
+				// Don't relax
+				ExpectApplied(ctx, env.Client, test.Provisioner(test.ProvisionerOptions{Requirements: []v1.NodeSelectorRequirement{{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-1"}}}}))
+				ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+				ExpectNotScheduled(ctx, env.Client, pod)
+			})
+			It("should relax multiple terms", func() {
+				pod := test.UnschedulablePod()
+				pod.Spec.Affinity = &v1.Affinity{NodeAffinity: &v1.NodeAffinity{RequiredDuringSchedulingIgnoredDuringExecution: &v1.NodeSelector{NodeSelectorTerms: []v1.NodeSelectorTerm{
+					{MatchExpressions: []v1.NodeSelectorRequirement{
 						{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"invalid"}},
 					}},
-				},
-				{
-					Weight: 1, Preference: v1.NodeSelectorTerm{MatchExpressions: []v1.NodeSelectorRequirement{
-						{Key: v1.LabelInstanceTypeStable, Operator: v1.NodeSelectorOpIn, Values: []string{"invalid"}},
+					{MatchExpressions: []v1.NodeSelectorRequirement{
+						{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"invalid"}},
 					}},
-				},
-			}}}
-			// Success
-			ExpectApplied(ctx, env.Client, test.Provisioner(test.ProvisionerOptions{Taints: []v1.Taint{{Key: "foo", Value: "bar", Effect: v1.TaintEffectPreferNoSchedule}}}))
-			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
-			node := ExpectScheduled(ctx, env.Client, pod)
-			Expect(node.Spec.Taints).To(ContainElement(v1.Taint{Key: "foo", Value: "bar", Effect: v1.TaintEffectPreferNoSchedule}))
-		})
-	})
-})
-
-var _ = Describe("Multiple Provisioners", func() {
-	It("should schedule to an explicitly selected provisioner", func() {
-		provisioner := test.Provisioner()
-		ExpectApplied(ctx, env.Client, provisioner, test.Provisioner())
-		pod := test.UnschedulablePod(test.PodOptions{NodeSelector: map[string]string{v1alpha5.ProvisionerNameLabelKey: provisioner.Name}})
-		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
-		node := ExpectScheduled(ctx, env.Client, pod)
-		Expect(node.Labels[v1alpha5.ProvisionerNameLabelKey]).To(Equal(provisioner.Name))
-	})
-	It("should schedule to a provisioner by labels", func() {
-		provisioner := test.Provisioner(test.ProvisionerOptions{Labels: map[string]string{"foo": "bar"}})
-		ExpectApplied(ctx, env.Client, provisioner, test.Provisioner())
-		pod := test.UnschedulablePod(test.PodOptions{NodeSelector: provisioner.Spec.Labels})
-		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
-		node := ExpectScheduled(ctx, env.Client, pod)
-		Expect(node.Labels[v1alpha5.ProvisionerNameLabelKey]).To(Equal(provisioner.Name))
-	})
-	It("should not match provisioner with PreferNoSchedule taint when other provisioner match", func() {
-		provisioner := test.Provisioner(test.ProvisionerOptions{Taints: []v1.Taint{{Key: "foo", Value: "bar", Effect: v1.TaintEffectPreferNoSchedule}}})
-		ExpectApplied(ctx, env.Client, provisioner, test.Provisioner())
-		pod := test.UnschedulablePod()
-		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
-		node := ExpectScheduled(ctx, env.Client, pod)
-		Expect(node.Labels[v1alpha5.ProvisionerNameLabelKey]).ToNot(Equal(provisioner.Name))
-	})
-	Context("Weighted Provisioners", func() {
-		It("should schedule to the provisioner with the highest priority always", func() {
-			provisioners := []client.Object{
-				test.Provisioner(),
-				test.Provisioner(test.ProvisionerOptions{Weight: ptr.Int32(20)}),
-				test.Provisioner(test.ProvisionerOptions{Weight: ptr.Int32(100)}),
-			}
-			ExpectApplied(ctx, env.Client, provisioners...)
-			pods := []*v1.Pod{
-				test.UnschedulablePod(), test.UnschedulablePod(), test.UnschedulablePod(),
-			}
-			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pods...)
-			for _, pod := range pods {
+					{MatchExpressions: []v1.NodeSelectorRequirement{
+						{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-1"}},
+					}},
+					{MatchExpressions: []v1.NodeSelectorRequirement{
+						{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-2"}}, // OR operator, never get to this one
+					}},
+				}}}}
+				// Success
+				ExpectApplied(ctx, env.Client, test.Provisioner())
+				ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
 				node := ExpectScheduled(ctx, env.Client, pod)
-				Expect(node.Labels[v1alpha5.ProvisionerNameLabelKey]).To(Equal(provisioners[2].GetName()))
-			}
+				Expect(node.Labels).To(HaveKeyWithValue(v1.LabelTopologyZone, "test-zone-1"))
+			})
 		})
-		It("should schedule to explicitly selected provisioner even if other provisioners are higher priority", func() {
-			targetedProvisioner := test.Provisioner()
-			provisioners := []client.Object{
-				targetedProvisioner,
-				test.Provisioner(test.ProvisionerOptions{Weight: ptr.Int32(20)}),
-				test.Provisioner(test.ProvisionerOptions{Weight: ptr.Int32(100)}),
-			}
-			ExpectApplied(ctx, env.Client, provisioners...)
-			pod := test.UnschedulablePod(test.PodOptions{NodeSelector: map[string]string{v1alpha5.ProvisionerNameLabelKey: targetedProvisioner.Name}})
+		Context("Preferences", func() {
+			It("should relax all node affinity terms", func() {
+				pod := test.UnschedulablePod()
+				pod.Spec.Affinity = &v1.Affinity{NodeAffinity: &v1.NodeAffinity{PreferredDuringSchedulingIgnoredDuringExecution: []v1.PreferredSchedulingTerm{
+					{
+						Weight: 1, Preference: v1.NodeSelectorTerm{MatchExpressions: []v1.NodeSelectorRequirement{
+							{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"invalid"}},
+						}},
+					},
+					{
+						Weight: 1, Preference: v1.NodeSelectorTerm{MatchExpressions: []v1.NodeSelectorRequirement{
+							{Key: v1.LabelInstanceTypeStable, Operator: v1.NodeSelectorOpIn, Values: []string{"invalid"}},
+						}},
+					},
+				}}}
+				// Success
+				ExpectApplied(ctx, env.Client, test.Provisioner())
+				ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+				ExpectScheduled(ctx, env.Client, pod)
+			})
+			It("should relax to use lighter weights", func() {
+				pod := test.UnschedulablePod()
+				pod.Spec.Affinity = &v1.Affinity{NodeAffinity: &v1.NodeAffinity{PreferredDuringSchedulingIgnoredDuringExecution: []v1.PreferredSchedulingTerm{
+					{
+						Weight: 100, Preference: v1.NodeSelectorTerm{MatchExpressions: []v1.NodeSelectorRequirement{
+							{Key: v1.LabelInstanceTypeStable, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-3"}},
+						}},
+					},
+					{
+						Weight: 50, Preference: v1.NodeSelectorTerm{MatchExpressions: []v1.NodeSelectorRequirement{
+							{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-2"}},
+						}},
+					},
+					{
+						Weight: 1, Preference: v1.NodeSelectorTerm{MatchExpressions: []v1.NodeSelectorRequirement{ // OR operator, never get to this one
+							{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-1"}},
+						}},
+					},
+				}}}
+				// Success
+				ExpectApplied(ctx, env.Client, test.Provisioner(test.ProvisionerOptions{Requirements: []v1.NodeSelectorRequirement{{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-1", "test-zone-2"}}}}))
+				ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+				node := ExpectScheduled(ctx, env.Client, pod)
+				Expect(node.Labels).To(HaveKeyWithValue(v1.LabelTopologyZone, "test-zone-2"))
+			})
+			It("should tolerate PreferNoSchedule taint only after trying to relax Affinity terms", func() {
+				pod := test.UnschedulablePod()
+				pod.Spec.Affinity = &v1.Affinity{NodeAffinity: &v1.NodeAffinity{PreferredDuringSchedulingIgnoredDuringExecution: []v1.PreferredSchedulingTerm{
+					{
+						Weight: 1, Preference: v1.NodeSelectorTerm{MatchExpressions: []v1.NodeSelectorRequirement{
+							{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"invalid"}},
+						}},
+					},
+					{
+						Weight: 1, Preference: v1.NodeSelectorTerm{MatchExpressions: []v1.NodeSelectorRequirement{
+							{Key: v1.LabelInstanceTypeStable, Operator: v1.NodeSelectorOpIn, Values: []string{"invalid"}},
+						}},
+					},
+				}}}
+				// Success
+				ExpectApplied(ctx, env.Client, test.Provisioner(test.ProvisionerOptions{Taints: []v1.Taint{{Key: "foo", Value: "bar", Effect: v1.TaintEffectPreferNoSchedule}}}))
+				ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+				node := ExpectScheduled(ctx, env.Client, pod)
+				Expect(node.Spec.Taints).To(ContainElement(v1.Taint{Key: "foo", Value: "bar", Effect: v1.TaintEffectPreferNoSchedule}))
+			})
+		})
+	})
+	Context("Multiple Provisioners", func() {
+		It("should schedule to an explicitly selected provisioner", func() {
+			provisioner := test.Provisioner()
+			ExpectApplied(ctx, env.Client, provisioner, test.Provisioner())
+			pod := test.UnschedulablePod(test.PodOptions{NodeSelector: map[string]string{v1alpha5.ProvisionerNameLabelKey: provisioner.Name}})
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
 			node := ExpectScheduled(ctx, env.Client, pod)
-			Expect(node.Labels[v1alpha5.ProvisionerNameLabelKey]).To(Equal(targetedProvisioner.Name))
+			Expect(node.Labels[v1alpha5.ProvisionerNameLabelKey]).To(Equal(provisioner.Name))
+		})
+		It("should schedule to a provisioner by labels", func() {
+			provisioner := test.Provisioner(test.ProvisionerOptions{Labels: map[string]string{"foo": "bar"}})
+			ExpectApplied(ctx, env.Client, provisioner, test.Provisioner())
+			pod := test.UnschedulablePod(test.PodOptions{NodeSelector: provisioner.Spec.Labels})
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+			node := ExpectScheduled(ctx, env.Client, pod)
+			Expect(node.Labels[v1alpha5.ProvisionerNameLabelKey]).To(Equal(provisioner.Name))
+		})
+		It("should not match provisioner with PreferNoSchedule taint when other provisioner match", func() {
+			provisioner := test.Provisioner(test.ProvisionerOptions{Taints: []v1.Taint{{Key: "foo", Value: "bar", Effect: v1.TaintEffectPreferNoSchedule}}})
+			ExpectApplied(ctx, env.Client, provisioner, test.Provisioner())
+			pod := test.UnschedulablePod()
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+			node := ExpectScheduled(ctx, env.Client, pod)
+			Expect(node.Labels[v1alpha5.ProvisionerNameLabelKey]).ToNot(Equal(provisioner.Name))
+		})
+		Context("Weighted Provisioners", func() {
+			It("should schedule to the provisioner with the highest priority always", func() {
+				provisioners := []client.Object{
+					test.Provisioner(),
+					test.Provisioner(test.ProvisionerOptions{Weight: ptr.Int32(20)}),
+					test.Provisioner(test.ProvisionerOptions{Weight: ptr.Int32(100)}),
+				}
+				ExpectApplied(ctx, env.Client, provisioners...)
+				pods := []*v1.Pod{
+					test.UnschedulablePod(), test.UnschedulablePod(), test.UnschedulablePod(),
+				}
+				ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pods...)
+				for _, pod := range pods {
+					node := ExpectScheduled(ctx, env.Client, pod)
+					Expect(node.Labels[v1alpha5.ProvisionerNameLabelKey]).To(Equal(provisioners[2].GetName()))
+				}
+			})
+			It("should schedule to explicitly selected provisioner even if other provisioners are higher priority", func() {
+				targetedProvisioner := test.Provisioner()
+				provisioners := []client.Object{
+					targetedProvisioner,
+					test.Provisioner(test.ProvisionerOptions{Weight: ptr.Int32(20)}),
+					test.Provisioner(test.ProvisionerOptions{Weight: ptr.Int32(100)}),
+				}
+				ExpectApplied(ctx, env.Client, provisioners...)
+				pod := test.UnschedulablePod(test.PodOptions{NodeSelector: map[string]string{v1alpha5.ProvisionerNameLabelKey: targetedProvisioner.Name}})
+				ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+				node := ExpectScheduled(ctx, env.Client, pod)
+				Expect(node.Labels[v1alpha5.ProvisionerNameLabelKey]).To(Equal(targetedProvisioner.Name))
+			})
 		})
 	})
 })

--- a/pkg/controllers/provisioning/scheduling/nodepool_test.go
+++ b/pkg/controllers/provisioning/scheduling/nodepool_test.go
@@ -1476,8 +1476,8 @@ var _ = Context("NodePool", func() {
 				}}
 
 			// Two large pods are all that will fit on the default-instance type (the largest instance type) which will create
-			// twenty nodes. This leaves just enough room on each of those newNodes for one additional small pod per node, so we
-			// should only end up with 20 newNodes total.
+			// twenty nodes. This leaves just enough room on each of those nodes for one additional small pod per node, so we
+			// should only end up with 20 nodes total.
 			provPods := append(test.Pods(40, largeOpts), test.Pods(20, smallOpts)...)
 			ExpectApplied(ctx, env.Client, nodePool)
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, provPods...)
@@ -1489,7 +1489,7 @@ var _ = Context("NodePool", func() {
 			}
 			Expect(nodeNames).To(HaveLen(20))
 		})
-		It("should pack newNodes tightly", func() {
+		It("should pack nodes tightly", func() {
 			cloudProvider.InstanceTypes = fake.InstanceTypes(5)
 			var nodes []*v1.Node
 			ExpectApplied(ctx, env.Client, nodePool)
@@ -1538,7 +1538,7 @@ var _ = Context("NodePool", func() {
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
 			ExpectNotScheduled(ctx, env.Client, pod)
 		})
-		It("should create new newNodes when a node is at capacity due to pod limits per node", func() {
+		It("should create new nodes when a node is at capacity due to pod limits per node", func() {
 			opts := test.PodOptions{
 				NodeSelector: map[string]string{v1.LabelArchStable: "amd64"},
 				Conditions:   []v1.PodCondition{{Type: v1.PodScheduled, Reason: v1.PodReasonUnschedulable, Status: v1.ConditionFalse}},
@@ -1800,7 +1800,7 @@ var _ = Context("NodePool", func() {
 			Expect(node1.Name).ToNot(Equal(node2.Name))
 		})
 		Context("Topology", func() {
-			It("should balance pods across zones with in-flight newNodes", func() {
+			It("should balance pods across zones with in-flight nodes", func() {
 				labels := map[string]string{"foo": "bar"}
 				topology := []v1.TopologySpreadConstraint{{
 					TopologyKey:       v1.LabelTopologyZone,
@@ -1814,7 +1814,7 @@ var _ = Context("NodePool", func() {
 				)
 				ExpectSkew(ctx, env.Client, "default", &topology[0]).To(ConsistOf(1, 1, 2))
 
-				// reconcile our newNodes with the cluster state so they'll show up as in-flight
+				// reconcile our nodes with the cluster state so they'll show up as in-flight
 				var nodeList v1.NodeList
 				Expect(env.Client.List(ctx, &nodeList)).To(Succeed())
 				for _, node := range nodeList.Items {
@@ -1828,10 +1828,10 @@ var _ = Context("NodePool", func() {
 				ExpectSkew(ctx, env.Client, "default", &topology[0]).To(ConsistOf(3, 3, 3))
 				Expect(env.Client.List(ctx, &nodeList)).To(Succeed())
 
-				// shouldn't create any new newNodes as the in-flight ones can support the pods
+				// shouldn't create any new nodes as the in-flight ones can support the pods
 				Expect(nodeList.Items).To(HaveLen(firstRoundNumNodes))
 			})
-			It("should balance pods across hostnames with in-flight newNodes", func() {
+			It("should balance pods across hostnames with in-flight nodes", func() {
 				labels := map[string]string{"foo": "bar"}
 				topology := []v1.TopologySpreadConstraint{{
 					TopologyKey:       v1.LabelHostname,
@@ -1845,7 +1845,7 @@ var _ = Context("NodePool", func() {
 				)
 				ExpectSkew(ctx, env.Client, "default", &topology[0]).To(ConsistOf(1, 1, 1, 1))
 
-				// reconcile our newNodes with the cluster state so they'll show up as in-flight
+				// reconcile our nodes with the cluster state so they'll show up as in-flight
 				var nodeList v1.NodeList
 				Expect(env.Client.List(ctx, &nodeList)).To(Succeed())
 				for _, node := range nodeList.Items {
@@ -1854,7 +1854,7 @@ var _ = Context("NodePool", func() {
 				ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov,
 					test.UnschedulablePods(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology}, 5)...,
 				)
-				// we prefer to launch new newNodes to satisfy the topology spread even though we could technically schedule against existingNodes
+				// we prefer to launch new nodes to satisfy the topology spread even though we could technically schedule against existingNodes
 				ExpectSkew(ctx, env.Client, "default", &topology[0]).To(ConsistOf(1, 1, 1, 1, 1, 1, 1, 1, 1))
 			})
 		})
@@ -2174,7 +2174,7 @@ var _ = Context("NodePool", func() {
 
 		})
 		// nolint:gosec
-		It("should pack in-flight newNodes before launching new newNodes", func() {
+		It("should pack in-flight nodes before launching new nodes", func() {
 			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{
 				fake.NewInstanceType(fake.InstanceTypeOptions{
 					Name: "medium",
@@ -2203,7 +2203,7 @@ var _ = Context("NodePool", func() {
 				}
 			}
 
-			// due to the in-flight node support, we should pack existing newNodes before launching new node. The end result
+			// due to the in-flight node support, we should pack existing nodes before launching new node. The end result
 			// is that we should only have some spare capacity on our final node
 			nodesWithCPUFree := 0
 			cluster.ForEachNode(func(n *state.StateNode) bool {
@@ -2456,7 +2456,7 @@ var _ = Context("NodePool", func() {
 	})
 
 	Describe("No Pre-Binding", func() {
-		It("should not bind pods to newNodes", func() {
+		It("should not bind pods to nodes", func() {
 			opts := test.PodOptions{ResourceRequirements: v1.ResourceRequirements{
 				Limits: map[v1.ResourceName]resource.Quantity{
 					v1.ResourceCPU: resource.MustParse("10m"),
@@ -2464,7 +2464,7 @@ var _ = Context("NodePool", func() {
 			}}
 
 			var nodeList v1.NodeList
-			// shouldn't have any newNodes
+			// shouldn't have any nodes
 			Expect(env.Client.List(ctx, &nodeList)).To(Succeed())
 			Expect(nodeList.Items).To(HaveLen(0))
 
@@ -2496,7 +2496,7 @@ var _ = Context("NodePool", func() {
 			}}
 
 			var nodeList v1.NodeList
-			// shouldn't have any newNodes
+			// shouldn't have any nodes
 			Expect(env.Client.List(ctx, &nodeList)).To(Succeed())
 			Expect(nodeList.Items).To(HaveLen(0))
 
@@ -2573,7 +2573,7 @@ var _ = Context("NodePool", func() {
 			}
 			nodePool.Spec.Limits = nil
 		})
-		It("should launch multiple newNodes if required due to volume limits", func() {
+		It("should launch multiple nodes if required due to volume limits", func() {
 			ExpectApplied(ctx, env.Client, nodePool)
 			initialPod := test.UnschedulablePod()
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, initialPod)

--- a/pkg/controllers/provisioning/scheduling/nodepool_topology_test.go
+++ b/pkg/controllers/provisioning/scheduling/nodepool_topology_test.go
@@ -2390,7 +2390,7 @@ var _ = Describe("Taints", func() {
 			},
 		})
 	})
-	It("should taint nodes with nodePool taints", func() {
+	It("should taint nodes with NodePool taints", func() {
 		nodePool.Spec.Template.Spec.Taints = []v1.Taint{{Key: "test", Value: "bar", Effect: v1.TaintEffectNoSchedule}}
 		ExpectApplied(ctx, env.Client, nodePool)
 		pod := test.UnschedulablePod(
@@ -2400,7 +2400,7 @@ var _ = Describe("Taints", func() {
 		node := ExpectScheduled(ctx, env.Client, pod)
 		Expect(node.Spec.Taints).To(ContainElement(nodePool.Spec.Template.Spec.Taints[0]))
 	})
-	It("should schedule pods that tolerate nodePool constraints", func() {
+	It("should schedule pods that tolerate NodePool constraints", func() {
 		nodePool.Spec.Template.Spec.Taints = []v1.Taint{{Key: "test-key", Value: "test-value", Effect: v1.TaintEffectNoSchedule}}
 		ExpectApplied(ctx, env.Client, nodePool)
 		pods := []*v1.Pod{

--- a/pkg/controllers/provisioning/scheduling/provisioner_test.go
+++ b/pkg/controllers/provisioning/scheduling/provisioner_test.go
@@ -1466,8 +1466,8 @@ var _ = Context("Provisioner", func() {
 				}}
 
 			// Two large pods are all that will fit on the default-instance type (the largest instance type) which will create
-			// twenty nodes. This leaves just enough room on each of those newNodes for one additional small pod per node, so we
-			// should only end up with 20 newNodes total.
+			// twenty nodes. This leaves just enough room on each of those nodes for one additional small pod per node, so we
+			// should only end up with 20 nodes total.
 			provPods := append(test.Pods(40, largeOpts), test.Pods(20, smallOpts)...)
 			ExpectApplied(ctx, env.Client, provisioner)
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, provPods...)
@@ -1479,7 +1479,7 @@ var _ = Context("Provisioner", func() {
 			}
 			Expect(nodeNames).To(HaveLen(20))
 		})
-		It("should pack newNodes tightly", func() {
+		It("should pack nodes tightly", func() {
 			cloudProvider.InstanceTypes = fake.InstanceTypes(5)
 			var nodes []*v1.Node
 			ExpectApplied(ctx, env.Client, provisioner)
@@ -1528,7 +1528,7 @@ var _ = Context("Provisioner", func() {
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
 			ExpectNotScheduled(ctx, env.Client, pod)
 		})
-		It("should create new newNodes when a node is at capacity due to pod limits per node", func() {
+		It("should create new nodes when a node is at capacity due to pod limits per node", func() {
 			opts := test.PodOptions{
 				NodeSelector: map[string]string{v1.LabelArchStable: "amd64"},
 				Conditions:   []v1.PodCondition{{Type: v1.PodScheduled, Reason: v1.PodReasonUnschedulable, Status: v1.ConditionFalse}},
@@ -1790,7 +1790,7 @@ var _ = Context("Provisioner", func() {
 			Expect(node1.Name).ToNot(Equal(node2.Name))
 		})
 		Context("Topology", func() {
-			It("should balance pods across zones with in-flight newNodes", func() {
+			It("should balance pods across zones with in-flight nodes", func() {
 				labels := map[string]string{"foo": "bar"}
 				topology := []v1.TopologySpreadConstraint{{
 					TopologyKey:       v1.LabelTopologyZone,
@@ -1804,7 +1804,7 @@ var _ = Context("Provisioner", func() {
 				)
 				ExpectSkew(ctx, env.Client, "default", &topology[0]).To(ConsistOf(1, 1, 2))
 
-				// reconcile our newNodes with the cluster state so they'll show up as in-flight
+				// reconcile our nodes with the cluster state so they'll show up as in-flight
 				var nodeList v1.NodeList
 				Expect(env.Client.List(ctx, &nodeList)).To(Succeed())
 				for _, node := range nodeList.Items {
@@ -1818,10 +1818,10 @@ var _ = Context("Provisioner", func() {
 				ExpectSkew(ctx, env.Client, "default", &topology[0]).To(ConsistOf(3, 3, 3))
 				Expect(env.Client.List(ctx, &nodeList)).To(Succeed())
 
-				// shouldn't create any new newNodes as the in-flight ones can support the pods
+				// shouldn't create any new nodes as the in-flight ones can support the pods
 				Expect(nodeList.Items).To(HaveLen(firstRoundNumNodes))
 			})
-			It("should balance pods across hostnames with in-flight newNodes", func() {
+			It("should balance pods across hostnames with in-flight nodes", func() {
 				labels := map[string]string{"foo": "bar"}
 				topology := []v1.TopologySpreadConstraint{{
 					TopologyKey:       v1.LabelHostname,
@@ -1835,7 +1835,7 @@ var _ = Context("Provisioner", func() {
 				)
 				ExpectSkew(ctx, env.Client, "default", &topology[0]).To(ConsistOf(1, 1, 1, 1))
 
-				// reconcile our newNodes with the cluster state so they'll show up as in-flight
+				// reconcile our nodes with the cluster state so they'll show up as in-flight
 				var nodeList v1.NodeList
 				Expect(env.Client.List(ctx, &nodeList)).To(Succeed())
 				for _, node := range nodeList.Items {
@@ -1844,7 +1844,7 @@ var _ = Context("Provisioner", func() {
 				ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov,
 					test.UnschedulablePods(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology}, 5)...,
 				)
-				// we prefer to launch new newNodes to satisfy the topology spread even though we could technically schedule against existingNodes
+				// we prefer to launch new nodes to satisfy the topology spread even though we could technically schedule against existingNodes
 				ExpectSkew(ctx, env.Client, "default", &topology[0]).To(ConsistOf(1, 1, 1, 1, 1, 1, 1, 1, 1))
 			})
 		})
@@ -2161,10 +2161,9 @@ var _ = Context("Provisioner", func() {
 				// must create a new node
 				Expect(node1.Name).ToNot(Equal(node2.Name))
 			})
-
 		})
 		// nolint:gosec
-		It("should pack in-flight newNodes before launching new newNodes", func() {
+		It("should pack in-flight nodes before launching new nodes", func() {
 			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{
 				fake.NewInstanceType(fake.InstanceTypeOptions{
 					Name: "medium",
@@ -2193,7 +2192,7 @@ var _ = Context("Provisioner", func() {
 				}
 			}
 
-			// due to the in-flight node support, we should pack existing newNodes before launching new node. The end result
+			// due to the in-flight node support, we should pack existing nodes before launching new node. The end result
 			// is that we should only have some spare capacity on our final node
 			nodesWithCPUFree := 0
 			cluster.ForEachNode(func(n *state.StateNode) bool {
@@ -2452,7 +2451,7 @@ var _ = Context("Provisioner", func() {
 	})
 
 	Describe("No Pre-Binding", func() {
-		It("should not bind pods to newNodes", func() {
+		It("should not bind pods to nodes", func() {
 			opts := test.PodOptions{ResourceRequirements: v1.ResourceRequirements{
 				Limits: map[v1.ResourceName]resource.Quantity{
 					v1.ResourceCPU: resource.MustParse("10m"),
@@ -2460,7 +2459,7 @@ var _ = Context("Provisioner", func() {
 			}}
 
 			var nodeList v1.NodeList
-			// shouldn't have any newNodes
+			// shouldn't have any nodes
 			Expect(env.Client.List(ctx, &nodeList)).To(Succeed())
 			Expect(nodeList.Items).To(HaveLen(0))
 
@@ -2492,7 +2491,7 @@ var _ = Context("Provisioner", func() {
 			}}
 
 			var nodeList v1.NodeList
-			// shouldn't have any newNodes
+			// shouldn't have any nodes
 			Expect(env.Client.List(ctx, &nodeList)).To(Succeed())
 			Expect(nodeList.Items).To(HaveLen(0))
 
@@ -2569,7 +2568,7 @@ var _ = Context("Provisioner", func() {
 			}
 			provisioner.Spec.Limits = nil
 		})
-		It("should launch multiple newNodes if required due to volume limits", func() {
+		It("should launch multiple nodes if required due to volume limits", func() {
 			ExpectApplied(ctx, env.Client, provisioner)
 			initialPod := test.UnschedulablePod()
 			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, initialPod)

--- a/pkg/controllers/provisioning/scheduling/provisioner_topology_test.go
+++ b/pkg/controllers/provisioning/scheduling/provisioner_topology_test.go
@@ -128,7 +128,7 @@ var _ = Describe("Topology", func() {
 			)
 			ExpectSkew(ctx, env.Client, "default", &topology[0]).To(ConsistOf(1, 1, 2))
 		})
-		It("should respect provisioner zonal constraints (subset)", func() {
+		It("should respect provisioner zonal constraints (subset) with requirements", func() {
 			provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
 				{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-1", "test-zone-2"}}}
 			topology := []v1.TopologySpreadConstraint{{

--- a/pkg/controllers/provisioning/suite_test.go
+++ b/pkg/controllers/provisioning/suite_test.go
@@ -16,6 +16,7 @@ package provisioning_test
 
 import (
 	"context"
+	"math/rand"
 	"testing"
 	"time"
 
@@ -23,6 +24,8 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/record"
@@ -31,6 +34,7 @@ import (
 
 	"github.com/aws/karpenter-core/pkg/apis"
 	"github.com/aws/karpenter-core/pkg/apis/settings"
+	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
 	"github.com/aws/karpenter-core/pkg/cloudprovider/fake"
@@ -87,7 +91,575 @@ var _ = AfterSuite(func() {
 
 var _ = AfterEach(func() {
 	ExpectCleanedUp(ctx, env.Client)
+	cloudProvider.Reset()
 	cluster.Reset()
+})
+
+var _ = Describe("Combined/Provisioning", func() {
+	var provisioner *v1alpha5.Provisioner
+	var nodePool *v1beta1.NodePool
+	BeforeEach(func() {
+		provisioner = test.Provisioner()
+		nodePool = test.NodePool()
+	})
+	It("should schedule pods using owner label selectors", func() {
+		ExpectApplied(ctx, env.Client, nodePool, provisioner)
+
+		provisionerPod := test.UnschedulablePod(test.PodOptions{
+			NodeSelector: map[string]string{
+				v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
+			},
+		})
+		nodePoolPod := test.UnschedulablePod(test.PodOptions{
+			NodeSelector: map[string]string{
+				v1beta1.NodePoolLabelKey: nodePool.Name,
+			},
+		})
+		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, provisionerPod, nodePoolPod)
+		node := ExpectScheduled(ctx, env.Client, provisionerPod)
+		Expect(node.Labels).To(HaveKeyWithValue(v1alpha5.ProvisionerNameLabelKey, provisioner.Name))
+		node = ExpectScheduled(ctx, env.Client, nodePoolPod)
+		Expect(node.Labels).To(HaveKeyWithValue(v1beta1.NodePoolLabelKey, nodePool.Name))
+	})
+	It("should schedule pods using custom labels", func() {
+		provisioner.Spec.Labels = map[string]string{
+			"provisioner": "true",
+		}
+		nodePool.Spec.Template.Labels = map[string]string{
+			"nodepool": "true",
+		}
+		ExpectApplied(ctx, env.Client, nodePool, provisioner)
+
+		provisionerPod := test.UnschedulablePod(test.PodOptions{
+			NodeSelector: map[string]string{
+				"provisioner": "true",
+			},
+		})
+		nodePoolPod := test.UnschedulablePod(test.PodOptions{
+			NodeSelector: map[string]string{
+				"nodepool": "true",
+			},
+		})
+
+		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, provisionerPod, nodePoolPod)
+		node := ExpectScheduled(ctx, env.Client, provisionerPod)
+		Expect(node.Labels).To(HaveKeyWithValue(v1alpha5.ProvisionerNameLabelKey, provisioner.Name))
+		node = ExpectScheduled(ctx, env.Client, nodePoolPod)
+		Expect(node.Labels).To(HaveKeyWithValue(v1beta1.NodePoolLabelKey, nodePool.Name))
+	})
+	It("should schedule pods using custom requirements", func() {
+		provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
+			{
+				Key:      "provisioner",
+				Operator: v1.NodeSelectorOpIn,
+				Values:   []string{"true"},
+			},
+		}
+		nodePool.Spec.Template.Spec.Requirements = []v1.NodeSelectorRequirement{
+			{
+				Key:      "nodepool",
+				Operator: v1.NodeSelectorOpIn,
+				Values:   []string{"true"},
+			},
+		}
+		ExpectApplied(ctx, env.Client, nodePool, provisioner)
+
+		provisionerPod := test.UnschedulablePod(test.PodOptions{
+			NodeSelector: map[string]string{
+				"provisioner": "true",
+			},
+		})
+		nodePoolPod := test.UnschedulablePod(test.PodOptions{
+			NodeSelector: map[string]string{
+				"nodepool": "true",
+			},
+		})
+
+		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, provisionerPod, nodePoolPod)
+		node := ExpectScheduled(ctx, env.Client, provisionerPod)
+		Expect(node.Labels).To(HaveKeyWithValue(v1alpha5.ProvisionerNameLabelKey, provisioner.Name))
+		node = ExpectScheduled(ctx, env.Client, nodePoolPod)
+		Expect(node.Labels).To(HaveKeyWithValue(v1beta1.NodePoolLabelKey, nodePool.Name))
+	})
+	It("should schedule pods using taints", func() {
+		provisioner.Spec.Taints = append(provisioner.Spec.Taints, v1.Taint{
+			Key:    "only-provisioner",
+			Value:  "true",
+			Effect: v1.TaintEffectNoSchedule,
+		})
+		nodePool.Spec.Template.Spec.Taints = append(nodePool.Spec.Template.Spec.Taints, v1.Taint{
+			Key:    "only-nodepool",
+			Value:  "true",
+			Effect: v1.TaintEffectNoSchedule,
+		})
+		ExpectApplied(ctx, env.Client, provisioner, nodePool)
+
+		provisionerPod := test.UnschedulablePod(test.PodOptions{
+			Tolerations: []v1.Toleration{
+				{
+					Key:      "only-provisioner",
+					Operator: v1.TolerationOpExists,
+				},
+			},
+		})
+		nodePoolPod := test.UnschedulablePod(test.PodOptions{
+			Tolerations: []v1.Toleration{
+				{
+					Key:      "only-nodepool",
+					Operator: v1.TolerationOpExists,
+				},
+			},
+		})
+		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, provisionerPod, nodePoolPod)
+		node := ExpectScheduled(ctx, env.Client, provisionerPod)
+		Expect(node.Labels).To(HaveKeyWithValue(v1alpha5.ProvisionerNameLabelKey, provisioner.Name))
+		node = ExpectScheduled(ctx, env.Client, nodePoolPod)
+		Expect(node.Labels).To(HaveKeyWithValue(v1beta1.NodePoolLabelKey, nodePool.Name))
+	})
+	It("should order the NodePools and Provisioner by weight", func() {
+		var provisioners []*v1alpha5.Provisioner
+		var nodePools []*v1beta1.NodePool
+		weights := lo.Reject(rand.Perm(101), func(i int, _ int) bool { return i == 0 })
+		for i := 0; i < 10; i++ {
+			p := test.Provisioner(test.ProvisionerOptions{
+				Weight: lo.ToPtr[int32](int32(weights[i])),
+			})
+			provisioners = append(provisioners, p)
+			ExpectApplied(ctx, env.Client, p)
+		}
+		for i := 0; i < 10; i++ {
+			np := test.NodePool(v1beta1.NodePool{
+				Spec: v1beta1.NodePoolSpec{
+					Weight: lo.ToPtr[int32](int32(weights[i+10])),
+				},
+			})
+			nodePools = append(nodePools, np)
+			ExpectApplied(ctx, env.Client, np)
+		}
+		highestWeightProvisioner := lo.MaxBy(provisioners, func(a, b *v1alpha5.Provisioner) bool {
+			return lo.FromPtr(a.Spec.Weight) > lo.FromPtr(b.Spec.Weight)
+		})
+		highestWeightNodePool := lo.MaxBy(nodePools, func(a, b *v1beta1.NodePool) bool {
+			return lo.FromPtr(a.Spec.Weight) > lo.FromPtr(b.Spec.Weight)
+		})
+
+		pod := test.UnschedulablePod()
+		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+		node := ExpectScheduled(ctx, env.Client, pod)
+
+		if lo.FromPtr(highestWeightProvisioner.Spec.Weight) > lo.FromPtr(highestWeightNodePool.Spec.Weight) {
+			Expect(node.Labels).To(HaveKeyWithValue(v1alpha5.ProvisionerNameLabelKey, highestWeightProvisioner.Name))
+		} else {
+			Expect(node.Labels).To(HaveKeyWithValue(v1beta1.NodePoolLabelKey, highestWeightNodePool.Name))
+		}
+	})
+	Context("Limits", func() {
+		It("should select a NodePool if a Provisioner is over its limit", func() {
+			provisioner.Spec.Limits = &v1alpha5.Limits{Resources: v1.ResourceList{v1.ResourceCPU: resource.MustParse("0")}}
+			ExpectApplied(ctx, env.Client, provisioner, nodePool)
+
+			pod := test.UnschedulablePod()
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+			node := ExpectScheduled(ctx, env.Client, pod)
+			Expect(node.Labels).To(HaveKeyWithValue(v1beta1.NodePoolLabelKey, nodePool.Name))
+		})
+		It("should select a Provisioner if a NodePool is over its limit", func() {
+			nodePool.Spec.Limits = v1beta1.Limits(v1.ResourceList{v1.ResourceCPU: resource.MustParse("0")})
+			ExpectApplied(ctx, env.Client, provisioner, nodePool)
+
+			pod := test.UnschedulablePod()
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+			node := ExpectScheduled(ctx, env.Client, pod)
+			Expect(node.Labels).To(HaveKeyWithValue(v1alpha5.ProvisionerNameLabelKey, provisioner.Name))
+		})
+	})
+	Context("Deleting", func() {
+		It("should select a NodePool if a Provisioner is deleting", func() {
+			ExpectApplied(ctx, env.Client, nodePool, provisioner)
+			ExpectDeletionTimestampSet(ctx, env.Client, provisioner)
+			pod := test.UnschedulablePod()
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+			node := ExpectScheduled(ctx, env.Client, pod)
+			Expect(node.Labels).To(HaveKeyWithValue(v1beta1.NodePoolLabelKey, nodePool.Name))
+		})
+		It("should select a Provisioner if a NodePool is deleting", func() {
+			ExpectApplied(ctx, env.Client, nodePool, provisioner)
+			ExpectDeletionTimestampSet(ctx, env.Client, nodePool)
+			pod := test.UnschedulablePod()
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+			node := ExpectScheduled(ctx, env.Client, pod)
+			Expect(node.Labels).To(HaveKeyWithValue(v1alpha5.ProvisionerNameLabelKey, provisioner.Name))
+		})
+	})
+	Context("Daemonsets", func() {
+		It("should select a NodePool if Daemonsets that would schedule to Provisioner would exceed capacity", func() {
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{
+				fake.NewInstanceType(fake.InstanceTypeOptions{
+					Name: "provisioner-instance-type",
+					Resources: map[v1.ResourceName]resource.Quantity{
+						v1.ResourceCPU:    resource.MustParse("2"),
+						v1.ResourceMemory: resource.MustParse("2Gi"),
+					},
+				}),
+				fake.NewInstanceType(fake.InstanceTypeOptions{
+					Name: "nodepool-instance-type",
+					Resources: map[v1.ResourceName]resource.Quantity{
+						v1.ResourceCPU:    resource.MustParse("4"),
+						v1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+				}),
+			}
+			provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
+				{
+					Key:      v1.LabelInstanceType,
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"provisioner-instance-type"},
+				},
+			}
+			nodePool.Spec.Template.Spec.Requirements = []v1.NodeSelectorRequirement{
+				{
+					Key:      v1.LabelInstanceType,
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"nodepool-instance-type"},
+				},
+			}
+			daemonSet := test.DaemonSet(
+				test.DaemonSetOptions{PodOptions: test.PodOptions{
+					ResourceRequirements: v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("2"), v1.ResourceMemory: resource.MustParse("2Gi")}},
+				}},
+			)
+			ExpectApplied(ctx, env.Client, nodePool, provisioner, daemonSet)
+
+			pod := test.UnschedulablePod(test.PodOptions{
+				ResourceRequirements: v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1"), v1.ResourceMemory: resource.MustParse("1Gi")}},
+			})
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+			node := ExpectScheduled(ctx, env.Client, pod)
+			Expect(node.Labels).To(HaveKeyWithValue(v1beta1.NodePoolLabelKey, nodePool.Name))
+		})
+		It("should select a Provisioner if Daemonsets that would schedule to NodePool would exceed capacity", func() {
+			cloudProvider.InstanceTypes = []*cloudprovider.InstanceType{
+				fake.NewInstanceType(fake.InstanceTypeOptions{
+					Name: "provisioner-instance-type",
+					Resources: map[v1.ResourceName]resource.Quantity{
+						v1.ResourceCPU:    resource.MustParse("4"),
+						v1.ResourceMemory: resource.MustParse("4Gi"),
+					},
+				}),
+				fake.NewInstanceType(fake.InstanceTypeOptions{
+					Name: "nodepool-instance-type",
+					Resources: map[v1.ResourceName]resource.Quantity{
+						v1.ResourceCPU:    resource.MustParse("2"),
+						v1.ResourceMemory: resource.MustParse("2Gi"),
+					},
+				}),
+			}
+			provisioner.Spec.Requirements = []v1.NodeSelectorRequirement{
+				{
+					Key:      v1.LabelInstanceType,
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"provisioner-instance-type"},
+				},
+			}
+			nodePool.Spec.Template.Spec.Requirements = []v1.NodeSelectorRequirement{
+				{
+					Key:      v1.LabelInstanceType,
+					Operator: v1.NodeSelectorOpIn,
+					Values:   []string{"nodepool-instance-type"},
+				},
+			}
+			daemonSet := test.DaemonSet(
+				test.DaemonSetOptions{PodOptions: test.PodOptions{
+					ResourceRequirements: v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("2"), v1.ResourceMemory: resource.MustParse("2Gi")}},
+				}},
+			)
+			ExpectApplied(ctx, env.Client, nodePool, provisioner, daemonSet)
+
+			pod := test.UnschedulablePod(test.PodOptions{
+				ResourceRequirements: v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1"), v1.ResourceMemory: resource.MustParse("1Gi")}},
+			})
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+			node := ExpectScheduled(ctx, env.Client, pod)
+			Expect(node.Labels).To(HaveKeyWithValue(v1alpha5.ProvisionerNameLabelKey, provisioner.Name))
+		})
+		It("should select a NodePool if Daemonset select against a Provisioner and would cause the Provisioner to exceed capacity", func() {
+			provisioner.Spec.Labels = lo.Assign(provisioner.Spec.Labels, map[string]string{"scheduleme": "true"})
+			nodePool.Spec.Template.Labels = lo.Assign(nodePool.Spec.Template.Labels, map[string]string{"scheduleme": "false"})
+
+			daemonSet := test.DaemonSet(
+				test.DaemonSetOptions{PodOptions: test.PodOptions{
+					NodeRequirements: []v1.NodeSelectorRequirement{
+						{
+							Key:      "scheduleme",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"true"},
+						},
+					},
+					ResourceRequirements: v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("10000"), v1.ResourceMemory: resource.MustParse("10000Gi")}},
+				}},
+			)
+			ExpectApplied(ctx, env.Client, nodePool, provisioner, daemonSet)
+
+			pod := test.UnschedulablePod(test.PodOptions{
+				ResourceRequirements: v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1"), v1.ResourceMemory: resource.MustParse("1Gi")}},
+			})
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+			node := ExpectScheduled(ctx, env.Client, pod)
+			Expect(node.Labels).To(HaveKeyWithValue(v1beta1.NodePoolLabelKey, nodePool.Name))
+		})
+		It("should select a Provisioner if Daemonset select against a NodePool and would cause the NodePool to exceed capacity", func() {
+			provisioner.Spec.Labels = lo.Assign(provisioner.Spec.Labels, map[string]string{"scheduleme": "false"})
+			nodePool.Spec.Template.Labels = lo.Assign(nodePool.Spec.Template.Labels, map[string]string{"scheduleme": "true"})
+
+			daemonSet := test.DaemonSet(
+				test.DaemonSetOptions{PodOptions: test.PodOptions{
+					NodeRequirements: []v1.NodeSelectorRequirement{
+						{
+							Key:      "scheduleme",
+							Operator: v1.NodeSelectorOpIn,
+							Values:   []string{"true"},
+						},
+					},
+					ResourceRequirements: v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("10000"), v1.ResourceMemory: resource.MustParse("10000Gi")}},
+				}},
+			)
+			ExpectApplied(ctx, env.Client, nodePool, provisioner, daemonSet)
+
+			pod := test.UnschedulablePod(test.PodOptions{
+				ResourceRequirements: v1.ResourceRequirements{Requests: v1.ResourceList{v1.ResourceCPU: resource.MustParse("1"), v1.ResourceMemory: resource.MustParse("1Gi")}},
+			})
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+			node := ExpectScheduled(ctx, env.Client, pod)
+			Expect(node.Labels).To(HaveKeyWithValue(v1alpha5.ProvisionerNameLabelKey, provisioner.Name))
+		})
+	})
+	Context("Preferential Fallback", func() {
+		It("should fallback from a NodePool to a Provisioner when preferences can't be satisfied against the NodePool", func() {
+			provisioner.Spec.Labels = lo.Assign(provisioner.Spec.Labels, map[string]string{
+				"foo": "true",
+			})
+			ExpectApplied(ctx, env.Client, nodePool, provisioner)
+
+			pod := test.UnschedulablePod()
+			pod.Spec.Affinity = &v1.Affinity{NodeAffinity: &v1.NodeAffinity{PreferredDuringSchedulingIgnoredDuringExecution: []v1.PreferredSchedulingTerm{
+				{
+					Weight: 1, Preference: v1.NodeSelectorTerm{MatchExpressions: []v1.NodeSelectorRequirement{
+						{Key: "foo", Operator: v1.NodeSelectorOpIn, Values: []string{"true"}},
+					}},
+				},
+				{
+					Weight: 1, Preference: v1.NodeSelectorTerm{MatchExpressions: []v1.NodeSelectorRequirement{
+						{Key: "bar", Operator: v1.NodeSelectorOpIn, Values: []string{"true"}},
+					}},
+				},
+			}}}
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+			node := ExpectScheduled(ctx, env.Client, pod)
+			Expect(node.Labels).To(HaveKeyWithValue(v1alpha5.ProvisionerNameLabelKey, provisioner.Name))
+		})
+		It("should fallback from a Provisioner to a NodePool when preferences can't be satisfied against the Provisioner", func() {
+			nodePool.Spec.Template.Labels = lo.Assign(nodePool.Spec.Template.Labels, map[string]string{
+				"foo": "true",
+			})
+			ExpectApplied(ctx, env.Client, nodePool, provisioner)
+
+			pod := test.UnschedulablePod()
+			pod.Spec.Affinity = &v1.Affinity{NodeAffinity: &v1.NodeAffinity{PreferredDuringSchedulingIgnoredDuringExecution: []v1.PreferredSchedulingTerm{
+				{
+					Weight: 1, Preference: v1.NodeSelectorTerm{MatchExpressions: []v1.NodeSelectorRequirement{
+						{Key: "foo", Operator: v1.NodeSelectorOpIn, Values: []string{"true"}},
+					}},
+				},
+				{
+					Weight: 1, Preference: v1.NodeSelectorTerm{MatchExpressions: []v1.NodeSelectorRequirement{
+						{Key: "bar", Operator: v1.NodeSelectorOpIn, Values: []string{"true"}},
+					}},
+				},
+			}}}
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, pod)
+			node := ExpectScheduled(ctx, env.Client, pod)
+			Expect(node.Labels).To(HaveKeyWithValue(v1beta1.NodePoolLabelKey, nodePool.Name))
+		})
+	})
+	Context("Topology", func() {
+		var labels map[string]string
+		BeforeEach(func() {
+			labels = map[string]string{"test": "test"}
+		})
+		It("should spread across Provisioners and NodePools when considering zonal topology", func() {
+			topology := []v1.TopologySpreadConstraint{{
+				TopologyKey:       v1.LabelTopologyZone,
+				WhenUnsatisfiable: v1.DoNotSchedule,
+				LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
+				MaxSkew:           1,
+			}}
+
+			testZone1Provisioner := test.Provisioner(test.ProvisionerOptions{
+				Labels: map[string]string{
+					v1.LabelTopologyZone: "test-zone-1",
+				},
+			})
+			testZone2NodePool := test.NodePool(v1beta1.NodePool{
+				Spec: v1beta1.NodePoolSpec{
+					Template: v1beta1.NodeClaimTemplate{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								v1.LabelTopologyZone: "test-zone-2",
+							},
+						},
+					},
+				},
+			})
+			testZone3Provisioner := test.Provisioner(test.ProvisionerOptions{
+				Labels: map[string]string{
+					v1.LabelTopologyZone: "test-zone-3",
+				},
+			})
+			ExpectApplied(ctx, env.Client, testZone1Provisioner, testZone2NodePool, testZone3Provisioner)
+
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov,
+				test.UnschedulablePods(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology}, 4)...,
+			)
+			ExpectSkew(ctx, env.Client, "default", &topology[0]).To(ConsistOf(1, 1, 2))
+
+			// Expect that among the nodes that have skew that we have deployed nodes across Provisioners and NodePools
+			nodes := ExpectNodes(ctx, env.Client)
+			_, ok := lo.Find(nodes, func(n *v1.Node) bool { return n.Labels[v1alpha5.ProvisionerNameLabelKey] == testZone1Provisioner.Name })
+			Expect(ok).To(BeTrue())
+			_, ok = lo.Find(nodes, func(n *v1.Node) bool { return n.Labels[v1beta1.NodePoolLabelKey] == testZone2NodePool.Name })
+			Expect(ok).To(BeTrue())
+			_, ok = lo.Find(nodes, func(n *v1.Node) bool { return n.Labels[v1alpha5.ProvisionerNameLabelKey] == testZone3Provisioner.Name })
+			Expect(ok).To(BeTrue())
+		})
+		It("should spread across Provisioners and NodePools and respect zonal constraints (subset) with requirements", func() {
+			topology := []v1.TopologySpreadConstraint{{
+				TopologyKey:       v1.LabelTopologyZone,
+				WhenUnsatisfiable: v1.DoNotSchedule,
+				LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
+				MaxSkew:           1,
+			}}
+
+			testZone1Provisioner := test.Provisioner(test.ProvisionerOptions{
+				Requirements: []v1.NodeSelectorRequirement{
+					{
+						Key:      v1.LabelTopologyZone,
+						Operator: v1.NodeSelectorOpIn,
+						Values:   []string{"test-zone-1"},
+					},
+				},
+			})
+			testZone2NodePool := test.NodePool(v1beta1.NodePool{
+				Spec: v1beta1.NodePoolSpec{
+					Template: v1beta1.NodeClaimTemplate{
+						Spec: v1beta1.NodeClaimSpec{
+							Requirements: []v1.NodeSelectorRequirement{
+								{
+									Key:      v1.LabelTopologyZone,
+									Operator: v1.NodeSelectorOpIn,
+									Values:   []string{"test-zone-2"},
+								},
+							},
+						},
+					},
+				},
+			})
+			ExpectApplied(ctx, env.Client, testZone1Provisioner, testZone2NodePool)
+
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov,
+				test.UnschedulablePods(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology}, 4)...,
+			)
+			ExpectSkew(ctx, env.Client, "default", &topology[0]).To(ConsistOf(2, 2))
+
+			// Expect that among the nodes that have skew that we have deployed nodes across Provisioners and NodePools
+			nodes := ExpectNodes(ctx, env.Client)
+			_, ok := lo.Find(nodes, func(n *v1.Node) bool { return n.Labels[v1alpha5.ProvisionerNameLabelKey] == testZone1Provisioner.Name })
+			Expect(ok).To(BeTrue())
+			_, ok = lo.Find(nodes, func(n *v1.Node) bool { return n.Labels[v1beta1.NodePoolLabelKey] == testZone2NodePool.Name })
+			Expect(ok).To(BeTrue())
+		})
+		It("should spread across Provisioners and NodePools and respect zonal constraints (subset) with labels", func() {
+			topology := []v1.TopologySpreadConstraint{{
+				TopologyKey:       v1.LabelTopologyZone,
+				WhenUnsatisfiable: v1.DoNotSchedule,
+				LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
+				MaxSkew:           1,
+			}}
+
+			testZone1Provisioner := test.Provisioner(test.ProvisionerOptions{
+				Labels: map[string]string{
+					v1.LabelTopologyZone: "test-zone-1",
+				},
+			})
+			testZone2NodePool := test.NodePool(v1beta1.NodePool{
+				Spec: v1beta1.NodePoolSpec{
+					Template: v1beta1.NodeClaimTemplate{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: map[string]string{
+								v1.LabelTopologyZone: "test-zone-2",
+							},
+						},
+					},
+				},
+			})
+			ExpectApplied(ctx, env.Client, testZone1Provisioner, testZone2NodePool)
+
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov,
+				test.UnschedulablePods(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology}, 4)...,
+			)
+			ExpectSkew(ctx, env.Client, "default", &topology[0]).To(ConsistOf(2, 2))
+
+			// Expect that among the nodes that have skew that we have deployed nodes across Provisioners and NodePools
+			nodes := ExpectNodes(ctx, env.Client)
+			_, ok := lo.Find(nodes, func(n *v1.Node) bool { return n.Labels[v1alpha5.ProvisionerNameLabelKey] == testZone1Provisioner.Name })
+			Expect(ok).To(BeTrue())
+			_, ok = lo.Find(nodes, func(n *v1.Node) bool { return n.Labels[v1beta1.NodePoolLabelKey] == testZone2NodePool.Name })
+			Expect(ok).To(BeTrue())
+		})
+		It("should spread across Provisioners and NodePools when considering capacity type", func() {
+			topology := []v1.TopologySpreadConstraint{{
+				TopologyKey:       v1beta1.CapacityTypeLabelKey,
+				WhenUnsatisfiable: v1.DoNotSchedule,
+				LabelSelector:     &metav1.LabelSelector{MatchLabels: labels},
+				MaxSkew:           1,
+			}}
+			onDemandProvisioner := test.Provisioner(test.ProvisionerOptions{
+				Requirements: []v1.NodeSelectorRequirement{
+					{
+						Key:      v1alpha5.LabelCapacityType,
+						Operator: v1.NodeSelectorOpIn,
+						Values:   []string{v1alpha5.CapacityTypeOnDemand},
+					},
+				},
+			})
+			spotNodePool := test.NodePool(v1beta1.NodePool{
+				Spec: v1beta1.NodePoolSpec{
+					Template: v1beta1.NodeClaimTemplate{
+						Spec: v1beta1.NodeClaimSpec{
+							Requirements: []v1.NodeSelectorRequirement{
+								{
+									Key:      v1beta1.CapacityTypeLabelKey,
+									Operator: v1.NodeSelectorOpIn,
+									Values:   []string{v1beta1.CapacityTypeSpot},
+								},
+							},
+						},
+					},
+				},
+			})
+			ExpectApplied(ctx, env.Client, onDemandProvisioner, spotNodePool)
+			ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov,
+				test.UnschedulablePods(test.PodOptions{ObjectMeta: metav1.ObjectMeta{Labels: labels}, TopologySpreadConstraints: topology}, 4)...,
+			)
+			ExpectSkew(ctx, env.Client, "default", &topology[0]).To(ConsistOf(2, 2))
+
+			// Expect that among the nodes that have skew that we have deployed nodes across Provisioners and NodePools
+			nodes := ExpectNodes(ctx, env.Client)
+			_, ok := lo.Find(nodes, func(n *v1.Node) bool { return n.Labels[v1alpha5.ProvisionerNameLabelKey] == onDemandProvisioner.Name })
+			Expect(ok).To(BeTrue())
+			_, ok = lo.Find(nodes, func(n *v1.Node) bool { return n.Labels[v1beta1.NodePoolLabelKey] == spotNodePool.Name })
+			Expect(ok).To(BeTrue())
+		})
+	})
 })
 
 func ExpectNodeClaimRequirements(nodeClaim *v1beta1.NodeClaim, requirements ...v1.NodeSelectorRequirement) {

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -563,10 +563,11 @@ func ExpectManualBindingWithOffset(offset int, ctx context.Context, c client.Cli
 }
 
 func ExpectSkew(ctx context.Context, c client.Client, namespace string, constraint *v1.TopologySpreadConstraint) Assertion {
+	GinkgoHelper()
 	nodes := &v1.NodeList{}
-	ExpectWithOffset(1, c.List(ctx, nodes)).To(Succeed())
+	Expect(c.List(ctx, nodes)).To(Succeed())
 	pods := &v1.PodList{}
-	ExpectWithOffset(1, c.List(ctx, pods, scheduling.TopologyListOptions(namespace, constraint.LabelSelector))).To(Succeed())
+	Expect(c.List(ctx, pods, scheduling.TopologyListOptions(namespace, constraint.LabelSelector))).To(Succeed())
 	skew := map[string]int{}
 	for i, pod := range pods.Items {
 		if scheduling.IgnoredForTopology(&pods.Items[i]) {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR adds provisioning testing for validating that scheduling and provisioning together with `v1alpha5/Provisioner` and `v1beta1/NodePool` and that the scheduling logic won't consider them as separate entities but will consider all possibilities when scheduling pods to nodes.

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
