### PR TITLE
chore: Enable configuring logger through volume mount and environment variable

### DIFF
--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -17,11 +17,16 @@ package options
 import (
 	"errors"
 	"flag"
+	"log"
 	"os"
 	"runtime/debug"
 
+	"github.com/samber/lo"
+
 	"github.com/aws/karpenter-core/pkg/utils/env"
 )
+
+var validLogLevels = []string{"", "debug", "info", "error"}
 
 // Options for running this binary
 type Options struct {
@@ -38,6 +43,7 @@ type Options struct {
 	EnableProfiling      bool
 	EnableLeaderElection bool
 	MemoryLimit          int64
+	LogLevel             string
 }
 
 // New creates an Options struct and registers CLI flags and environment variables to fill-in the Options struct fields
@@ -58,10 +64,14 @@ func New() *Options {
 	f.BoolVar(&opts.EnableProfiling, "enable-profiling", env.WithDefaultBool("ENABLE_PROFILING", false), "Enable the profiling on the metric endpoint")
 	f.BoolVar(&opts.EnableLeaderElection, "leader-elect", env.WithDefaultBool("LEADER_ELECT", true), "Start leader election client and gain leadership before executing the main loop. Enable this when running replicated components for high availability.")
 	f.Int64Var(&opts.MemoryLimit, "memory-limit", env.WithDefaultInt64("MEMORY_LIMIT", -1), "Memory limit on the container running the controller. The GC soft memory limit is set to 90% of this value.")
+	f.StringVar(&opts.LogLevel, "log-level", env.WithDefaultString("LOG_LEVEL", ""), "Log verbosity level. Can be one of 'debug', 'info', or 'error'")
 
 	if opts.MemoryLimit > 0 {
 		newLimit := int64(float64(opts.MemoryLimit) * 0.9)
 		debug.SetMemoryLimit(newLimit)
+	}
+	if !lo.Contains(validLogLevels, opts.LogLevel) {
+		log.Fatalf("invalid log level %q passed through environment variables or cli arguments", opts.LogLevel)
 	}
 	return opts
 }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR deprecates the `karpenter/config-logging` ConfigMap for configuring the logger, in favor of an opinionated approach to how the logger is configured. Now, Karpenter will configure the logger by default and will surface the `LOG_LEVEL` environment variable and `--log-level` CLI argument to allow changing the log level for the controller. This is the recommended way to configure Karpenter logging if log level changes are needed.

Alternatively, Karpenter will support a soon-to-be-deprecated form of configuring the logger through the filesystem. This method is introduced as an alternative to Karpenter discovering the ConfigMap through API discovery and, instead, uses the container-native filesystem mechanism of loading in the configuration.

### Filesystem Paths
1. Global Zap Logger Config: `/etc/karpenter/logging/zap-logger-config`
2. Controller Component Log Level Override: `/etc/karpenter/logging/loglevel.controller`
3. Webhook Component Log Level Override: `/etc/karpenter/logging/loglevel/webhook`

### Configuring the Volume Mount with the ConfigMap

```yaml
apiVersion: apps/v1
kind: Deployment
spec:
  template:
    spec:
    ...
      containers:
      - name: controller
        volumeMounts:
        - name: config-logging
          mountPath: /etc/karpenter/logging
      volumes:
      - name: config-logging
        configMap:
          name: config-logging
```

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
