### PR TITLE
test: Add testing to validate `do-not-disrupt` and `do-not-evict`

### DIFF
--- a/pkg/controllers/deprovisioning/machine_drift_test.go
+++ b/pkg/controllers/deprovisioning/machine_drift_test.go
@@ -31,6 +31,7 @@ import (
 
 	"github.com/aws/karpenter-core/pkg/apis/settings"
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
+	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
 	"github.com/aws/karpenter-core/pkg/cloudprovider/fake"
 	"github.com/aws/karpenter-core/pkg/test"
@@ -38,16 +39,16 @@ import (
 )
 
 var _ = Describe("Machine/Drift", func() {
-	var prov *v1alpha5.Provisioner
+	var provisioner *v1alpha5.Provisioner
 	var machine *v1alpha5.Machine
 	var node *v1.Node
 
 	BeforeEach(func() {
-		prov = test.Provisioner()
+		provisioner = test.Provisioner()
 		machine, node = test.MachineAndNode(v1alpha5.Machine{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
-					v1alpha5.ProvisionerNameLabelKey: prov.Name,
+					v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
 					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name,
 					v1alpha5.LabelCapacityType:       mostExpensiveOffering.CapacityType,
 					v1.LabelTopologyZone:             mostExpensiveOffering.Zone,
@@ -65,7 +66,7 @@ var _ = Describe("Machine/Drift", func() {
 	})
 	It("should ignore drifted nodes if the feature flag is disabled", func() {
 		ctx = settings.ToContext(ctx, test.Settings(settings.Settings{DriftEnabled: false}))
-		ExpectApplied(ctx, env.Client, machine, node, prov)
+		ExpectApplied(ctx, env.Client, machine, node, provisioner)
 
 		// inform cluster state about nodes and machines
 		ExpectMakeNodesAndMachinesInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
@@ -96,7 +97,7 @@ var _ = Describe("Machine/Drift", func() {
 				},
 			},
 		})
-		ExpectApplied(ctx, env.Client, machine, node, prov, pod)
+		ExpectApplied(ctx, env.Client, machine, node, provisioner, pod)
 		ExpectManualBinding(ctx, env.Client, pod, node)
 
 		// inform cluster state about nodes and machines
@@ -105,7 +106,7 @@ var _ = Describe("Machine/Drift", func() {
 		machine2, node2 := test.MachineAndNode(v1alpha5.Machine{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
-					v1alpha5.ProvisionerNameLabelKey: prov.Name,
+					v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
 					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name,
 					v1alpha5.LabelCapacityType:       mostExpensiveOffering.CapacityType,
 					v1.LabelTopologyZone:             mostExpensiveOffering.Zone,
@@ -142,7 +143,7 @@ var _ = Describe("Machine/Drift", func() {
 	})
 	It("should ignore nodes without the drifted status condition", func() {
 		_ = machine.StatusConditions().ClearCondition(v1alpha5.MachineDrifted)
-		ExpectApplied(ctx, env.Client, machine, node, prov)
+		ExpectApplied(ctx, env.Client, machine, node, provisioner)
 
 		// inform cluster state about nodes and machines
 		ExpectMakeNodesAndMachinesInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
@@ -155,9 +156,65 @@ var _ = Describe("Machine/Drift", func() {
 		Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(1))
 		ExpectExists(ctx, env.Client, machine)
 	})
+	It("should ignore nodes with the karpenter.sh/do-not-disrupt annotation", func() {
+		node.Annotations = lo.Assign(node.Annotations, map[string]string{v1beta1.DoNotDisruptAnnotationKey: "true"})
+		ExpectApplied(ctx, env.Client, machine, node, provisioner)
+
+		// inform cluster state about nodes and machines
+		ExpectMakeNodesAndMachinesInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
+
+		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+
+		// Expect to not create or delete more machines
+		Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(1))
+		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
+		ExpectExists(ctx, env.Client, machine)
+	})
+	It("should ignore nodes that have pods with the karpenter.sh/do-not-evict annotation", func() {
+		pod := test.Pod(test.PodOptions{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					v1alpha5.DoNotEvictPodAnnotationKey: "true",
+				},
+			},
+		})
+		ExpectApplied(ctx, env.Client, machine, node, provisioner, pod)
+		ExpectManualBinding(ctx, env.Client, pod, node)
+
+		// inform cluster state about nodes and machines
+		ExpectMakeNodesAndMachinesInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
+
+		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+
+		// Expect to not create or delete more machines
+		Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(1))
+		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
+		ExpectExists(ctx, env.Client, machine)
+	})
+	It("should ignore nodes that have pods with the karpenter.sh/do-not-disrupt annotation", func() {
+		pod := test.Pod(test.PodOptions{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					v1beta1.DoNotDisruptAnnotationKey: "true",
+				},
+			},
+		})
+		ExpectApplied(ctx, env.Client, machine, node, provisioner, pod)
+		ExpectManualBinding(ctx, env.Client, pod, node)
+
+		// inform cluster state about nodes and machines
+		ExpectMakeNodesAndMachinesInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
+
+		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+
+		// Expect to not create or delete more machines
+		Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(1))
+		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
+		ExpectExists(ctx, env.Client, machine)
+	})
 	It("should ignore nodes with the drifted status condition set to false", func() {
 		machine.StatusConditions().MarkFalse(v1alpha5.MachineDrifted, "", "")
-		ExpectApplied(ctx, env.Client, machine, node, prov)
+		ExpectApplied(ctx, env.Client, machine, node, provisioner)
 
 		// inform cluster state about nodes and machines
 		ExpectMakeNodesAndMachinesInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
@@ -171,7 +228,7 @@ var _ = Describe("Machine/Drift", func() {
 		ExpectExists(ctx, env.Client, machine)
 	})
 	It("can delete drifted nodes", func() {
-		ExpectApplied(ctx, env.Client, machine, node, prov)
+		ExpectApplied(ctx, env.Client, machine, node, provisioner)
 
 		// inform cluster state about nodes and machines
 		ExpectMakeNodesAndMachinesInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
@@ -195,7 +252,7 @@ var _ = Describe("Machine/Drift", func() {
 		machines, nodes := test.MachinesAndNodes(100, v1alpha5.Machine{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
-					v1alpha5.ProvisionerNameLabelKey: prov.Name,
+					v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
 					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name,
 					v1alpha5.LabelCapacityType:       mostExpensiveOffering.CapacityType,
 					v1.LabelTopologyZone:             mostExpensiveOffering.Zone,
@@ -215,7 +272,7 @@ var _ = Describe("Machine/Drift", func() {
 		for _, n := range nodes {
 			ExpectApplied(ctx, env.Client, n)
 		}
-		ExpectApplied(ctx, env.Client, prov)
+		ExpectApplied(ctx, env.Client, provisioner)
 
 		// inform cluster state about nodes and machines
 		ExpectMakeNodesAndMachinesInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, nodes, machines)
@@ -254,7 +311,7 @@ var _ = Describe("Machine/Drift", func() {
 					},
 				}}})
 
-		ExpectApplied(ctx, env.Client, rs, pod, machine, node, prov)
+		ExpectApplied(ctx, env.Client, rs, pod, machine, node, provisioner)
 
 		// bind the pods to the node
 		ExpectManualBinding(ctx, env.Client, pod, node)
@@ -352,7 +409,7 @@ var _ = Describe("Machine/Drift", func() {
 		})
 		node.Status.Allocatable = map[v1.ResourceName]resource.Quantity{v1.ResourceCPU: resource.MustParse("8")}
 
-		ExpectApplied(ctx, env.Client, rs, machine, node, prov, pods[0], pods[1], pods[2])
+		ExpectApplied(ctx, env.Client, rs, machine, node, provisioner, pods[0], pods[1], pods[2])
 
 		// bind the pods to the node
 		ExpectManualBinding(ctx, env.Client, pods[0], node)
@@ -410,7 +467,7 @@ var _ = Describe("Machine/Drift", func() {
 		machine2, node2 := test.MachineAndNode(v1alpha5.Machine{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
-					v1alpha5.ProvisionerNameLabelKey: prov.Name,
+					v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
 					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name,
 					v1alpha5.LabelCapacityType:       mostExpensiveOffering.CapacityType,
 					v1.LabelTopologyZone:             mostExpensiveOffering.Zone,
@@ -427,7 +484,7 @@ var _ = Describe("Machine/Drift", func() {
 			LastTransitionTime: apis.VolatileTime{Inner: metav1.Time{Time: time.Now().Add(-time.Hour)}},
 		})
 
-		ExpectApplied(ctx, env.Client, rs, pods[0], pods[1], machine, node, machine2, node2, prov)
+		ExpectApplied(ctx, env.Client, rs, pods[0], pods[1], machine, node, machine2, node2, provisioner)
 
 		// bind pods to node so that they're not empty and don't deprovision in parallel.
 		ExpectManualBinding(ctx, env.Client, pods[0], node)

--- a/pkg/controllers/deprovisioning/machine_emptiness_test.go
+++ b/pkg/controllers/deprovisioning/machine_emptiness_test.go
@@ -16,7 +16,6 @@ limitations under the License.
 package deprovisioning_test
 
 import (
-	"sort"
 	"sync"
 	"time"
 
@@ -28,235 +27,143 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"knative.dev/pkg/ptr"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
-	"github.com/aws/karpenter-core/pkg/cloudprovider"
+	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-core/pkg/test"
 	. "github.com/aws/karpenter-core/pkg/test/expectations"
 )
 
 var _ = Describe("Machine/Emptiness", func() {
-	Context("TTLSecondsAfterEmpty", func() {
-		var prov *v1alpha5.Provisioner
-		var machine *v1alpha5.Machine
-		var node *v1.Node
+	var provisioner *v1alpha5.Provisioner
+	var machine *v1alpha5.Machine
+	var node *v1.Node
 
-		BeforeEach(func() {
-			prov = test.Provisioner(test.ProvisionerOptions{
-				TTLSecondsAfterEmpty: ptr.Int64(30),
-			})
-			machine, node = test.MachineAndNode(v1alpha5.Machine{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						v1alpha5.ProvisionerNameLabelKey: prov.Name,
-						v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name,
-						v1alpha5.LabelCapacityType:       mostExpensiveOffering.CapacityType,
-						v1.LabelTopologyZone:             mostExpensiveOffering.Zone,
-					},
+	BeforeEach(func() {
+		provisioner = test.Provisioner(test.ProvisionerOptions{
+			TTLSecondsAfterEmpty: ptr.Int64(30),
+		})
+		machine, node = test.MachineAndNode(v1alpha5.Machine{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
+					v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name,
+					v1alpha5.LabelCapacityType:       mostExpensiveOffering.CapacityType,
+					v1.LabelTopologyZone:             mostExpensiveOffering.Zone,
 				},
-				Status: v1alpha5.MachineStatus{
-					ProviderID: test.RandomProviderID(),
-					Allocatable: map[v1.ResourceName]resource.Quantity{
-						v1.ResourceCPU:  resource.MustParse("32"),
-						v1.ResourcePods: resource.MustParse("100"),
-					},
+			},
+			Status: v1alpha5.MachineStatus{
+				ProviderID: test.RandomProviderID(),
+				Allocatable: map[v1.ResourceName]resource.Quantity{
+					v1.ResourceCPU:  resource.MustParse("32"),
+					v1.ResourcePods: resource.MustParse("100"),
 				},
-			})
-			machine.StatusConditions().MarkTrue(v1alpha5.MachineEmpty)
+			},
 		})
-		It("can delete empty nodes with TTLSecondsAfterEmpty", func() {
-			ExpectApplied(ctx, env.Client, prov, machine, node)
-
-			// inform cluster state about nodes and machines
-			ExpectMakeNodesAndMachinesInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
-
-			fakeClock.Step(10 * time.Minute)
-			wg := sync.WaitGroup{}
-			ExpectTriggerVerifyAction(&wg)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
-
-			// Cascade any deletion of the machine to the node
-			ExpectMachinesCascadeDeletion(ctx, env.Client, machine)
-
-			// we should delete the empty node
-			Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(0))
-			Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(0))
-			ExpectNotFound(ctx, env.Client, machine, node)
-		})
-		It("should ignore TTLSecondsAfterEmpty nodes without the empty status condition", func() {
-			_ = machine.StatusConditions().ClearCondition(v1alpha5.MachineEmpty)
-			ExpectApplied(ctx, env.Client, machine, node, prov)
-
-			// inform cluster state about nodes and machines
-			ExpectMakeNodesAndMachinesInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
-
-			ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
-
-			// Expect to not create or delete more machines
-			Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(1))
-			Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
-			ExpectExists(ctx, env.Client, machine)
-		})
-		It("should ignore TTLSecondsAfterEmpty nodes with the empty status condition set to false", func() {
-			machine.StatusConditions().MarkFalse(v1alpha5.MachineEmpty, "", "")
-			ExpectApplied(ctx, env.Client, machine, node, prov)
-
-			// inform cluster state about nodes and machines
-			ExpectMakeNodesAndMachinesInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
-
-			fakeClock.Step(10 * time.Minute)
-
-			ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
-
-			// Expect to not create or delete more machines
-			Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(1))
-			ExpectExists(ctx, env.Client, machine)
-		})
+		machine.StatusConditions().MarkTrue(v1alpha5.MachineEmpty)
 	})
-	Context("Consolidation", func() {
-		var prov *v1alpha5.Provisioner
-		var machine1, machine2 *v1alpha5.Machine
-		var node1, node2 *v1.Node
+	It("can delete empty nodes", func() {
+		ExpectApplied(ctx, env.Client, provisioner, machine, node)
 
-		BeforeEach(func() {
-			prov = test.Provisioner(test.ProvisionerOptions{Consolidation: &v1alpha5.Consolidation{Enabled: ptr.Bool(true)}})
-			machine1, node1 = test.MachineAndNode(v1alpha5.Machine{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						v1alpha5.ProvisionerNameLabelKey: prov.Name,
-						v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name,
-						v1alpha5.LabelCapacityType:       mostExpensiveOffering.CapacityType,
-						v1.LabelTopologyZone:             mostExpensiveOffering.Zone,
-					},
+		// inform cluster state about nodes and machines
+		ExpectMakeNodesAndMachinesInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
+
+		fakeClock.Step(10 * time.Minute)
+		wg := sync.WaitGroup{}
+		ExpectTriggerVerifyAction(&wg)
+		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+
+		// Cascade any deletion of the machine to the node
+		ExpectMachinesCascadeDeletion(ctx, env.Client, machine)
+
+		// we should delete the empty node
+		Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(0))
+		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(0))
+		ExpectNotFound(ctx, env.Client, machine, node)
+	})
+	It("should ignore nodes without the empty status condition", func() {
+		_ = machine.StatusConditions().ClearCondition(v1alpha5.MachineEmpty)
+		ExpectApplied(ctx, env.Client, machine, node, provisioner)
+
+		// inform cluster state about nodes and machines
+		ExpectMakeNodesAndMachinesInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
+
+		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+
+		// Expect to not create or delete more machines
+		Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(1))
+		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
+		ExpectExists(ctx, env.Client, machine)
+	})
+	It("should ignore nodes with the karpenter.sh/do-not-disrupt annotation", func() {
+		node.Annotations = lo.Assign(node.Annotations, map[string]string{v1beta1.DoNotDisruptAnnotationKey: "true"})
+		ExpectApplied(ctx, env.Client, machine, node, provisioner)
+
+		// inform cluster state about nodes and machines
+		ExpectMakeNodesAndMachinesInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
+
+		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+
+		// Expect to not create or delete more machines
+		Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(1))
+		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
+		ExpectExists(ctx, env.Client, machine)
+	})
+	It("should ignore nodes that have pods with the karpenter.sh/do-not-evict annotation", func() {
+		pod := test.Pod(test.PodOptions{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					v1alpha5.DoNotEvictPodAnnotationKey: "true",
 				},
-				Status: v1alpha5.MachineStatus{
-					ProviderID: test.RandomProviderID(),
-					Allocatable: map[v1.ResourceName]resource.Quantity{
-						v1.ResourceCPU:  resource.MustParse("32"),
-						v1.ResourcePods: resource.MustParse("100"),
-					},
-				},
-			})
-			machine1.StatusConditions().MarkTrue(v1alpha5.MachineEmpty)
-			machine2, node2 = test.MachineAndNode(v1alpha5.Machine{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						v1alpha5.ProvisionerNameLabelKey: prov.Name,
-						v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name,
-						v1alpha5.LabelCapacityType:       mostExpensiveOffering.CapacityType,
-						v1.LabelTopologyZone:             mostExpensiveOffering.Zone,
-					},
-				},
-				Status: v1alpha5.MachineStatus{
-					ProviderID: test.RandomProviderID(),
-					Allocatable: map[v1.ResourceName]resource.Quantity{
-						v1.ResourceCPU:  resource.MustParse("32"),
-						v1.ResourcePods: resource.MustParse("100"),
-					},
-				},
-			})
-			machine2.StatusConditions().MarkTrue(v1alpha5.MachineEmpty)
+			},
 		})
-		It("can delete empty nodes with consolidation", func() {
-			ExpectApplied(ctx, env.Client, machine1, node1, prov)
+		ExpectApplied(ctx, env.Client, machine, node, provisioner, pod)
+		ExpectManualBinding(ctx, env.Client, pod, node)
 
-			// inform cluster state about nodes and machines
-			ExpectMakeNodesAndMachinesInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node1}, []*v1alpha5.Machine{machine1})
+		// inform cluster state about nodes and machines
+		ExpectMakeNodesAndMachinesInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
 
-			fakeClock.Step(10 * time.Minute)
+		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
 
-			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
-			wg.Wait()
-
-			// Cascade any deletion of the machine to the node
-			ExpectMachinesCascadeDeletion(ctx, env.Client, machine1)
-
-			// we should delete the empty node
-			Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(0))
-			Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(0))
-			ExpectNotFound(ctx, env.Client, machine1, node1)
+		// Expect to not create or delete more machines
+		Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(1))
+		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
+		ExpectExists(ctx, env.Client, machine)
+	})
+	It("should ignore nodes that have pods with the karpenter.sh/do-not-disrupt annotation", func() {
+		pod := test.Pod(test.PodOptions{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					v1beta1.DoNotDisruptAnnotationKey: "true",
+				},
+			},
 		})
-		It("can delete multiple empty nodes with consolidation", func() {
-			ExpectApplied(ctx, env.Client, machine1, node1, machine2, node2, prov)
+		ExpectApplied(ctx, env.Client, machine, node, provisioner, pod)
+		ExpectManualBinding(ctx, env.Client, pod, node)
 
-			// inform cluster state about nodes and machines
-			ExpectMakeNodesAndMachinesInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node1, node2}, []*v1alpha5.Machine{machine1, machine2})
+		// inform cluster state about nodes and machines
+		ExpectMakeNodesAndMachinesInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
 
-			fakeClock.Step(10 * time.Minute)
-			wg := sync.WaitGroup{}
-			ExpectTriggerVerifyAction(&wg)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
 
-			// Cascade any deletion of the machine to the node
-			ExpectMachinesCascadeDeletion(ctx, env.Client, machine1, machine2)
+		// Expect to not create or delete more machines
+		Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(1))
+		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
+		ExpectExists(ctx, env.Client, machine)
+	})
+	It("should ignore nodes with the empty status condition set to false", func() {
+		machine.StatusConditions().MarkFalse(v1alpha5.MachineEmpty, "", "")
+		ExpectApplied(ctx, env.Client, machine, node, provisioner)
 
-			// we should delete the empty nodes
-			Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(0))
-			Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(0))
-			ExpectNotFound(ctx, env.Client, machine1)
-			ExpectNotFound(ctx, env.Client, machine2)
-		})
-		It("considers pending pods when consolidating", func() {
-			largeTypes := lo.Filter(cloudProvider.InstanceTypes, func(item *cloudprovider.InstanceType, index int) bool {
-				return item.Capacity.Cpu().Cmp(resource.MustParse("64")) >= 0
-			})
-			sort.Slice(largeTypes, func(i, j int) bool {
-				return largeTypes[i].Offerings[0].Price < largeTypes[j].Offerings[0].Price
-			})
+		// inform cluster state about nodes and machines
+		ExpectMakeNodesAndMachinesInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
 
-			largeCheapType := largeTypes[0]
-			machine1, node1 = test.MachineAndNode(v1alpha5.Machine{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						v1alpha5.ProvisionerNameLabelKey: prov.Name,
-						v1.LabelInstanceTypeStable:       largeCheapType.Name,
-						v1alpha5.LabelCapacityType:       largeCheapType.Offerings[0].CapacityType,
-						v1.LabelTopologyZone:             largeCheapType.Offerings[0].Zone,
-					},
-				},
-				Status: v1alpha5.MachineStatus{
-					ProviderID: test.RandomProviderID(),
-					Allocatable: map[v1.ResourceName]resource.Quantity{
-						v1.ResourceCPU:  *largeCheapType.Capacity.Cpu(),
-						v1.ResourcePods: *largeCheapType.Capacity.Pods(),
-					},
-				},
-			})
+		fakeClock.Step(10 * time.Minute)
 
-			// there is a pending pod that should land on the node
-			pod := test.UnschedulablePod(test.PodOptions{
-				ResourceRequirements: v1.ResourceRequirements{
-					Requests: map[v1.ResourceName]resource.Quantity{
-						v1.ResourceCPU: resource.MustParse("1"),
-					},
-				},
-			})
-			unsched := test.UnschedulablePod(test.PodOptions{
-				ResourceRequirements: v1.ResourceRequirements{
-					Requests: map[v1.ResourceName]resource.Quantity{
-						v1.ResourceCPU: resource.MustParse("62"),
-					},
-				},
-			})
+		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
 
-			ExpectApplied(ctx, env.Client, machine1, node1, pod, unsched, prov)
-
-			// bind one of the pods to the node
-			ExpectManualBinding(ctx, env.Client, pod, node1)
-
-			// inform cluster state about nodes and machines
-			ExpectMakeNodesAndMachinesInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node1}, []*v1alpha5.Machine{machine1})
-
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
-
-			// we don't need any new nodes and consolidation should notice the huge pending pod that needs the large
-			// node to schedule, which prevents the large expensive node from being replaced
-			Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(1))
-			Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
-			ExpectExists(ctx, env.Client, machine1)
-		})
+		// Expect to not create or delete more machines
+		Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(1))
+		ExpectExists(ctx, env.Client, machine)
 	})
 })

--- a/pkg/controllers/deprovisioning/nodeclaim_drift_test.go
+++ b/pkg/controllers/deprovisioning/nodeclaim_drift_test.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aws/karpenter-core/pkg/apis/settings"
+	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
 	"github.com/aws/karpenter-core/pkg/cloudprovider/fake"
@@ -160,6 +161,62 @@ var _ = Describe("NodeClaim/Drift", func() {
 
 		// Expect to not create or delete more nodeclaims
 		Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
+		ExpectExists(ctx, env.Client, nodeClaim)
+	})
+	It("should ignore nodes with the karpenter.sh/do-not-disrupt annotation", func() {
+		node.Annotations = lo.Assign(node.Annotations, map[string]string{v1beta1.DoNotDisruptAnnotationKey: "true"})
+		ExpectApplied(ctx, env.Client, nodeClaim, node, nodePool)
+
+		// inform cluster state about nodes and nodeclaims
+		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
+
+		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+
+		// Expect to not create or delete more nodeclaims
+		Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
+		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
+		ExpectExists(ctx, env.Client, nodeClaim)
+	})
+	It("should ignore nodes that have pods with the karpenter.sh/do-not-evict annotation", func() {
+		pod := test.Pod(test.PodOptions{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					v1alpha5.DoNotEvictPodAnnotationKey: "true",
+				},
+			},
+		})
+		ExpectApplied(ctx, env.Client, nodeClaim, node, nodePool, pod)
+		ExpectManualBinding(ctx, env.Client, pod, node)
+
+		// inform cluster state about nodes and nodeclaims
+		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
+
+		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+
+		// Expect to not create or delete more nodeclaims
+		Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
+		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
+		ExpectExists(ctx, env.Client, nodeClaim)
+	})
+	It("should ignore nodes that have pods with the karpenter.sh/do-not-disrupt annotation", func() {
+		pod := test.Pod(test.PodOptions{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					v1beta1.DoNotDisruptAnnotationKey: "true",
+				},
+			},
+		})
+		ExpectApplied(ctx, env.Client, nodeClaim, node, nodePool, pod)
+		ExpectManualBinding(ctx, env.Client, pod, node)
+
+		// inform cluster state about nodes and nodeclaims
+		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
+
+		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+
+		// Expect to not create or delete more nodeclaims
+		Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
+		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
 		ExpectExists(ctx, env.Client, nodeClaim)
 	})
 	It("should ignore nodes with the drifted status condition set to false", func() {

--- a/pkg/controllers/deprovisioning/nodeclaim_emptiness_test.go
+++ b/pkg/controllers/deprovisioning/nodeclaim_emptiness_test.go
@@ -16,7 +16,6 @@ limitations under the License.
 package deprovisioning_test
 
 import (
-	"sort"
 	"sync"
 	"time"
 
@@ -27,249 +26,149 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
-	"github.com/aws/karpenter-core/pkg/cloudprovider"
 	"github.com/aws/karpenter-core/pkg/test"
 	. "github.com/aws/karpenter-core/pkg/test/expectations"
 )
 
 var _ = Describe("NodeClaim/Emptiness", func() {
-	Context("ConsolidationPolicy:WhenEmpty", func() {
-		var nodePool *v1beta1.NodePool
-		var nodeClaim *v1beta1.NodeClaim
-		var node *v1.Node
+	var nodePool *v1beta1.NodePool
+	var nodeClaim *v1beta1.NodeClaim
+	var node *v1.Node
 
-		BeforeEach(func() {
-			nodePool = test.NodePool(v1beta1.NodePool{
-				Spec: v1beta1.NodePoolSpec{
-					Disruption: v1beta1.Disruption{
-						ConsolidateAfter:    &v1beta1.NillableDuration{Duration: lo.ToPtr(time.Second * 30)},
-						ConsolidationPolicy: v1beta1.ConsolidationPolicyWhenEmpty,
-						ExpireAfter:         v1beta1.NillableDuration{Duration: nil},
-					},
+	BeforeEach(func() {
+		nodePool = test.NodePool(v1beta1.NodePool{
+			Spec: v1beta1.NodePoolSpec{
+				Disruption: v1beta1.Disruption{
+					ConsolidateAfter:    &v1beta1.NillableDuration{Duration: lo.ToPtr(time.Second * 30)},
+					ConsolidationPolicy: v1beta1.ConsolidationPolicyWhenEmpty,
+					ExpireAfter:         v1beta1.NillableDuration{Duration: nil},
 				},
-			})
-			nodeClaim, node = test.NodeClaimAndNode(v1beta1.NodeClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						v1beta1.NodePoolLabelKey:     nodePool.Name,
-						v1.LabelInstanceTypeStable:   mostExpensiveInstance.Name,
-						v1beta1.CapacityTypeLabelKey: mostExpensiveOffering.CapacityType,
-						v1.LabelTopologyZone:         mostExpensiveOffering.Zone,
-					},
+			},
+		})
+		nodeClaim, node = test.NodeClaimAndNode(v1beta1.NodeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					v1beta1.NodePoolLabelKey:     nodePool.Name,
+					v1.LabelInstanceTypeStable:   mostExpensiveInstance.Name,
+					v1beta1.CapacityTypeLabelKey: mostExpensiveOffering.CapacityType,
+					v1.LabelTopologyZone:         mostExpensiveOffering.Zone,
 				},
-				Status: v1beta1.NodeClaimStatus{
-					ProviderID: test.RandomProviderID(),
-					Allocatable: map[v1.ResourceName]resource.Quantity{
-						v1.ResourceCPU:  resource.MustParse("32"),
-						v1.ResourcePods: resource.MustParse("100"),
-					},
+			},
+			Status: v1beta1.NodeClaimStatus{
+				ProviderID: test.RandomProviderID(),
+				Allocatable: map[v1.ResourceName]resource.Quantity{
+					v1.ResourceCPU:  resource.MustParse("32"),
+					v1.ResourcePods: resource.MustParse("100"),
 				},
-			})
-			nodeClaim.StatusConditions().MarkTrue(v1beta1.Empty)
+			},
 		})
-		It("can delete empty nodes with TTLSecondsAfterEmpty", func() {
-			ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
-
-			// inform cluster state about nodes and nodeclaims
-			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
-
-			fakeClock.Step(10 * time.Minute)
-			wg := sync.WaitGroup{}
-			ExpectTriggerVerifyAction(&wg)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
-
-			// Cascade any deletion of the nodeClaim to the node
-			ExpectNodeClaimsCascadeDeletion(ctx, env.Client, nodeClaim)
-
-			// we should delete the empty node
-			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(0))
-			Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(0))
-			ExpectNotFound(ctx, env.Client, nodeClaim, node)
-		})
-		It("should ignore TTLSecondsAfterEmpty nodes without the empty status condition", func() {
-			_ = nodeClaim.StatusConditions().ClearCondition(v1beta1.Empty)
-			ExpectApplied(ctx, env.Client, nodeClaim, node, nodePool)
-
-			// inform cluster state about nodes and nodeclaims
-			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
-
-			ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
-
-			// Expect to not create or delete more nodeclaims
-			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
-			Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
-			ExpectExists(ctx, env.Client, nodeClaim)
-		})
-		It("should ignore TTLSecondsAfterEmpty nodes with the empty status condition set to false", func() {
-			nodeClaim.StatusConditions().MarkFalse(v1beta1.Empty, "", "")
-			ExpectApplied(ctx, env.Client, nodeClaim, node, nodePool)
-
-			// inform cluster state about nodes and nodeclaims
-			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
-
-			fakeClock.Step(10 * time.Minute)
-
-			ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
-
-			// Expect to not create or delete more nodeclaims
-			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
-			ExpectExists(ctx, env.Client, nodeClaim)
-		})
+		nodeClaim.StatusConditions().MarkTrue(v1beta1.Empty)
 	})
-	var _ = Describe("ConsolidatePolicy:WhenUnderutilized", func() {
-		var nodePool *v1beta1.NodePool
-		var nodeClaim1, nodeClaim2 *v1beta1.NodeClaim
-		var node1, node2 *v1.Node
+	It("can delete empty nodes", func() {
+		ExpectApplied(ctx, env.Client, nodePool, nodeClaim, node)
 
-		BeforeEach(func() {
-			nodePool = test.NodePool(v1beta1.NodePool{
-				Spec: v1beta1.NodePoolSpec{
-					Disruption: v1beta1.Disruption{
-						ConsolidateAfter:    &v1beta1.NillableDuration{Duration: lo.ToPtr(time.Second * 30)},
-						ConsolidationPolicy: v1beta1.ConsolidationPolicyWhenUnderutilized,
-						ExpireAfter:         v1beta1.NillableDuration{Duration: nil},
-					},
+		// inform cluster state about nodes and nodeclaims
+		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
+
+		fakeClock.Step(10 * time.Minute)
+		wg := sync.WaitGroup{}
+		ExpectTriggerVerifyAction(&wg)
+		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+
+		// Cascade any deletion of the nodeClaim to the node
+		ExpectNodeClaimsCascadeDeletion(ctx, env.Client, nodeClaim)
+
+		// we should delete the empty node
+		Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(0))
+		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(0))
+		ExpectNotFound(ctx, env.Client, nodeClaim, node)
+	})
+	It("should ignore nodes without the empty status condition", func() {
+		_ = nodeClaim.StatusConditions().ClearCondition(v1beta1.Empty)
+		ExpectApplied(ctx, env.Client, nodeClaim, node, nodePool)
+
+		// inform cluster state about nodes and nodeclaims
+		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
+
+		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+
+		// Expect to not create or delete more nodeclaims
+		Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
+		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
+		ExpectExists(ctx, env.Client, nodeClaim)
+	})
+	It("should ignore nodes with the karpenter.sh/do-not-disrupt annotation", func() {
+		node.Annotations = lo.Assign(node.Annotations, map[string]string{v1beta1.DoNotDisruptAnnotationKey: "true"})
+		ExpectApplied(ctx, env.Client, nodeClaim, node, nodePool)
+
+		// inform cluster state about nodes and nodeclaims
+		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
+
+		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+
+		// Expect to not create or delete more nodeclaims
+		Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
+		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
+		ExpectExists(ctx, env.Client, nodeClaim)
+	})
+	It("should ignore nodes that have pods with the karpenter.sh/do-not-evict annotation", func() {
+		pod := test.Pod(test.PodOptions{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					v1alpha5.DoNotEvictPodAnnotationKey: "true",
 				},
-			})
-			nodeClaim1, node1 = test.NodeClaimAndNode(v1beta1.NodeClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						v1beta1.NodePoolLabelKey:     nodePool.Name,
-						v1.LabelInstanceTypeStable:   mostExpensiveInstance.Name,
-						v1beta1.CapacityTypeLabelKey: mostExpensiveOffering.CapacityType,
-						v1.LabelTopologyZone:         mostExpensiveOffering.Zone,
-					},
-				},
-				Status: v1beta1.NodeClaimStatus{
-					ProviderID: test.RandomProviderID(),
-					Allocatable: map[v1.ResourceName]resource.Quantity{
-						v1.ResourceCPU:  resource.MustParse("32"),
-						v1.ResourcePods: resource.MustParse("100"),
-					},
-				},
-			})
-			nodeClaim1.StatusConditions().MarkTrue(v1beta1.Empty)
-			nodeClaim2, node2 = test.NodeClaimAndNode(v1beta1.NodeClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						v1beta1.NodePoolLabelKey:     nodePool.Name,
-						v1.LabelInstanceTypeStable:   mostExpensiveInstance.Name,
-						v1beta1.CapacityTypeLabelKey: mostExpensiveOffering.CapacityType,
-						v1.LabelTopologyZone:         mostExpensiveOffering.Zone,
-					},
-				},
-				Status: v1beta1.NodeClaimStatus{
-					ProviderID: test.RandomProviderID(),
-					Allocatable: map[v1.ResourceName]resource.Quantity{
-						v1.ResourceCPU:  resource.MustParse("32"),
-						v1.ResourcePods: resource.MustParse("100"),
-					},
-				},
-			})
-			nodeClaim2.StatusConditions().MarkTrue(v1beta1.Empty)
+			},
 		})
-		It("can delete empty nodes with consolidation", func() {
-			ExpectApplied(ctx, env.Client, nodeClaim1, node1, nodePool)
+		ExpectApplied(ctx, env.Client, nodeClaim, node, nodePool, pod)
+		ExpectManualBinding(ctx, env.Client, pod, node)
 
-			// inform cluster state about nodes and nodeclaims
-			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node1}, []*v1beta1.NodeClaim{nodeClaim1})
+		// inform cluster state about nodes and nodeclaims
+		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
 
-			fakeClock.Step(10 * time.Minute)
+		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
 
-			var wg sync.WaitGroup
-			ExpectTriggerVerifyAction(&wg)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
-			wg.Wait()
-
-			// Cascade any deletion of the nodeclaim to the node
-			ExpectNodeClaimsCascadeDeletion(ctx, env.Client, nodeClaim1)
-
-			// we should delete the empty node
-			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(0))
-			Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(0))
-			ExpectNotFound(ctx, env.Client, nodeClaim1, node1)
+		// Expect to not create or delete more nodeclaims
+		Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
+		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
+		ExpectExists(ctx, env.Client, nodeClaim)
+	})
+	It("should ignore nodes that have pods with the karpenter.sh/do-not-disrupt annotation", func() {
+		pod := test.Pod(test.PodOptions{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					v1beta1.DoNotDisruptAnnotationKey: "true",
+				},
+			},
 		})
-		It("can delete multiple empty nodes with consolidation", func() {
-			ExpectApplied(ctx, env.Client, nodeClaim1, node1, nodeClaim2, node2, nodePool)
+		ExpectApplied(ctx, env.Client, nodeClaim, node, nodePool, pod)
+		ExpectManualBinding(ctx, env.Client, pod, node)
 
-			// inform cluster state about nodes and nodeclaims
-			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node1, node2}, []*v1beta1.NodeClaim{nodeClaim1, nodeClaim2})
+		// inform cluster state about nodes and nodeclaims
+		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
 
-			fakeClock.Step(10 * time.Minute)
-			wg := sync.WaitGroup{}
-			ExpectTriggerVerifyAction(&wg)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
 
-			// Cascade any deletion of the nodeclaim to the node
-			ExpectNodeClaimsCascadeDeletion(ctx, env.Client, nodeClaim1, nodeClaim2)
+		// Expect to not create or delete more nodeclaims
+		Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
+		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
+		ExpectExists(ctx, env.Client, nodeClaim)
+	})
+	It("should ignore nodes with the empty status condition set to false", func() {
+		nodeClaim.StatusConditions().MarkFalse(v1beta1.Empty, "", "")
+		ExpectApplied(ctx, env.Client, nodeClaim, node, nodePool)
 
-			// we should delete the empty nodes
-			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(0))
-			Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(0))
-			ExpectNotFound(ctx, env.Client, nodeClaim1)
-			ExpectNotFound(ctx, env.Client, nodeClaim2)
-		})
-		It("considers pending pods when consolidating", func() {
-			largeTypes := lo.Filter(cloudProvider.InstanceTypes, func(item *cloudprovider.InstanceType, index int) bool {
-				return item.Capacity.Cpu().Cmp(resource.MustParse("64")) >= 0
-			})
-			sort.Slice(largeTypes, func(i, j int) bool {
-				return largeTypes[i].Offerings[0].Price < largeTypes[j].Offerings[0].Price
-			})
+		// inform cluster state about nodes and nodeclaims
+		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
 
-			largeCheapType := largeTypes[0]
-			nodeClaim1, node1 = test.NodeClaimAndNode(v1beta1.NodeClaim{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{
-						v1beta1.NodePoolLabelKey:     nodePool.Name,
-						v1.LabelInstanceTypeStable:   largeCheapType.Name,
-						v1beta1.CapacityTypeLabelKey: largeCheapType.Offerings[0].CapacityType,
-						v1.LabelTopologyZone:         largeCheapType.Offerings[0].Zone,
-					},
-				},
-				Status: v1beta1.NodeClaimStatus{
-					ProviderID: test.RandomProviderID(),
-					Allocatable: map[v1.ResourceName]resource.Quantity{
-						v1.ResourceCPU:  *largeCheapType.Capacity.Cpu(),
-						v1.ResourcePods: *largeCheapType.Capacity.Pods(),
-					},
-				},
-			})
+		fakeClock.Step(10 * time.Minute)
 
-			// there is a pending pod that should land on the node
-			pod := test.UnschedulablePod(test.PodOptions{
-				ResourceRequirements: v1.ResourceRequirements{
-					Requests: map[v1.ResourceName]resource.Quantity{
-						v1.ResourceCPU: resource.MustParse("1"),
-					},
-				},
-			})
-			unsched := test.UnschedulablePod(test.PodOptions{
-				ResourceRequirements: v1.ResourceRequirements{
-					Requests: map[v1.ResourceName]resource.Quantity{
-						v1.ResourceCPU: resource.MustParse("62"),
-					},
-				},
-			})
+		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
 
-			ExpectApplied(ctx, env.Client, nodeClaim1, node1, pod, unsched, nodePool)
-
-			// bind one of the pods to the node
-			ExpectManualBinding(ctx, env.Client, pod, node1)
-
-			// inform cluster state about nodes and nodeclaims
-			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node1}, []*v1beta1.NodeClaim{nodeClaim1})
-
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
-
-			// we don't need any new nodes and consolidation should notice the huge pending pod that needs the large
-			// node to schedule, which prevents the large expensive node from being replaced
-			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
-			Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
-			ExpectExists(ctx, env.Client, nodeClaim1)
-		})
+		// Expect to not create or delete more nodeclaims
+		Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
+		ExpectExists(ctx, env.Client, nodeClaim)
 	})
 })

--- a/pkg/controllers/deprovisioning/nodeclaim_expiration_test.go
+++ b/pkg/controllers/deprovisioning/nodeclaim_expiration_test.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
+	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
 	"github.com/aws/karpenter-core/pkg/cloudprovider/fake"
@@ -73,6 +74,62 @@ var _ = Describe("NodeClaim/Expiration", func() {
 	It("should ignore nodes without the expired status condition", func() {
 		_ = nodeClaim.StatusConditions().ClearCondition(v1beta1.Expired)
 		ExpectApplied(ctx, env.Client, nodeClaim, node, nodePool)
+
+		// inform cluster state about nodes and nodeclaims
+		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
+
+		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+
+		// Expect to not create or delete more nodeclaims
+		Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
+		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
+		ExpectExists(ctx, env.Client, nodeClaim)
+	})
+	It("should ignore nodes with the karpenter.sh/do-not-disrupt annotation", func() {
+		node.Annotations = lo.Assign(node.Annotations, map[string]string{v1beta1.DoNotDisruptAnnotationKey: "true"})
+		ExpectApplied(ctx, env.Client, nodeClaim, node, nodePool)
+
+		// inform cluster state about nodes and nodeclaims
+		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
+
+		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+
+		// Expect to not create or delete more nodeclaims
+		Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
+		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
+		ExpectExists(ctx, env.Client, nodeClaim)
+	})
+	It("should ignore nodes that have pods with the karpenter.sh/do-not-evict annotation", func() {
+		pod := test.Pod(test.PodOptions{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					v1alpha5.DoNotEvictPodAnnotationKey: "true",
+				},
+			},
+		})
+		ExpectApplied(ctx, env.Client, nodeClaim, node, nodePool, pod)
+		ExpectManualBinding(ctx, env.Client, pod, node)
+
+		// inform cluster state about nodes and nodeclaims
+		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
+
+		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+
+		// Expect to not create or delete more nodeclaims
+		Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
+		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
+		ExpectExists(ctx, env.Client, nodeClaim)
+	})
+	It("should ignore nodes that have pods with the karpenter.sh/do-not-disrupt annotation", func() {
+		pod := test.Pod(test.PodOptions{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					v1beta1.DoNotDisruptAnnotationKey: "true",
+				},
+			},
+		})
+		ExpectApplied(ctx, env.Client, nodeClaim, node, nodePool, pod)
+		ExpectManualBinding(ctx, env.Client, pod, node)
 
 		// inform cluster state about nodes and nodeclaims
 		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR adds testing for both `v1alpha5` and `v1beta1` components to validate that both APIs respect the `do-not-consolidate`, `do-not-disrupt`, and `do-not-evict` annotation keys across all deprovisioning mechanisms.

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
