### PR TITLE
feat: Add karpenter.k8s.aws/instance-ami-id label #4637 - add ImageID…

### DIFF
--- a/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodeclaims.yaml
@@ -341,6 +341,9 @@ spec:
                   - type
                   type: object
                 type: array
+              imageId:
+                description: ImageId is the image the node was created from
+                type: string
               nodeName:
                 description: NodeName is the name of the corresponding node object
                 type: string

--- a/pkg/apis/v1beta1/nodeclaim_status.go
+++ b/pkg/apis/v1beta1/nodeclaim_status.go
@@ -27,6 +27,9 @@ type NodeClaimStatus struct {
 	// ProviderID of the corresponding node object
 	// +optional
 	ProviderID string `json:"providerID,omitempty"`
+	// ImageId is the image the node was created from
+	// +optional
+	ImageID string `json:"imageId,omitempty"`
 	// Capacity is the estimated full capacity of the node
 	// +optional
 	Capacity v1.ResourceList `json:"capacity,omitempty"`


### PR DESCRIPTION
… to status field of nodeclaim

<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #4637

**Description**
Add ImageID field to node claim status to help resolve issue #4637 - as this could be the best place to store this node metadata

**How was this change tested?**
ran presubmit locally and in github actions, also pulled this into my karpenter build and ran against my own cluster

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
