### PR TITLE
Status register empty nodepool

### DIFF
--- a/pkg/controllers/nodepool/counter/controller.go
+++ b/pkg/controllers/nodepool/counter/controller.go
@@ -68,7 +68,7 @@ func (c *Controller) Reconcile(ctx context.Context, nodePool *v1beta1.NodePool) 
 	// Determine resource usage and update provisioner.status.resources
 	nodePool.Status.Resources = c.resourceCountsFor(lo.Ternary(nodePool.IsProvisioner, v1alpha5.ProvisionerNameLabelKey, v1beta1.NodePoolLabelKey), nodePool.Name)
 	if !equality.Semantic.DeepEqual(stored, nodePool) {
-		if err := nodepoolutil.PatchStatus(ctx, c.kubeClient, stored, nodePool); err != nil {
+		if err := nodepoolutil.UpdateStatus(ctx, c.kubeClient, nodePool); err != nil {
 			return reconcile.Result{}, client.IgnoreNotFound(err)
 		}
 	}

--- a/pkg/controllers/nodepool/counter/nodepool_test.go
+++ b/pkg/controllers/nodepool/counter/nodepool_test.go
@@ -137,4 +137,19 @@ var _ = Describe("NodePool Counter", func() {
 		Expect(nodePool.Status.Resources).To(BeEquivalentTo(nodeClaim2.Status.Capacity))
 		Expect(nodePool.Status.Resources).To(BeEquivalentTo(node2.Status.Capacity))
 	})
+	It("should decrease the counter to 0 when all nodes are spun down", func() {
+		ExpectApplied(ctx, env.Client, node, nodeClaim)
+		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeController, nodeClaimController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
+
+		ExpectReconcileSucceeded(ctx, nodePoolController, client.ObjectKeyFromObject(nodePool))
+		nodePool = ExpectExists(ctx, env.Client, nodePool)
+
+		ExpectDeleted(ctx, env.Client, node, nodeClaim)
+		ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(node))
+		ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(nodeClaim))
+		ExpectReconcileSucceeded(ctx, nodePoolController, client.ObjectKeyFromObject(nodePool))
+		nodePool = ExpectExists(ctx, env.Client, nodePool)
+
+		Expect(nodePool.Status.Resources).To(BeEmpty())
+	})
 })

--- a/pkg/utils/nodepool/nodepool.go
+++ b/pkg/utils/nodepool/nodepool.go
@@ -159,6 +159,14 @@ func PatchStatus(ctx context.Context, c client.Client, stored, nodePool *v1beta1
 	return c.Status().Patch(ctx, nodePool, client.MergeFrom(stored))
 }
 
+func UpdateStatus(ctx context.Context, c client.Client, nodePool *v1beta1.NodePool) error {
+	if nodePool.IsProvisioner {
+		provisioner := provisionerutil.New(nodePool)
+		return c.Status().Update(ctx, provisioner)
+	}
+	return c.Status().Update(ctx, nodePool)
+}
+
 func HashAnnotation(nodePool *v1beta1.NodePool) map[string]string {
 	if nodePool.IsProvisioner {
 		provisioner := provisionerutil.New(nodePool)


### PR DESCRIPTION
reconcile nodepool controller via updating instead of patching to allow nil map status to be reflected correctly

Fixes [#4628 ](https://github.com/aws/karpenter/issues/4628)

**Description**
Since nodepool controller reconciles with patch, when the last node is deleted, after [resourceCountsFor](https://github.com/aws/karpenter-core/blob/main/pkg/controllers/nodepool/counter/controller.go#L78) returns nil map, the patch would merge this with the existing map and the status cannot be updated to have no CPU and Mem associated with a provisioner. 

**How was this change tested?**
Tested using the included unit test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
