### PR TITLE
fix: Fix patching `nil` resources when converting Provisioner to NodePool

### DIFF
--- a/pkg/controllers/nodepool/counter/nodepool_test.go
+++ b/pkg/controllers/nodepool/counter/nodepool_test.go
@@ -137,4 +137,23 @@ var _ = Describe("NodePool Counter", func() {
 		Expect(nodePool.Status.Resources).To(BeEquivalentTo(nodeClaim2.Status.Capacity))
 		Expect(nodePool.Status.Resources).To(BeEquivalentTo(node2.Status.Capacity))
 	})
+	It("should nil out the counter when all nodes are deleted", func() {
+		ExpectApplied(ctx, env.Client, node, nodeClaim)
+		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeController, nodeClaimController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
+
+		ExpectReconcileSucceeded(ctx, nodePoolController, client.ObjectKeyFromObject(nodePool))
+		nodePool = ExpectExists(ctx, env.Client, nodePool)
+
+		// Should equal both the nodeClaim and node capacity
+		Expect(nodePool.Status.Resources).To(BeEquivalentTo(nodeClaim.Status.Capacity))
+		Expect(nodePool.Status.Resources).To(BeEquivalentTo(node.Status.Capacity))
+
+		ExpectDeleted(ctx, env.Client, node, nodeClaim)
+
+		ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(node))
+		ExpectReconcileSucceeded(ctx, nodeClaimController, client.ObjectKeyFromObject(nodeClaim))
+		ExpectReconcileSucceeded(ctx, nodePoolController, client.ObjectKeyFromObject(nodePool))
+		nodePool = ExpectExists(ctx, env.Client, nodePool)
+		Expect(nodePool.Status.Resources).To(BeNil())
+	})
 })

--- a/pkg/controllers/nodepool/counter/suite_test.go
+++ b/pkg/controllers/nodepool/counter/suite_test.go
@@ -44,7 +44,6 @@ var nodePoolInformerController controller.Controller
 var nodeClaimController controller.Controller
 var machineController controller.Controller
 var nodeController controller.Controller
-var podController controller.Controller
 var ctx context.Context
 var env *test.Environment
 var cluster *state.Cluster
@@ -68,7 +67,6 @@ var _ = BeforeSuite(func() {
 	nodeClaimController = informer.NewNodeClaimController(env.Client, cluster)
 	machineController = informer.NewMachineController(env.Client, cluster)
 	nodeController = informer.NewNodeController(env.Client, cluster)
-	podController = informer.NewPodController(env.Client, cluster)
 	provisionerInformerController = informer.NewProvisionerController(env.Client, cluster)
 	nodePoolInformerController = informer.NewNodePoolController(env.Client, cluster)
 	provisionerController = counter.NewProvisionerController(env.Client, cluster)

--- a/pkg/utils/nodepool/nodepool.go
+++ b/pkg/utils/nodepool/nodepool.go
@@ -59,6 +59,9 @@ func New(provisioner *v1alpha5.Provisioner) *v1beta1.NodePool {
 			},
 			Weight: provisioner.Spec.Weight,
 		},
+		Status: v1beta1.NodePoolStatus{
+			Resources: provisioner.Status.Resources,
+		},
 		IsProvisioner: true,
 	}
 	if provisioner.Spec.TTLSecondsUntilExpired != nil {

--- a/pkg/utils/nodepool/suite_test.go
+++ b/pkg/utils/nodepool/suite_test.go
@@ -228,6 +228,8 @@ var _ = Describe("NodePoolUtils", func() {
 
 		ExpectResources(v1.ResourceList(nodePool.Spec.Limits), provisioner.Spec.Limits.Resources)
 		Expect(lo.FromPtr(nodePool.Spec.Weight)).To(BeNumerically("==", lo.FromPtr(provisioner.Spec.Weight)))
+
+		ExpectResources(nodePool.Status.Resources, provisioner.Status.Resources)
 	})
 	It("should convert a Provisioner to a NodePool (with Provider)", func() {
 		provisioner.Spec.Provider = &runtime.RawExtension{Raw: lo.Must(json.Marshal(map[string]string{

--- a/pkg/utils/provisioner/suite_test.go
+++ b/pkg/utils/provisioner/suite_test.go
@@ -227,6 +227,8 @@ var _ = Describe("ProvisionerUtils", func() {
 
 		ExpectResources(provisioner.Spec.Limits.Resources, v1.ResourceList(nodePool.Spec.Limits))
 		Expect(lo.FromPtr(provisioner.Spec.Weight)).To(BeNumerically("==", lo.FromPtr(nodePool.Spec.Weight)))
+
+		ExpectResources(provisioner.Status.Resources, nodePool.Status.Resources)
 	})
 	It("should convert a Provisioner to a NodePool (with Provider)", func() {
 		nodePool.Spec.Template.Spec.Provider = &runtime.RawExtension{Raw: lo.Must(json.Marshal(map[string]string{


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes https://github.com/aws/karpenter/issues/4628

**Description**

Fixes the conversion logic converting from `v1beta1/NodePool` -> `v1alpha5/Provisioner` to retain the status information so that patch operations that remove details can properly handle this operation.

**How was this change tested?**

`make presubmit`
`make apply` (manual validation)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
