### PR TITLE
feat: Adding CEL validation for the `nodepool.spec.disruption`

### DIFF
--- a/pkg/apis/crds/karpenter.sh_nodepools.yaml
+++ b/pkg/apis/crds/karpenter.sh_nodepools.yaml
@@ -79,6 +79,14 @@ spec:
                     pattern: ^(([0-9]+(s|m|h))+)|(Never)$
                     type: string
                 type: object
+                x-kubernetes-validations:
+                - message: consolidateAfter cannot be combined with consolidationPolicy=WhenUnderutilized
+                  rule: 'has(self.consolidateAfter) ? self.consolidationPolicy !=
+                    ''WhenUnderutilized'' || self.consolidateAfter == ''Never'' :
+                    true'
+                - message: consolidateAfter must be specified with consolidationPolicy=WhenEmpty
+                  rule: 'self.consolidationPolicy == ''WhenEmpty'' ? has(self.consolidateAfter)
+                    : true'
               limits:
                 additionalProperties:
                   anyOf:

--- a/pkg/apis/v1beta1/nodeclaim_validation_test.go
+++ b/pkg/apis/v1beta1/nodeclaim_validation_test.go
@@ -12,7 +12,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta1
+package v1beta1_test
 
 import (
 	"strings"
@@ -24,6 +24,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"knative.dev/pkg/ptr"
+
+	. "github.com/aws/karpenter-core/pkg/apis/v1beta1"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/apis/v1beta1/nodepool.go
+++ b/pkg/apis/v1beta1/nodepool.go
@@ -36,6 +36,8 @@ type NodePoolSpec struct {
 	Template NodeClaimTemplate `json:"template,omitempty"`
 	// Disruption contains the parameters that relate to Karpenter's disruption logic
 	// +kubebuilder:default={"consolidationPolicy": "WhenUnderutilized", "expireAfter": "720h"}
+	// +kubebuilder:validation:XValidation:message="consolidateAfter cannot be combined with consolidationPolicy=WhenUnderutilized",rule="has(self.consolidateAfter) ? self.consolidationPolicy != 'WhenUnderutilized' || self.consolidateAfter == 'Never' : true"
+	// +kubebuilder:validation:XValidation:message="consolidateAfter must be specified with consolidationPolicy=WhenEmpty",rule="self.consolidationPolicy == 'WhenEmpty' ? has(self.consolidateAfter) : true"
 	// +optional
 	Disruption Disruption `json:"disruption"`
 	// Limits define a set of bounds for provisioning capacity.

--- a/pkg/apis/v1beta1/nodepool_validation_cel_test.go
+++ b/pkg/apis/v1beta1/nodepool_validation_cel_test.go
@@ -1,0 +1,102 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1beta1_test
+
+import (
+	"strings"
+	"time"
+
+	"github.com/Pallinder/go-randomdata"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/aws/karpenter-core/pkg/apis"
+	. "github.com/aws/karpenter-core/pkg/apis/v1beta1"
+	"github.com/aws/karpenter-core/pkg/operator/scheme"
+	"github.com/aws/karpenter-core/pkg/test"
+)
+
+var _ = Describe("CEL/Validation", func() {
+	var nodePool *NodePool
+	var env *test.Environment
+
+	BeforeEach(func() {
+		env = test.NewEnvironment(scheme.Scheme, test.WithCRDs(apis.CRDs...))
+		nodePool = &NodePool{
+			ObjectMeta: metav1.ObjectMeta{Name: strings.ToLower(randomdata.SillyName())},
+			Spec: NodePoolSpec{
+				Template: NodeClaimTemplate{
+					Spec: NodeClaimSpec{
+						NodeClassRef: &NodeClassReference{
+							Kind: "NodeClaim",
+							Name: "default",
+						},
+						Requirements: []v1.NodeSelectorRequirement{
+							{
+								Key:      CapacityTypeLabelKey,
+								Operator: v1.NodeSelectorOpExists,
+							},
+						},
+					},
+				},
+			},
+		}
+	})
+	Context("Disruption", func() {
+		It("should fail on negative expireAfter", func() {
+			nodePool.Spec.Disruption.ExpireAfter.Duration = lo.ToPtr(lo.Must(time.ParseDuration("-1s")))
+			Expect(env.Client.Create(ctx, nodePool)).ToNot(Succeed())
+		})
+		It("should succeed on a disabled expireAfter", func() {
+			nodePool.Spec.Disruption.ExpireAfter.Duration = nil
+			Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
+		})
+		It("should succeed on a valid expireAfter", func() {
+			nodePool.Spec.Disruption.ExpireAfter.Duration = lo.ToPtr(lo.Must(time.ParseDuration("30s")))
+			Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
+		})
+		It("should fail on negative consolidateAfter", func() {
+			nodePool.Spec.Disruption.ConsolidateAfter = &NillableDuration{Duration: lo.ToPtr(lo.Must(time.ParseDuration("-1s")))}
+			Expect(env.Client.Create(ctx, nodePool)).ToNot(Succeed())
+		})
+		It("should succeed on a disabled consolidateAfter", func() {
+			nodePool.Spec.Disruption.ConsolidateAfter = &NillableDuration{Duration: nil}
+			Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
+		})
+		It("should succeed on a valid consolidateAfter", func() {
+			nodePool.Spec.Disruption.ConsolidateAfter = &NillableDuration{Duration: lo.ToPtr(lo.Must(time.ParseDuration("30s")))}
+			nodePool.Spec.Disruption.ConsolidationPolicy = ConsolidationPolicyWhenEmpty
+			Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
+		})
+		It("should succeed when setting consolidateAfter with consolidationPolicy=WhenEmpty", func() {
+			nodePool.Spec.Disruption.ConsolidateAfter = &NillableDuration{Duration: lo.ToPtr(lo.Must(time.ParseDuration("30s")))}
+			nodePool.Spec.Disruption.ConsolidationPolicy = ConsolidationPolicyWhenEmpty
+			Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
+		})
+		It("should fail when setting consolidateAfter with consolidationPolicy=WhenUnderutilized", func() {
+			nodePool.Spec.Disruption.ConsolidateAfter = &NillableDuration{Duration: lo.ToPtr(lo.Must(time.ParseDuration("30s")))}
+			nodePool.Spec.Disruption.ConsolidationPolicy = ConsolidationPolicyWhenUnderutilized
+			Expect(env.Client.Create(ctx, nodePool)).ToNot(Succeed())
+		})
+		It("should succeed when not setting consolidateAfter to 'Never' with consolidationPolicy=WhenUnderutilized", func() {
+			nodePool.Spec.Disruption.ConsolidateAfter = &NillableDuration{Duration: nil}
+			nodePool.Spec.Disruption.ConsolidationPolicy = ConsolidationPolicyWhenUnderutilized
+			Expect(env.Client.Create(ctx, nodePool)).To(Succeed())
+		})
+	})
+})

--- a/pkg/apis/v1beta1/nodepool_validation_webhook_test.go
+++ b/pkg/apis/v1beta1/nodepool_validation_webhook_test.go
@@ -12,7 +12,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta1
+package v1beta1_test
 
 import (
 	"fmt"
@@ -28,9 +28,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/sets"
 	"knative.dev/pkg/ptr"
+
+	. "github.com/aws/karpenter-core/pkg/apis/v1beta1"
 )
 
-var _ = Describe("Validation", func() {
+var _ = Describe("Webhook/Validation", func() {
 	var nodePool *NodePool
 
 	BeforeEach(func() {
@@ -514,4 +516,8 @@ var _ = Describe("Limits", func() {
 		provisioner.Status.Resources = v1.ResourceList{"cpu": resource.MustParse("17")}
 		Expect(provisioner.Spec.Limits.ExceededBy(provisioner.Status.Resources)).To(MatchError("cpu resource usage of 17 exceeds limit of 16"))
 	})
+})
+
+var _ = Describe("CEL/Validation", func() {
+
 })

--- a/pkg/apis/v1beta1/suite_test.go
+++ b/pkg/apis/v1beta1/suite_test.go
@@ -12,7 +12,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package v1beta1
+package v1beta1_test
 
 import (
 	"context"

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -106,6 +106,7 @@ func NewEnvironment(scheme *runtime.Scheme, options ...functional.Option[Environ
 		// Ref: https://github.com/aws/karpenter-core/pull/330
 		environment.ControlPlane.GetAPIServer().Configure().Set("feature-gates", "MinDomainsInPodTopologySpread=true")
 	}
+	environment.ControlPlane.GetAPIServer().Configure().Append("feature-gates", "CustomResourceValidationExpressions=true")
 
 	_ = lo.Must(environment.Start())
 	c := lo.Must(client.New(environment.Config, client.Options{Scheme: scheme}))


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Adding CEL validation in the effort of moving away from webhook validation.
- https://github.com/aws/karpenter-core/issues/103

**How was this change tested?**
- `make test`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
