### PR TITLE
ci: Remove 1.22 from our testing

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
         matrix:
-          k8sVersion: ["1.22.x", "1.23.x", "1.24.x", "1.25.x", "1.26.x", "1.27.x", "1.28.x"]
+          k8sVersion: ["1.23.x", "1.24.x", "1.25.x", "1.26.x", "1.27.x", "1.28.x"]
     steps:
     - uses: actions/checkout@v4
     - uses: ./.github/actions/install-deps


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Remove k8s 1.22 from unit testing.
- karpenter does not support 1.22

**How was this change tested?**
- N/A
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
