### PR TITLE
test: Move `env` to be created at the beginning of suite for `v1beta1`

### DIFF
--- a/pkg/apis/v1beta1/nodepool_validation_cel_test.go
+++ b/pkg/apis/v1beta1/nodepool_validation_cel_test.go
@@ -25,18 +25,13 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/aws/karpenter-core/pkg/apis"
 	. "github.com/aws/karpenter-core/pkg/apis/v1beta1"
-	"github.com/aws/karpenter-core/pkg/operator/scheme"
-	"github.com/aws/karpenter-core/pkg/test"
 )
 
 var _ = Describe("CEL/Validation", func() {
 	var nodePool *NodePool
-	var env *test.Environment
 
 	BeforeEach(func() {
-		env = test.NewEnvironment(scheme.Scheme, test.WithCRDs(apis.CRDs...))
 		nodePool = &NodePool{
 			ObjectMeta: metav1.ObjectMeta{Name: strings.ToLower(randomdata.SillyName())},
 			Spec: NodePoolSpec{

--- a/pkg/apis/v1beta1/suite_test.go
+++ b/pkg/apis/v1beta1/suite_test.go
@@ -21,12 +21,30 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	. "knative.dev/pkg/logging/testing"
+
+	"github.com/aws/karpenter-core/pkg/apis"
+	"github.com/aws/karpenter-core/pkg/operator/scheme"
+	"github.com/aws/karpenter-core/pkg/test"
+	. "github.com/aws/karpenter-core/pkg/test/expectations"
 )
 
 var ctx context.Context
+var env *test.Environment
 
 func TestAPIs(t *testing.T) {
 	ctx = TestContextWithLogger(t)
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "v1beta1")
 }
+
+var _ = BeforeSuite(func() {
+	env = test.NewEnvironment(scheme.Scheme, test.WithCRDs(apis.CRDs...))
+})
+
+var _ = AfterEach(func() {
+	ExpectCleanedUp(ctx, env.Client)
+})
+
+var _ = AfterSuite(func() {
+	Expect(env.Stop()).To(Succeed(), "Failed to stop environment")
+})


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
- To improve testing speed, the environment set-up should be create an the beginning of the suite for the v1bata1 test suite.

**How was this change tested?**
- N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
