### PR TITLE
chore: move termination queue to singleton controller

### DIFF
--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -54,10 +54,10 @@ func NewControllers(
 ) []controller.Controller {
 
 	p := provisioning.NewProvisioner(kubeClient, kubernetesInterface.CoreV1(), recorder, cloudProvider, cluster)
-	terminator := terminator.NewTerminator(clock, kubeClient, terminator.NewEvictionQueue(ctx, kubernetesInterface.CoreV1(), recorder))
+	evictionQueue := terminator.NewEvictionQueue(ctx, kubernetesInterface.CoreV1(), recorder)
 
 	return []controller.Controller{
-		p,
+		p, evictionQueue,
 		deprovisioning.NewController(clock, kubeClient, p, cloudProvider, recorder, cluster),
 		provisioning.NewController(kubeClient, p, recorder),
 		nodepoolhash.NewProvisionerController(kubeClient),
@@ -66,7 +66,7 @@ func NewControllers(
 		informer.NewPodController(kubeClient, cluster),
 		informer.NewProvisionerController(kubeClient, cluster),
 		informer.NewMachineController(kubeClient, cluster),
-		termination.NewController(kubeClient, cloudProvider, terminator, recorder),
+		termination.NewController(kubeClient, cloudProvider, terminator.NewTerminator(clock, kubeClient, evictionQueue), recorder),
 		metricspod.NewController(kubeClient),
 		metricsprovisioner.NewController(kubeClient),
 		metricsnode.NewController(cluster),

--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -15,8 +15,6 @@ limitations under the License.
 package controllers
 
 import (
-	"context"
-
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/utils/clock"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -44,7 +42,6 @@ import (
 )
 
 func NewControllers(
-	ctx context.Context,
 	clock clock.Clock,
 	kubeClient client.Client,
 	kubernetesInterface kubernetes.Interface,
@@ -54,7 +51,7 @@ func NewControllers(
 ) []controller.Controller {
 
 	p := provisioning.NewProvisioner(kubeClient, kubernetesInterface.CoreV1(), recorder, cloudProvider, cluster)
-	evictionQueue := terminator.NewEvictionQueue(ctx, kubernetesInterface.CoreV1(), recorder)
+	evictionQueue := terminator.NewQueue(kubernetesInterface.CoreV1(), recorder)
 
 	return []controller.Controller{
 		p, evictionQueue,

--- a/pkg/controllers/deprovisioning/controller.go
+++ b/pkg/controllers/deprovisioning/controller.go
@@ -58,7 +58,6 @@ type Controller struct {
 
 // pollingPeriod that we inspect cluster to look for opportunities to deprovision
 const pollingPeriod = 10 * time.Second
-const immediately = time.Millisecond
 
 var errCandidateDeleting = fmt.Errorf("candidate is deleting")
 
@@ -132,7 +131,7 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 			return reconcile.Result{}, fmt.Errorf("deprovisioning via %q, %w", d, err)
 		}
 		if success {
-			return reconcile.Result{RequeueAfter: immediately}, nil
+			return reconcile.Result{RequeueAfter: controller.Immediately}, nil
 		}
 	}
 

--- a/pkg/controllers/termination/suite_test.go
+++ b/pkg/controllers/termination/suite_test.go
@@ -183,7 +183,7 @@ var _ = Describe("Termination", func() {
 			Expect(env.Client.Delete(ctx, node)).To(Succeed())
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
 			ExpectReconcileSucceeded(ctx, terminationController, client.ObjectKeyFromObject(node))
-			ExpectQueueItemProcessed(ctx, queue)
+			ExpectReconcileSucceeded(ctx, queue, client.ObjectKey{})
 
 			// Expect node to exist and be draining
 			ExpectNodeDraining(env.Client, node.Name)
@@ -209,7 +209,7 @@ var _ = Describe("Termination", func() {
 			Expect(env.Client.Delete(ctx, node)).To(Succeed())
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
 			ExpectReconcileSucceeded(ctx, terminationController, client.ObjectKeyFromObject(node))
-			ExpectQueueItemProcessed(ctx, queue)
+			ExpectReconcileSucceeded(ctx, queue, client.ObjectKey{})
 
 			// Expect pod with no owner ref to be enqueued for eviction
 			ExpectEvicted(env.Client, pod)
@@ -267,7 +267,7 @@ var _ = Describe("Termination", func() {
 			Expect(env.Client.Delete(ctx, node)).To(Succeed())
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
 			ExpectReconcileSucceeded(ctx, terminationController, client.ObjectKeyFromObject(node))
-			ExpectQueueItemProcessed(ctx, queue)
+			ExpectReconcileSucceeded(ctx, queue, client.ObjectKey{})
 
 			// Expect node to exist and be draining
 			ExpectNodeDraining(env.Client, node.Name)
@@ -297,7 +297,7 @@ var _ = Describe("Termination", func() {
 			Expect(env.Client.Delete(ctx, node)).To(Succeed())
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
 			ExpectReconcileSucceeded(ctx, terminationController, client.ObjectKeyFromObject(node))
-			ExpectQueueItemProcessed(ctx, queue)
+			ExpectReconcileSucceeded(ctx, queue, client.ObjectKey{})
 
 			// Expect node to exist and be draining
 			ExpectNodeDraining(env.Client, node.Name)
@@ -309,10 +309,10 @@ var _ = Describe("Termination", func() {
 			// Expect the critical pods to be evicted and deleted
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
 			ExpectReconcileSucceeded(ctx, terminationController, client.ObjectKeyFromObject(node))
-			ExpectQueueItemProcessed(ctx, queue)
+			ExpectReconcileSucceeded(ctx, queue, client.ObjectKey{})
 			ExpectEvicted(env.Client, podNodeCritical)
 			ExpectDeleted(ctx, env.Client, podNodeCritical)
-			ExpectQueueItemProcessed(ctx, queue)
+			ExpectReconcileSucceeded(ctx, queue, client.ObjectKey{})
 			ExpectEvicted(env.Client, podClusterCritical)
 			ExpectDeleted(ctx, env.Client, podClusterCritical)
 
@@ -342,7 +342,7 @@ var _ = Describe("Termination", func() {
 			Expect(env.Client.Delete(ctx, node)).To(Succeed())
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
 			ExpectReconcileSucceeded(ctx, terminationController, client.ObjectKeyFromObject(node))
-			ExpectQueueItemProcessed(ctx, queue)
+			ExpectReconcileSucceeded(ctx, queue, client.ObjectKey{})
 
 			// Expect mirror pod to not be queued for eviction
 			ExpectNotEnqueuedForEviction(queue, podNoEvict)
@@ -374,8 +374,8 @@ var _ = Describe("Termination", func() {
 			Expect(env.Client.Delete(ctx, node)).To(Succeed())
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
 			ExpectReconcileSucceeded(ctx, terminationController, client.ObjectKeyFromObject(node))
-			ExpectQueueItemProcessed(ctx, queue)
-			ExpectQueueItemProcessed(ctx, queue)
+			ExpectReconcileSucceeded(ctx, queue, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, queue, client.ObjectKey{})
 
 			// Expect the pods to be evicted
 			ExpectEvicted(env.Client, pods[0], pods[1])
@@ -407,8 +407,8 @@ var _ = Describe("Termination", func() {
 			Expect(env.Client.Delete(ctx, node)).To(Succeed())
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
 			ExpectReconcileSucceeded(ctx, terminationController, client.ObjectKeyFromObject(node))
-			ExpectQueueItemProcessed(ctx, queue)
-			ExpectQueueItemProcessed(ctx, queue)
+			ExpectReconcileSucceeded(ctx, queue, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, queue, client.ObjectKey{})
 
 			// Expect the pods to be evicted
 			ExpectEvicted(env.Client, pods[0], pods[1])
@@ -437,7 +437,7 @@ var _ = Describe("Termination", func() {
 			// Before grace period, node should not delete
 			Expect(env.Client.Delete(ctx, node)).To(Succeed())
 			ExpectReconcileSucceeded(ctx, terminationController, client.ObjectKeyFromObject(node))
-			ExpectQueueItemProcessed(ctx, queue)
+			ExpectReconcileSucceeded(ctx, queue, client.ObjectKey{})
 			ExpectNodeExists(ctx, env.Client, node.Name)
 			ExpectEvicted(env.Client, pod)
 
@@ -496,10 +496,4 @@ func ExpectNodeDraining(c client.Client, nodeName string) *v1.Node {
 	Expect(lo.Contains(node.Finalizers, v1alpha5.TerminationFinalizer)).To(BeTrue())
 	Expect(node.DeletionTimestamp.IsZero()).To(BeFalse())
 	return node
-}
-
-func ExpectQueueItemProcessed(ctx context.Context, queue *terminator.Queue) {
-	nn, shutdown := queue.Pop()
-	Expect(shutdown).To(BeFalse())
-	queue.ProcessItem(ctx, nn)
 }

--- a/pkg/controllers/termination/suite_test.go
+++ b/pkg/controllers/termination/suite_test.go
@@ -51,7 +51,7 @@ import (
 
 var ctx context.Context
 var terminationController controller.Controller
-var evictionQueue *terminator.EvictionQueue
+var evictionQueue *terminator.Queue
 var env *test.Environment
 var defaultOwnerRefs = []metav1.OwnerReference{{Kind: "ReplicaSet", APIVersion: "appsv1", Name: "rs", UID: "1234567890"}}
 var fakeClock *clock.FakeClock
@@ -68,7 +68,7 @@ var _ = BeforeSuite(func() {
 	env = test.NewEnvironment(scheme.Scheme, test.WithCRDs(apis.CRDs...), test.WithFieldIndexers(test.MachineFieldIndexer(ctx), test.NodeClaimFieldIndexer(ctx)))
 
 	cloudProvider = fake.NewCloudProvider()
-	evictionQueue = terminator.NewEvictionQueue(ctx, env.KubernetesInterface.CoreV1(), events.NewRecorder(&record.FakeRecorder{}))
+	evictionQueue = terminator.NewQueue(env.KubernetesInterface.CoreV1(), events.NewRecorder(&record.FakeRecorder{}))
 	terminationController = termination.NewController(env.Client, cloudProvider, terminator.NewTerminator(fakeClock, env.Client, evictionQueue), events.NewRecorder(&record.FakeRecorder{}))
 })
 
@@ -466,7 +466,7 @@ var _ = Describe("Termination", func() {
 	})
 })
 
-func ExpectNotEnqueuedForEviction(e *terminator.EvictionQueue, pods ...*v1.Pod) {
+func ExpectNotEnqueuedForEviction(e *terminator.Queue, pods ...*v1.Pod) {
 	for _, pod := range pods {
 		ExpectWithOffset(1, e.Contains(client.ObjectKeyFromObject(pod))).To(BeFalse())
 	}

--- a/pkg/controllers/termination/suite_test.go
+++ b/pkg/controllers/termination/suite_test.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/samber/lo"
-	"k8s.io/client-go/tools/record"
 	clock "k8s.io/utils/clock/testing"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -32,7 +31,6 @@ import (
 	"github.com/aws/karpenter-core/pkg/cloudprovider/fake"
 	"github.com/aws/karpenter-core/pkg/controllers/termination"
 	"github.com/aws/karpenter-core/pkg/controllers/termination/terminator"
-	"github.com/aws/karpenter-core/pkg/events"
 	"github.com/aws/karpenter-core/pkg/metrics"
 	"github.com/aws/karpenter-core/pkg/operator/controller"
 	"github.com/aws/karpenter-core/pkg/operator/scheme"
@@ -51,11 +49,12 @@ import (
 
 var ctx context.Context
 var terminationController controller.Controller
-var evictionQueue *terminator.Queue
 var env *test.Environment
 var defaultOwnerRefs = []metav1.OwnerReference{{Kind: "ReplicaSet", APIVersion: "appsv1", Name: "rs", UID: "1234567890"}}
 var fakeClock *clock.FakeClock
 var cloudProvider *fake.CloudProvider
+var recorder *test.EventRecorder
+var queue *terminator.Queue
 
 func TestAPIs(t *testing.T) {
 	ctx = TestContextWithLogger(t)
@@ -68,8 +67,9 @@ var _ = BeforeSuite(func() {
 	env = test.NewEnvironment(scheme.Scheme, test.WithCRDs(apis.CRDs...), test.WithFieldIndexers(test.MachineFieldIndexer(ctx), test.NodeClaimFieldIndexer(ctx)))
 
 	cloudProvider = fake.NewCloudProvider()
-	evictionQueue = terminator.NewQueue(env.KubernetesInterface.CoreV1(), events.NewRecorder(&record.FakeRecorder{}))
-	terminationController = termination.NewController(env.Client, cloudProvider, terminator.NewTerminator(fakeClock, env.Client, evictionQueue), events.NewRecorder(&record.FakeRecorder{}))
+	recorder = test.NewEventRecorder()
+	queue = terminator.NewQueue(env.KubernetesInterface.CoreV1(), recorder)
+	terminationController = termination.NewController(env.Client, cloudProvider, terminator.NewTerminator(fakeClock, env.Client, queue), recorder)
 })
 
 var _ = AfterSuite(func() {
@@ -85,6 +85,7 @@ var _ = Describe("Termination", func() {
 		nodeClaim, node = test.NodeClaimAndNode(v1beta1.NodeClaim{ObjectMeta: metav1.ObjectMeta{Finalizers: []string{v1beta1.TerminationFinalizer}}})
 		machine = test.Machine(v1alpha5.Machine{ObjectMeta: metav1.ObjectMeta{Finalizers: []string{v1beta1.TerminationFinalizer}}, Status: v1alpha5.MachineStatus{ProviderID: node.Spec.ProviderID}})
 		cloudProvider.CreatedNodeClaims[node.Spec.ProviderID] = nodeclaimutil.New(machine)
+		queue.Reset()
 	})
 
 	AfterEach(func() {
@@ -182,6 +183,7 @@ var _ = Describe("Termination", func() {
 			Expect(env.Client.Delete(ctx, node)).To(Succeed())
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
 			ExpectReconcileSucceeded(ctx, terminationController, client.ObjectKeyFromObject(node))
+			ExpectQueueItemProcessed(ctx, queue)
 
 			// Expect node to exist and be draining
 			ExpectNodeDraining(env.Client, node.Name)
@@ -207,6 +209,7 @@ var _ = Describe("Termination", func() {
 			Expect(env.Client.Delete(ctx, node)).To(Succeed())
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
 			ExpectReconcileSucceeded(ctx, terminationController, client.ObjectKeyFromObject(node))
+			ExpectQueueItemProcessed(ctx, queue)
 
 			// Expect pod with no owner ref to be enqueued for eviction
 			ExpectEvicted(env.Client, pod)
@@ -264,13 +267,14 @@ var _ = Describe("Termination", func() {
 			Expect(env.Client.Delete(ctx, node)).To(Succeed())
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
 			ExpectReconcileSucceeded(ctx, terminationController, client.ObjectKeyFromObject(node))
+			ExpectQueueItemProcessed(ctx, queue)
 
 			// Expect node to exist and be draining
 			ExpectNodeDraining(env.Client, node.Name)
 
 			// Expect podNoEvict to fail eviction due to PDB, and be retried
 			Eventually(func() int {
-				return evictionQueue.NumRequeues(client.ObjectKeyFromObject(podNoEvict))
+				return queue.NumRequeues(client.ObjectKeyFromObject(podNoEvict))
 			}).Should(BeNumerically(">=", 1))
 
 			// Delete pod to simulate successful eviction
@@ -293,6 +297,7 @@ var _ = Describe("Termination", func() {
 			Expect(env.Client.Delete(ctx, node)).To(Succeed())
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
 			ExpectReconcileSucceeded(ctx, terminationController, client.ObjectKeyFromObject(node))
+			ExpectQueueItemProcessed(ctx, queue)
 
 			// Expect node to exist and be draining
 			ExpectNodeDraining(env.Client, node.Name)
@@ -304,8 +309,10 @@ var _ = Describe("Termination", func() {
 			// Expect the critical pods to be evicted and deleted
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
 			ExpectReconcileSucceeded(ctx, terminationController, client.ObjectKeyFromObject(node))
+			ExpectQueueItemProcessed(ctx, queue)
 			ExpectEvicted(env.Client, podNodeCritical)
 			ExpectDeleted(ctx, env.Client, podNodeCritical)
+			ExpectQueueItemProcessed(ctx, queue)
 			ExpectEvicted(env.Client, podClusterCritical)
 			ExpectDeleted(ctx, env.Client, podClusterCritical)
 
@@ -335,9 +342,10 @@ var _ = Describe("Termination", func() {
 			Expect(env.Client.Delete(ctx, node)).To(Succeed())
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
 			ExpectReconcileSucceeded(ctx, terminationController, client.ObjectKeyFromObject(node))
+			ExpectQueueItemProcessed(ctx, queue)
 
 			// Expect mirror pod to not be queued for eviction
-			ExpectNotEnqueuedForEviction(evictionQueue, podNoEvict)
+			ExpectNotEnqueuedForEviction(queue, podNoEvict)
 
 			// Expect podEvict to be enqueued for eviction then be successful
 			ExpectEvicted(env.Client, podEvict)
@@ -359,16 +367,15 @@ var _ = Describe("Termination", func() {
 
 		})
 		It("should not delete nodes until all pods are deleted", func() {
-			pods := []*v1.Pod{
-				test.Pod(test.PodOptions{NodeName: node.Name, ObjectMeta: metav1.ObjectMeta{OwnerReferences: defaultOwnerRefs}}),
-				test.Pod(test.PodOptions{NodeName: node.Name, ObjectMeta: metav1.ObjectMeta{OwnerReferences: defaultOwnerRefs}}),
-			}
+			pods := test.Pods(2, test.PodOptions{NodeName: node.Name, ObjectMeta: metav1.ObjectMeta{OwnerReferences: defaultOwnerRefs}})
 			ExpectApplied(ctx, env.Client, node, pods[0], pods[1])
 
 			// Trigger Termination Controller
 			Expect(env.Client.Delete(ctx, node)).To(Succeed())
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
 			ExpectReconcileSucceeded(ctx, terminationController, client.ObjectKeyFromObject(node))
+			ExpectQueueItemProcessed(ctx, queue)
+			ExpectQueueItemProcessed(ctx, queue)
 
 			// Expect the pods to be evicted
 			ExpectEvicted(env.Client, pods[0], pods[1])
@@ -393,16 +400,15 @@ var _ = Describe("Termination", func() {
 			ExpectNotFound(ctx, env.Client, node)
 		})
 		It("should delete nodes with no underlying instance even if not fully drained", func() {
-			pods := []*v1.Pod{
-				test.Pod(test.PodOptions{NodeName: node.Name, ObjectMeta: metav1.ObjectMeta{OwnerReferences: defaultOwnerRefs}}),
-				test.Pod(test.PodOptions{NodeName: node.Name, ObjectMeta: metav1.ObjectMeta{OwnerReferences: defaultOwnerRefs}}),
-			}
+			pods := test.Pods(2, test.PodOptions{NodeName: node.Name, ObjectMeta: metav1.ObjectMeta{OwnerReferences: defaultOwnerRefs}})
 			ExpectApplied(ctx, env.Client, node, pods[0], pods[1])
 
 			// Trigger Termination Controller
 			Expect(env.Client.Delete(ctx, node)).To(Succeed())
 			node = ExpectNodeExists(ctx, env.Client, node.Name)
 			ExpectReconcileSucceeded(ctx, terminationController, client.ObjectKeyFromObject(node))
+			ExpectQueueItemProcessed(ctx, queue)
+			ExpectQueueItemProcessed(ctx, queue)
 
 			// Expect the pods to be evicted
 			ExpectEvicted(env.Client, pods[0], pods[1])
@@ -431,6 +437,7 @@ var _ = Describe("Termination", func() {
 			// Before grace period, node should not delete
 			Expect(env.Client.Delete(ctx, node)).To(Succeed())
 			ExpectReconcileSucceeded(ctx, terminationController, client.ObjectKeyFromObject(node))
+			ExpectQueueItemProcessed(ctx, queue)
 			ExpectNodeExists(ctx, env.Client, node.Name)
 			ExpectEvicted(env.Client, pod)
 
@@ -489,4 +496,10 @@ func ExpectNodeDraining(c client.Client, nodeName string) *v1.Node {
 	Expect(lo.Contains(node.Finalizers, v1alpha5.TerminationFinalizer)).To(BeTrue())
 	Expect(node.DeletionTimestamp.IsZero()).To(BeFalse())
 	return node
+}
+
+func ExpectQueueItemProcessed(ctx context.Context, queue *terminator.Queue) {
+	nn, shutdown := queue.Pop()
+	Expect(shutdown).To(BeFalse())
+	queue.ProcessItem(ctx, nn)
 }

--- a/pkg/controllers/termination/terminator/eviction.go
+++ b/pkg/controllers/termination/terminator/eviction.go
@@ -100,7 +100,7 @@ func (q *Queue) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.R
 	// Get pod from queue. This waits until queue is non-empty.
 	item, shutdown := q.RateLimitingInterface.Get()
 	if shutdown {
-		return reconcile.Result{RequeueAfter: controller.Immediately}, nil
+		return reconcile.Result{}, fmt.Errorf("EvictionQueue is broken and has shutdown")
 	}
 	nn := item.(types.NamespacedName)
 	defer q.RateLimitingInterface.Done(nn)

--- a/pkg/controllers/termination/terminator/eviction.go
+++ b/pkg/controllers/termination/terminator/eviction.go
@@ -117,14 +117,13 @@ func (q *Queue) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.R
 }
 
 func (q *Queue) ProcessItem(ctx context.Context, nn types.NamespacedName) {
+	defer q.RateLimitingInterface.Done(nn)
 	// Evict pod
 	if q.Evict(ctx, nn) {
 		q.RateLimitingInterface.Forget(nn)
 		q.Set.Remove(nn)
-		q.RateLimitingInterface.Done(nn)
 		return
 	}
-	q.RateLimitingInterface.Done(nn)
 	// Requeue pod if eviction failed
 	q.RateLimitingInterface.AddRateLimited(nn)
 }

--- a/pkg/controllers/termination/terminator/suite_test.go
+++ b/pkg/controllers/termination/terminator/suite_test.go
@@ -1,0 +1,123 @@
+/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package terminator_test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	policyv1 "k8s.io/api/policy/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	. "knative.dev/pkg/logging/testing"
+
+	"github.com/aws/karpenter-core/pkg/controllers/termination/terminator"
+
+	v1 "k8s.io/api/core/v1"
+
+	"github.com/aws/karpenter-core/pkg/apis"
+	"github.com/aws/karpenter-core/pkg/apis/settings"
+	"github.com/aws/karpenter-core/pkg/operator/scheme"
+	"github.com/aws/karpenter-core/pkg/test"
+	. "github.com/aws/karpenter-core/pkg/test/expectations"
+)
+
+var ctx context.Context
+var env *test.Environment
+var recorder *test.EventRecorder
+var queue *terminator.Queue
+var pdb *policyv1.PodDisruptionBudget
+var pod *v1.Pod
+
+func TestAPIs(t *testing.T) {
+	ctx = TestContextWithLogger(t)
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Eviction")
+}
+
+var _ = BeforeSuite(func() {
+	env = test.NewEnvironment(scheme.Scheme, test.WithCRDs(apis.CRDs...))
+	ctx = settings.ToContext(ctx, test.Settings(settings.Settings{DriftEnabled: true}))
+	recorder = test.NewEventRecorder()
+	queue = terminator.NewQueue(env.KubernetesInterface.CoreV1(), recorder)
+})
+
+var _ = AfterSuite(func() {
+	Expect(env.Stop()).To(Succeed(), "Failed to stop environment")
+})
+
+var _ = BeforeEach(func() {
+	recorder.Reset() // Reset the events that we captured during the run
+	// Shut down the queue and restart it to ensure no races
+	queue.Reset()
+})
+
+var _ = AfterEach(func() {
+	ExpectCleanedUp(ctx, env.Client)
+})
+
+var testLabels = map[string]string{"test": "label"}
+
+var _ = Describe("Eviction/Queue", func() {
+	BeforeEach(func() {
+		pdb = test.PodDisruptionBudget(test.PDBOptions{
+			Labels:         testLabels,
+			MaxUnavailable: &intstr.IntOrString{IntVal: 0},
+		})
+		pod = test.Pod(test.PodOptions{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: testLabels,
+			},
+		})
+	})
+
+	Context("Eviction API", func() {
+		It("should succeed with no event when the pod is not found", func() {
+			ExpectApplied(ctx, env.Client, pdb)
+			Expect(queue.Evict(ctx, types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace})).To(BeTrue())
+			Expect(recorder.Events()).To(HaveLen(0))
+		})
+		It("should succeed with an evicted event when there are no PDBs", func() {
+			ExpectApplied(ctx, env.Client, pod)
+			Expect(queue.Evict(ctx, types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace})).To(BeTrue())
+			Expect(recorder.Calls("Evicted")).To(Equal(1))
+		})
+		It("should succeed with no event when there are PDBs that allow an eviction", func() {
+			pdb = test.PodDisruptionBudget(test.PDBOptions{
+				Labels:         testLabels,
+				MaxUnavailable: &intstr.IntOrString{IntVal: 1},
+			})
+			ExpectApplied(ctx, env.Client, pod)
+			Expect(queue.Evict(ctx, types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace})).To(BeTrue())
+			Expect(recorder.Calls("Evicted")).To(Equal(1))
+		})
+		It("should return a NodeDrainError event when a PDB is blocking", func() {
+			ExpectApplied(ctx, env.Client, pdb, pod)
+			Expect(queue.Evict(ctx, types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace})).To(BeFalse())
+			Expect(recorder.Calls("FailedDraining")).To(Equal(1))
+		})
+		It("should fail when two PDBs refer to the same pod", func() {
+			pdb2 := test.PodDisruptionBudget(test.PDBOptions{
+				Labels:         testLabels,
+				MaxUnavailable: &intstr.IntOrString{IntVal: 0},
+			})
+			ExpectApplied(ctx, env.Client, pdb, pdb2, pod)
+			Expect(queue.Evict(ctx, types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace})).To(BeFalse())
+		})
+	})
+})

--- a/pkg/controllers/termination/terminator/terminator.go
+++ b/pkg/controllers/termination/terminator/terminator.go
@@ -32,10 +32,10 @@ import (
 type Terminator struct {
 	clock         clock.Clock
 	kubeClient    client.Client
-	evictionQueue *EvictionQueue
+	evictionQueue *Queue
 }
 
-func NewTerminator(clk clock.Clock, kubeClient client.Client, eq *EvictionQueue) *Terminator {
+func NewTerminator(clk clock.Clock, kubeClient client.Client, eq *Queue) *Terminator {
 	return &Terminator{
 		clock:         clk,
 		kubeClient:    kubeClient,
@@ -86,7 +86,7 @@ func (t *Terminator) Drain(ctx context.Context, node *v1.Node) error {
 		podsToEvict = append(podsToEvict, p)
 	}
 	// Enqueue for eviction
-	t.evict(podsToEvict)
+	t.Evict(podsToEvict)
 
 	if len(podsToEvict) > 0 {
 		return NewNodeDrainError(fmt.Errorf("%d pods are waiting to be evicted", len(podsToEvict)))
@@ -115,7 +115,7 @@ func (t *Terminator) getPods(ctx context.Context, node *v1.Node) ([]*v1.Pod, err
 	return pods, nil
 }
 
-func (t *Terminator) evict(pods []*v1.Pod) {
+func (t *Terminator) Evict(pods []*v1.Pod) {
 	// 1. Prioritize noncritical pods https://kubernetes.io/docs/concepts/architecture/nodes/#graceful-node-shutdown
 	critical := []*v1.Pod{}
 	nonCritical := []*v1.Pod{}

--- a/pkg/events/suite_test.go
+++ b/pkg/events/suite_test.go
@@ -137,7 +137,6 @@ var _ = Describe("Rate Limiting", func() {
 			eventRecorder.Publish(schedulingevents.NominatePodEvent(PodWithUID(), NodeWithUID(), NodeClaimWithUID()))
 		}
 		Expect(internalRecorder.Calls(schedulingevents.NominatePodEvent(PodWithUID(), NodeWithUID(), NodeClaimWithUID()).Reason)).To(Equal(10))
-
 	})
 	It("should allow many events over time due to smoothed rate limiting", func() {
 		for i := 0; i < 3; i++ {

--- a/pkg/operator/controller/singleton.go
+++ b/pkg/operator/controller/singleton.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	Immediately = 1 * time.Millisecond
+	Immediately = 1 * time.Nanosecond
 )
 
 type SingletonBuilder struct {

--- a/pkg/operator/controller/singleton.go
+++ b/pkg/operator/controller/singleton.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	Immediately = time.Millisecond
+	Immediately = 1 * time.Millisecond
 )
 
 type SingletonBuilder struct {

--- a/pkg/operator/controller/singleton.go
+++ b/pkg/operator/controller/singleton.go
@@ -30,6 +30,10 @@ import (
 	"github.com/aws/karpenter-core/pkg/metrics"
 )
 
+const (
+	Immediately = time.Millisecond
+)
+
 type SingletonBuilder struct {
 	mgr manager.Manager
 }

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -44,7 +44,7 @@ import (
 	"github.com/aws/karpenter-core/pkg/apis"
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/events"
-	corecontroller "github.com/aws/karpenter-core/pkg/operator/controller"
+	"github.com/aws/karpenter-core/pkg/operator/controller"
 	"github.com/aws/karpenter-core/pkg/operator/injection"
 	"github.com/aws/karpenter-core/pkg/operator/logging"
 	"github.com/aws/karpenter-core/pkg/operator/options"
@@ -155,7 +155,7 @@ func NewOperator() (context.Context, *Operator) {
 	}
 }
 
-func (o *Operator) WithControllers(ctx context.Context, controllers ...corecontroller.Controller) *Operator {
+func (o *Operator) WithControllers(ctx context.Context, controllers ...controller.Controller) *Operator {
 	for _, c := range controllers {
 		lo.Must0(c.Builder(ctx, o.Manager).Complete(c))
 	}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
This makes the termination controller into a singleton controller. This removes the goroutine from the constructor and allow the underlying controller manager to start/cancel the context so that this goroutine cleans up with Karpenter is shutting down.

**How was this change tested?**
- make presubmit
- applied to local cluster

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
