### PR TITLE
fix: Sync nodes that are Initialized from cluster state

### DIFF
--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -513,6 +513,12 @@ func (c *Cluster) populateInflight(ctx context.Context, n *StateNode) error {
 	if err != nil {
 		return client.IgnoreNotFound(err)
 	}
+	if n.Initialized() {
+		n.inflightInitialized = true
+		n.inflightCapacity = n.Capacity()
+		n.inflightAllocatable = n.Allocatable()
+		return nil
+	}
 	instanceTypes, err := c.cloudProvider.GetInstanceTypes(ctx, owner)
 	if err != nil {
 		return err

--- a/pkg/controllers/state/suite_test.go
+++ b/pkg/controllers/state/suite_test.go
@@ -524,37 +524,6 @@ var _ = Describe("Inflight Nodes", func() {
 		// Still expect to succeed w/o instance type since inflight details are set once
 		ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(node))
 	})
-	It("should populate node from the cluster if the node initialized", func() {
-		instanceType := cloudProvider.InstanceTypes[0]
-		node := test.Node(test.NodeOptions{
-			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
-				v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
-				v1.LabelInstanceTypeStable:       instanceType.Name,
-				v1beta1.NodeInitializedLabelKey:  "true",
-			}},
-			ProviderID: test.RandomProviderID(),
-			Capacity: v1.ResourceList{
-				v1.ResourceCPU:    resource.MustParse(fmt.Sprintf("%d", 64)),
-				v1.ResourceMemory: resource.MustParse(fmt.Sprintf("%dGi", 128)),
-			},
-			Allocatable: v1.ResourceList{
-				v1.ResourceCPU:    resource.MustParse(fmt.Sprintf("%d", 32)),
-				v1.ResourceMemory: resource.MustParse(fmt.Sprintf("%dGi", 64)),
-			},
-		})
-		ExpectApplied(ctx, env.Client, node)
-		ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(node))
-
-		ExpectStateNodeCount("==", 1)
-		NotExpectResources(instanceType.Allocatable(), ExpectStateNodeExists(node).Allocatable())
-		NotExpectResources(instanceType.Capacity, ExpectStateNodeExists(node).Capacity())
-		ExpectResources(node.Status.Allocatable, ExpectStateNodeExists(node).Allocatable())
-		ExpectResources(node.Status.Capacity, ExpectStateNodeExists(node).Capacity())
-
-		cloudProvider.InstanceTypes = cloudProvider.InstanceTypes[1:]
-		// Still expect to succeed w/o instance type since inflight details are set once
-		ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(node))
-	})
 	It("should populate node from the cluster if we have no instance types", func() {
 		cloudProvider.InstanceTypes = []*corecloudprovider.InstanceType{}
 		node := test.Node(test.NodeOptions{
@@ -608,6 +577,31 @@ var _ = Describe("Inflight Nodes", func() {
 			v1.ResourceCPU:              *instanceType.Capacity.Cpu(),
 			v1.ResourceEphemeralStorage: resource.MustParse("100Gi"), // pulled from the node's real capacity
 		}, ExpectStateNodeExists(node).Capacity())
+	})
+	It("should consider the node capacity/allocatable to be equal to the node when the node is initialized", func() {
+		instanceType := cloudProvider.InstanceTypes[0]
+		node := test.Node(test.NodeOptions{
+			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
+				v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
+				v1.LabelInstanceTypeStable:       instanceType.Name,
+				v1beta1.NodeInitializedLabelKey:  "true",
+			}},
+			ProviderID: test.RandomProviderID(),
+			Capacity: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse(fmt.Sprintf("%d", 64)),
+				v1.ResourceMemory: resource.MustParse(fmt.Sprintf("%dGi", 128)),
+			},
+			Allocatable: v1.ResourceList{
+				v1.ResourceCPU:    resource.MustParse(fmt.Sprintf("%d", 32)),
+				v1.ResourceMemory: resource.MustParse(fmt.Sprintf("%dGi", 64)),
+			},
+		})
+		ExpectApplied(ctx, env.Client, node)
+		ExpectReconcileSucceeded(ctx, nodeController, client.ObjectKeyFromObject(node))
+
+		ExpectStateNodeCount("==", 1)
+		ExpectResources(node.Status.Allocatable, ExpectStateNodeExists(node).Allocatable())
+		ExpectResources(node.Status.Capacity, ExpectStateNodeExists(node).Capacity())
 	})
 	It("should only set startup taints once", func() {
 		taints := []v1.Taint{

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -593,6 +593,15 @@ func ExpectResources(expected, real v1.ResourceList) {
 	}
 }
 
+// NotExpectResources expects all the resources in expected to not exist in real with the same values
+func NotExpectResources(expected, real v1.ResourceList) {
+	GinkgoHelper()
+	for k, v := range expected {
+		realV := real[k]
+		Expect(v.Value()).ToNot(BeNumerically("~", realV.Value()))
+	}
+}
+
 func ExpectNodes(ctx context.Context, c client.Client) []*v1.Node {
 	GinkgoHelper()
 	nodeList := &v1.NodeList{}

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -593,15 +593,6 @@ func ExpectResources(expected, real v1.ResourceList) {
 	}
 }
 
-// NotExpectResources expects all the resources in expected to not exist in real with the same values
-func NotExpectResources(expected, real v1.ResourceList) {
-	GinkgoHelper()
-	for k, v := range expected {
-		realV := real[k]
-		Expect(v.Value()).ToNot(BeNumerically("~", realV.Value()))
-	}
-}
-
 func ExpectNodes(ctx context.Context, c client.Client) []*v1.Node {
 	GinkgoHelper()
 	nodeList := &v1.NodeList{}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #567 

**Description**
- Provisioning can hang when AWSNodeTemplate doesn't exist and Karpenter is restart, this will block karpenter from provisioning and deprovisioning nodes 

**How was this change tested?**
- Manually tested

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
