### PR TITLE
chore: Rename filename for empty node consolidation

### DIFF
--- a/pkg/controllers/deprovisioning/controller.go
+++ b/pkg/controllers/deprovisioning/controller.go
@@ -93,7 +93,7 @@ func NewController(clk clock.Clock, kubeClient client.Client, provisioner *provi
 			// Delete any remaining empty NodeClaims as there is zero cost in terms of disruption.  Emptiness and
 			// emptyNodeConsolidation are mutually exclusive, only one of these will operate
 			NewEmptiness(clk),
-			NewEmptyNodeClaimConsolidation(clk, cluster, kubeClient, provisioner, cp, recorder),
+			NewEmptyNodeConsolidation(clk, cluster, kubeClient, provisioner, cp, recorder),
 			// Attempt to identify multiple NodeClaims that we can consolidate simultaneously to reduce pod churn
 			NewMultiNodeConsolidation(clk, cluster, kubeClient, provisioner, cp, recorder),
 			// And finally fall back our single NodeClaim consolidation to further reduce cluster cost.

--- a/pkg/controllers/deprovisioning/emptynodeconsolidation.go
+++ b/pkg/controllers/deprovisioning/emptynodeconsolidation.go
@@ -35,7 +35,7 @@ type EmptyNodeConsolidation struct {
 	consolidation
 }
 
-func NewEmptyNodeClaimConsolidation(clk clock.Clock, cluster *state.Cluster, kubeClient client.Client,
+func NewEmptyNodeConsolidation(clk clock.Clock, cluster *state.Cluster, kubeClient client.Client,
 	provisioner *provisioning.Provisioner, cp cloudprovider.CloudProvider, recorder events.Recorder) *EmptyNodeConsolidation {
 	return &EmptyNodeConsolidation{consolidation: makeConsolidation(clk, cluster, kubeClient, provisioner, cp, recorder)}
 }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change updates the filename and constructor for `emptynodeclaimconsolidation` to be `emptynodeconsolidation`

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
