### PR TITLE
fix: Fix using the wrong pods when validating `do-not-evict` pods

### DIFF
--- a/pkg/controllers/deprovisioning/emptynodeconsolidation.go
+++ b/pkg/controllers/deprovisioning/emptynodeconsolidation.go
@@ -76,6 +76,8 @@ func (c *EmptyNodeConsolidation) ComputeCommand(ctx context.Context, candidates 
 		logging.FromContext(ctx).Errorf("computing validation candidates %s", err)
 		return Command{}, err
 	}
+	// Get the current representation of the proposed candidates from before the validation timeout
+	// We do this so that we can re-validate that the candidates that were computed before we made the decision are the same
 	candidatesToDelete := mapCandidates(cmd.candidates, validationCandidates)
 
 	// The deletion of empty NodeClaims is easy to validate, we just ensure that:

--- a/pkg/controllers/deprovisioning/machine_consolidation_test.go
+++ b/pkg/controllers/deprovisioning/machine_consolidation_test.go
@@ -2162,90 +2162,6 @@ var _ = Describe("Machine/Consolidation", func() {
 				},
 			})
 		})
-		It("should not deprovision nodes that receive blocking pods during the TTL", func() {
-			labels := map[string]string{
-				"app": "test",
-			}
-			// create our RS so we can link a pod to it
-			rs := test.ReplicaSet()
-			ExpectApplied(ctx, env.Client, rs)
-			Expect(env.Client.Get(ctx, client.ObjectKeyFromObject(rs), rs)).To(Succeed())
-
-			pod := test.Pod(test.PodOptions{
-				ObjectMeta: metav1.ObjectMeta{Labels: labels,
-					OwnerReferences: []metav1.OwnerReference{
-						{
-							APIVersion:         "apps/v1",
-							Kind:               "ReplicaSet",
-							Name:               rs.Name,
-							UID:                rs.UID,
-							Controller:         ptr.Bool(true),
-							BlockOwnerDeletion: ptr.Bool(true),
-						},
-					},
-				},
-				ResourceRequirements: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
-						v1.ResourceCPU: resource.MustParse("1"),
-					},
-				}})
-			noEvictPod := test.Pod(test.PodOptions{
-				ObjectMeta: metav1.ObjectMeta{Labels: labels,
-					Annotations: map[string]string{v1alpha5.DoNotEvictPodAnnotationKey: "true"},
-					OwnerReferences: []metav1.OwnerReference{
-						{
-							APIVersion:         "apps/v1",
-							Kind:               "ReplicaSet",
-							Name:               rs.Name,
-							UID:                rs.UID,
-							Controller:         ptr.Bool(true),
-							BlockOwnerDeletion: ptr.Bool(true),
-						},
-					},
-				},
-				ResourceRequirements: v1.ResourceRequirements{
-					Requests: v1.ResourceList{
-						v1.ResourceCPU: resource.MustParse("1"),
-					},
-				}})
-			ExpectApplied(ctx, env.Client, machine1, node1, provisioner, pod, noEvictPod)
-			ExpectManualBinding(ctx, env.Client, pod, node1)
-
-			// inform cluster state about nodes and machines
-			ExpectMakeNodesAndMachinesInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node1}, []*v1alpha5.Machine{machine1})
-
-			var wg sync.WaitGroup
-			wg.Add(1)
-			finished := atomic.Bool{}
-			go func() {
-				defer GinkgoRecover()
-				defer wg.Done()
-				defer finished.Store(true)
-				ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
-			}()
-
-			// wait for the deprovisioningController to block on the validation timeout
-			Eventually(fakeClock.HasWaiters, time.Second*10).Should(BeTrue())
-			// controller should be blocking during the timeout
-			Expect(finished.Load()).To(BeFalse())
-
-			// and the node should not be deleted yet
-			ExpectExists(ctx, env.Client, node1)
-
-			// make the node non-empty by binding it
-			ExpectManualBinding(ctx, env.Client, noEvictPod, node1)
-			ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node1))
-
-			// advance the clock so that the timeout expires
-			fakeClock.Step(31 * time.Second)
-			// controller should finish
-			Eventually(finished.Load, 10*time.Second).Should(BeTrue())
-			wg.Wait()
-
-			// nothing should be removed since the node is no longer empty
-			Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
-			ExpectExists(ctx, env.Client, node1)
-		})
 		It("should wait for the node TTL for empty nodes before consolidating", func() {
 			ExpectApplied(ctx, env.Client, machine1, node1, provisioner)
 
@@ -2369,6 +2285,92 @@ var _ = Describe("Machine/Consolidation", func() {
 			Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
 			ExpectNotFound(ctx, env.Client, machine2, node2)
 		})
+		It("should not consolidate if the action picks different instance types after the node TTL wait", func() {
+			labels := map[string]string{
+				"app": "test",
+			}
+			// create our RS so we can link a pod to it
+			rs := test.ReplicaSet()
+			ExpectApplied(ctx, env.Client, rs)
+			Expect(env.Client.Get(ctx, client.ObjectKeyFromObject(rs), rs)).To(Succeed())
+
+			pod := test.Pod(test.PodOptions{
+				ObjectMeta: metav1.ObjectMeta{Labels: labels,
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion:         "apps/v1",
+							Kind:               "ReplicaSet",
+							Name:               rs.Name,
+							UID:                rs.UID,
+							Controller:         ptr.Bool(true),
+							BlockOwnerDeletion: ptr.Bool(true),
+						},
+					},
+				},
+				ResourceRequirements: v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						v1.ResourceCPU: resource.MustParse("1"),
+					},
+				}})
+			ExpectApplied(ctx, env.Client, machine1, node1, provisioner, pod)
+			ExpectManualBinding(ctx, env.Client, pod, node1)
+
+			// inform cluster state about nodes and machines
+			ExpectMakeNodesAndMachinesInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node1}, []*v1alpha5.Machine{machine1})
+
+			var wg sync.WaitGroup
+			wg.Add(1)
+			finished := atomic.Bool{}
+			go func() {
+				defer GinkgoRecover()
+				defer wg.Done()
+				defer finished.Store(true)
+				ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			}()
+
+			// wait for the deprovisioningController to block on the validation timeout
+			Eventually(fakeClock.HasWaiters, time.Second*10).Should(BeTrue())
+			// controller should be blocking during the timeout
+			Expect(finished.Load()).To(BeFalse())
+
+			// and the node should not be deleted yet
+			ExpectExists(ctx, env.Client, node1)
+
+			// add an additional pod to the node to change the consolidation decision
+			pod2 := test.Pod(test.PodOptions{
+				ObjectMeta: metav1.ObjectMeta{Labels: labels,
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion:         "apps/v1",
+							Kind:               "ReplicaSet",
+							Name:               rs.Name,
+							UID:                rs.UID,
+							Controller:         ptr.Bool(true),
+							BlockOwnerDeletion: ptr.Bool(true),
+						},
+					},
+				},
+				ResourceRequirements: v1.ResourceRequirements{
+					Requests: v1.ResourceList{
+						v1.ResourceCPU: resource.MustParse("1"),
+					},
+				},
+			})
+			ExpectApplied(ctx, env.Client, pod2)
+			ExpectManualBinding(ctx, env.Client, pod2, node1)
+			ExpectReconcileSucceeded(ctx, nodeStateController, client.ObjectKeyFromObject(node1))
+
+			// advance the clock so that the timeout expires
+			fakeClock.Step(31 * time.Second)
+			// controller should finish
+			Eventually(finished.Load, 10*time.Second).Should(BeTrue())
+			wg.Wait()
+
+			// nothing should be removed since the node is no longer empty
+			Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(1))
+			Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
+			ExpectExists(ctx, env.Client, node1)
+		})
 		It("should not consolidate if the action becomes invalid during the node TTL wait", func() {
 			pod := test.Pod(test.PodOptions{ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
@@ -2411,6 +2413,378 @@ var _ = Describe("Machine/Consolidation", func() {
 			Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(1))
 			Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
 			ExpectExists(ctx, env.Client, machine1)
+		})
+		It("should not replace node if a pod schedules with karpenter.sh/do-not-evict during the TTL wait", func() {
+			machine, node := test.MachineAndNode(v1alpha5.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
+						v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name,
+						v1alpha5.LabelCapacityType:       mostExpensiveOffering.CapacityType,
+						v1.LabelTopologyZone:             mostExpensiveOffering.Zone,
+					},
+				},
+				Status: v1alpha5.MachineStatus{
+					ProviderID: test.RandomProviderID(),
+					Allocatable: map[v1.ResourceName]resource.Quantity{
+						v1.ResourceCPU:  resource.MustParse("5"),
+						v1.ResourcePods: resource.MustParse("100"),
+					},
+				},
+			})
+			pod := test.Pod()
+			ExpectApplied(ctx, env.Client, provisioner, machine, node, pod)
+
+			// bind pods to node
+			ExpectManualBinding(ctx, env.Client, pod, node)
+
+			// inform cluster state about nodes and machines
+			ExpectMakeNodesAndMachinesInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
+
+			fakeClock.Step(10 * time.Minute)
+
+			var wg sync.WaitGroup
+
+			// Trigger the reconcile loop to start but don't trigger the verify action
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			}()
+
+			// Iterate in a loop until we get to the validation action
+			// Then, apply the pods to the cluster and bind them to the nodes
+			for {
+				time.Sleep(250 * time.Millisecond)
+				if fakeClock.HasWaiters() {
+					break
+				}
+			}
+			doNotEvictPod := test.Pod(test.PodOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						v1alpha5.DoNotEvictPodAnnotationKey: "true",
+					},
+				},
+			})
+			ExpectApplied(ctx, env.Client, doNotEvictPod)
+			ExpectManualBinding(ctx, env.Client, doNotEvictPod, node)
+
+			// Step forward to satisfy the validation timeout and wait for the reconcile to finish
+			fakeClock.Step(45 * time.Second)
+			wg.Wait()
+
+			// we would normally be able to replace a node, but we are blocked by the do-not-evict pods during validation
+			Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(1))
+			Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
+			ExpectExists(ctx, env.Client, node)
+		})
+		It("should not replace node if a pod schedules with karpenter.sh/do-not-disrupt during the TTL wait", func() {
+			pod := test.Pod()
+			machine, node := test.MachineAndNode(v1alpha5.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
+						v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name,
+						v1alpha5.LabelCapacityType:       mostExpensiveOffering.CapacityType,
+						v1.LabelTopologyZone:             mostExpensiveOffering.Zone,
+					},
+				},
+				Status: v1alpha5.MachineStatus{
+					ProviderID: test.RandomProviderID(),
+					Allocatable: map[v1.ResourceName]resource.Quantity{
+						v1.ResourceCPU:  resource.MustParse("5"),
+						v1.ResourcePods: resource.MustParse("100"),
+					},
+				},
+			})
+			ExpectApplied(ctx, env.Client, provisioner, machine, node, pod)
+
+			// bind pods to node
+			ExpectManualBinding(ctx, env.Client, pod, node)
+
+			// inform cluster state about nodes and machines
+			ExpectMakeNodesAndMachinesInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
+
+			fakeClock.Step(10 * time.Minute)
+
+			var wg sync.WaitGroup
+
+			// Trigger the reconcile loop to start but don't trigger the verify action
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			}()
+
+			// Iterate in a loop until we get to the validation action
+			// Then, apply the pods to the cluster and bind them to the nodes
+			for {
+				time.Sleep(250 * time.Millisecond)
+				if fakeClock.HasWaiters() {
+					break
+				}
+			}
+			doNotEvictPod := test.Pod(test.PodOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						v1beta1.DoNotDisruptAnnotationKey: "true",
+					},
+				},
+			})
+			ExpectApplied(ctx, env.Client, doNotEvictPod)
+			ExpectManualBinding(ctx, env.Client, doNotEvictPod, node)
+
+			// Step forward to satisfy the validation timeout and wait for the reconcile to finish
+			fakeClock.Step(45 * time.Second)
+			wg.Wait()
+
+			// we would normally be able to replace a node, but we are blocked by the do-not-evict pods during validation
+			Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(1))
+			Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
+			ExpectExists(ctx, env.Client, node)
+		})
+		It("should not replace node if a pod schedules with a blocking PDB during the TTL wait", func() {
+			pod := test.Pod()
+			machine, node := test.MachineAndNode(v1alpha5.Machine{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						v1alpha5.ProvisionerNameLabelKey: provisioner.Name,
+						v1.LabelInstanceTypeStable:       mostExpensiveInstance.Name,
+						v1alpha5.LabelCapacityType:       mostExpensiveOffering.CapacityType,
+						v1.LabelTopologyZone:             mostExpensiveOffering.Zone,
+					},
+				},
+				Status: v1alpha5.MachineStatus{
+					ProviderID: test.RandomProviderID(),
+					Allocatable: map[v1.ResourceName]resource.Quantity{
+						v1.ResourceCPU:  resource.MustParse("5"),
+						v1.ResourcePods: resource.MustParse("100"),
+					},
+				},
+			})
+			ExpectApplied(ctx, env.Client, provisioner, machine, node, pod)
+
+			// bind pods to node
+			ExpectManualBinding(ctx, env.Client, pod, node)
+
+			// inform cluster state about nodes and machines
+			ExpectMakeNodesAndMachinesInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
+
+			fakeClock.Step(10 * time.Minute)
+
+			var wg sync.WaitGroup
+
+			// Trigger the reconcile loop to start but don't trigger the verify action
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			}()
+
+			// Iterate in a loop until we get to the validation action
+			// Then, apply the pods to the cluster and bind them to the nodes
+			for {
+				time.Sleep(250 * time.Millisecond)
+				if fakeClock.HasWaiters() {
+					break
+				}
+			}
+			labels := map[string]string{
+				"app": "test",
+			}
+			blockingPDBPod := test.Pod(test.PodOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+				},
+			})
+			pdb := test.PodDisruptionBudget(test.PDBOptions{
+				Labels:         labels,
+				MaxUnavailable: fromInt(0),
+				Status: &policyv1.PodDisruptionBudgetStatus{
+					ObservedGeneration: 1,
+					DisruptionsAllowed: 0,
+					CurrentHealthy:     1,
+					DesiredHealthy:     1,
+					ExpectedPods:       1,
+				},
+			})
+			ExpectApplied(ctx, env.Client, blockingPDBPod, pdb)
+			ExpectManualBinding(ctx, env.Client, blockingPDBPod, node)
+
+			// Step forward to satisfy the validation timeout and wait for the reconcile to finish
+			fakeClock.Step(45 * time.Second)
+			wg.Wait()
+
+			// we would normally be able to replace a node, but we are blocked by the PDB during validation
+			Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(1))
+			Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
+			ExpectExists(ctx, env.Client, node)
+		})
+		It("should not delete node if pods schedule with karpenter.sh/do-not-evict during the TTL wait", func() {
+			pods := test.Pods(2, test.PodOptions{})
+			ExpectApplied(ctx, env.Client, provisioner, machine1, node1, machine2, node2, pods[0], pods[1])
+
+			// bind pods to node
+			ExpectManualBinding(ctx, env.Client, pods[0], node1)
+			ExpectManualBinding(ctx, env.Client, pods[1], node2)
+
+			// inform cluster state about nodes and machines
+			ExpectMakeNodesAndMachinesInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node1, node2}, []*v1alpha5.Machine{machine1, machine2})
+
+			fakeClock.Step(10 * time.Minute)
+
+			var wg sync.WaitGroup
+
+			// Trigger the reconcile loop to start but don't trigger the verify action
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			}()
+
+			// Iterate in a loop until we get to the validation action
+			// Then, apply the pods to the cluster and bind them to the nodes
+			for {
+				time.Sleep(250 * time.Millisecond)
+				if fakeClock.HasWaiters() {
+					break
+				}
+			}
+			doNotEvictPods := test.Pods(2, test.PodOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						v1alpha5.DoNotEvictPodAnnotationKey: "true",
+					},
+				},
+			})
+			ExpectApplied(ctx, env.Client, doNotEvictPods[0], doNotEvictPods[1])
+			ExpectManualBinding(ctx, env.Client, doNotEvictPods[0], node1)
+			ExpectManualBinding(ctx, env.Client, doNotEvictPods[1], node2)
+
+			// Step forward to satisfy the validation timeout and wait for the reconcile to finish
+			fakeClock.Step(45 * time.Second)
+			wg.Wait()
+
+			// we would normally be able to consolidate down to a single node, but we are blocked by the do-not-evict pods during validation
+			Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(2))
+			Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(2))
+			ExpectExists(ctx, env.Client, node1)
+			ExpectExists(ctx, env.Client, node2)
+		})
+		It("should not delete node if pods schedule with karpenter.sh/do-not-disrupt during the TTL wait", func() {
+			pods := test.Pods(2, test.PodOptions{})
+			ExpectApplied(ctx, env.Client, provisioner, machine1, node1, machine2, node2, pods[0], pods[1])
+
+			// bind pods to node
+			ExpectManualBinding(ctx, env.Client, pods[0], node1)
+			ExpectManualBinding(ctx, env.Client, pods[1], node2)
+
+			// inform cluster state about nodes and machines
+			ExpectMakeNodesAndMachinesInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node1, node2}, []*v1alpha5.Machine{machine1, machine2})
+
+			fakeClock.Step(10 * time.Minute)
+
+			var wg sync.WaitGroup
+
+			// Trigger the reconcile loop to start but don't trigger the verify action
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			}()
+
+			// Iterate in a loop until we get to the validation action
+			// Then, apply the pods to the cluster and bind them to the nodes
+			for {
+				time.Sleep(250 * time.Millisecond)
+				if fakeClock.HasWaiters() {
+					break
+				}
+			}
+			doNotEvictPods := test.Pods(2, test.PodOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						v1beta1.DoNotDisruptAnnotationKey: "true",
+					},
+				},
+			})
+			ExpectApplied(ctx, env.Client, doNotEvictPods[0], doNotEvictPods[1])
+			ExpectManualBinding(ctx, env.Client, doNotEvictPods[0], node1)
+			ExpectManualBinding(ctx, env.Client, doNotEvictPods[1], node2)
+
+			// Step forward to satisfy the validation timeout and wait for the reconcile to finish
+			fakeClock.Step(45 * time.Second)
+			wg.Wait()
+
+			// we would normally be able to consolidate down to a single node, but we are blocked by the do-not-evict pods during validation
+			Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(2))
+			Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(2))
+			ExpectExists(ctx, env.Client, node1)
+			ExpectExists(ctx, env.Client, node2)
+		})
+		It("should not delete node if pods schedule with a blocking PDB during the TTL wait", func() {
+			pods := test.Pods(2, test.PodOptions{})
+			ExpectApplied(ctx, env.Client, provisioner, machine1, node1, machine2, node2, pods[0], pods[1])
+
+			// bind pods to node
+			ExpectManualBinding(ctx, env.Client, pods[0], node1)
+			ExpectManualBinding(ctx, env.Client, pods[1], node2)
+
+			// inform cluster state about nodes and machines
+			ExpectMakeNodesAndMachinesInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node1, node2}, []*v1alpha5.Machine{machine1, machine2})
+
+			fakeClock.Step(10 * time.Minute)
+
+			var wg sync.WaitGroup
+
+			// Trigger the reconcile loop to start but don't trigger the verify action
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			}()
+
+			// Iterate in a loop until we get to the validation action
+			// Then, apply the pods to the cluster and bind them to the nodes
+			for {
+				time.Sleep(250 * time.Millisecond)
+				if fakeClock.HasWaiters() {
+					break
+				}
+			}
+			labels := map[string]string{
+				"app": "test",
+			}
+			blockingPDBPods := test.Pods(2, test.PodOptions{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: labels,
+				},
+			})
+			pdb := test.PodDisruptionBudget(test.PDBOptions{
+				Labels:         labels,
+				MaxUnavailable: fromInt(0),
+				Status: &policyv1.PodDisruptionBudgetStatus{
+					ObservedGeneration: 1,
+					DisruptionsAllowed: 0,
+					CurrentHealthy:     1,
+					DesiredHealthy:     1,
+					ExpectedPods:       1,
+				},
+			})
+			ExpectApplied(ctx, env.Client, blockingPDBPods[0], blockingPDBPods[1], pdb)
+			ExpectManualBinding(ctx, env.Client, blockingPDBPods[0], node1)
+			ExpectManualBinding(ctx, env.Client, blockingPDBPods[1], node2)
+
+			// Step forward to satisfy the validation timeout and wait for the reconcile to finish
+			fakeClock.Step(45 * time.Second)
+			wg.Wait()
+
+			// we would normally be able to consolidate down to a single node, but we are blocked by the PDB during validation
+			Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(2))
+			Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(2))
+			ExpectExists(ctx, env.Client, node1)
+			ExpectExists(ctx, env.Client, node2)
 		})
 	})
 	Context("Timeout", func() {

--- a/pkg/controllers/deprovisioning/machine_consolidation_test.go
+++ b/pkg/controllers/deprovisioning/machine_consolidation_test.go
@@ -2455,7 +2455,7 @@ var _ = Describe("Machine/Consolidation", func() {
 			// Iterate in a loop until we get to the validation action
 			// Then, apply the pods to the cluster and bind them to the nodes
 			for {
-				time.Sleep(250 * time.Millisecond)
+				time.Sleep(100 * time.Millisecond)
 				if fakeClock.HasWaiters() {
 					break
 				}
@@ -2471,7 +2471,7 @@ var _ = Describe("Machine/Consolidation", func() {
 			ExpectManualBinding(ctx, env.Client, doNotEvictPod, node)
 
 			// Step forward to satisfy the validation timeout and wait for the reconcile to finish
-			fakeClock.Step(45 * time.Second)
+			ExpectTriggerVerifyAction(&wg)
 			wg.Wait()
 
 			// we would normally be able to replace a node, but we are blocked by the do-not-evict pods during validation
@@ -2520,7 +2520,7 @@ var _ = Describe("Machine/Consolidation", func() {
 			// Iterate in a loop until we get to the validation action
 			// Then, apply the pods to the cluster and bind them to the nodes
 			for {
-				time.Sleep(250 * time.Millisecond)
+				time.Sleep(100 * time.Millisecond)
 				if fakeClock.HasWaiters() {
 					break
 				}
@@ -2536,7 +2536,7 @@ var _ = Describe("Machine/Consolidation", func() {
 			ExpectManualBinding(ctx, env.Client, doNotEvictPod, node)
 
 			// Step forward to satisfy the validation timeout and wait for the reconcile to finish
-			fakeClock.Step(45 * time.Second)
+			ExpectTriggerVerifyAction(&wg)
 			wg.Wait()
 
 			// we would normally be able to replace a node, but we are blocked by the do-not-evict pods during validation
@@ -2585,7 +2585,7 @@ var _ = Describe("Machine/Consolidation", func() {
 			// Iterate in a loop until we get to the validation action
 			// Then, apply the pods to the cluster and bind them to the nodes
 			for {
-				time.Sleep(250 * time.Millisecond)
+				time.Sleep(100 * time.Millisecond)
 				if fakeClock.HasWaiters() {
 					break
 				}
@@ -2601,19 +2601,12 @@ var _ = Describe("Machine/Consolidation", func() {
 			pdb := test.PodDisruptionBudget(test.PDBOptions{
 				Labels:         labels,
 				MaxUnavailable: fromInt(0),
-				Status: &policyv1.PodDisruptionBudgetStatus{
-					ObservedGeneration: 1,
-					DisruptionsAllowed: 0,
-					CurrentHealthy:     1,
-					DesiredHealthy:     1,
-					ExpectedPods:       1,
-				},
 			})
 			ExpectApplied(ctx, env.Client, blockingPDBPod, pdb)
 			ExpectManualBinding(ctx, env.Client, blockingPDBPod, node)
 
 			// Step forward to satisfy the validation timeout and wait for the reconcile to finish
-			fakeClock.Step(45 * time.Second)
+			ExpectTriggerVerifyAction(&wg)
 			wg.Wait()
 
 			// we would normally be able to replace a node, but we are blocked by the PDB during validation
@@ -2646,7 +2639,7 @@ var _ = Describe("Machine/Consolidation", func() {
 			// Iterate in a loop until we get to the validation action
 			// Then, apply the pods to the cluster and bind them to the nodes
 			for {
-				time.Sleep(250 * time.Millisecond)
+				time.Sleep(100 * time.Millisecond)
 				if fakeClock.HasWaiters() {
 					break
 				}
@@ -2663,7 +2656,7 @@ var _ = Describe("Machine/Consolidation", func() {
 			ExpectManualBinding(ctx, env.Client, doNotEvictPods[1], node2)
 
 			// Step forward to satisfy the validation timeout and wait for the reconcile to finish
-			fakeClock.Step(45 * time.Second)
+			ExpectTriggerVerifyAction(&wg)
 			wg.Wait()
 
 			// we would normally be able to consolidate down to a single node, but we are blocked by the do-not-evict pods during validation
@@ -2697,7 +2690,7 @@ var _ = Describe("Machine/Consolidation", func() {
 			// Iterate in a loop until we get to the validation action
 			// Then, apply the pods to the cluster and bind them to the nodes
 			for {
-				time.Sleep(250 * time.Millisecond)
+				time.Sleep(100 * time.Millisecond)
 				if fakeClock.HasWaiters() {
 					break
 				}
@@ -2714,7 +2707,7 @@ var _ = Describe("Machine/Consolidation", func() {
 			ExpectManualBinding(ctx, env.Client, doNotEvictPods[1], node2)
 
 			// Step forward to satisfy the validation timeout and wait for the reconcile to finish
-			fakeClock.Step(45 * time.Second)
+			ExpectTriggerVerifyAction(&wg)
 			wg.Wait()
 
 			// we would normally be able to consolidate down to a single node, but we are blocked by the do-not-evict pods during validation
@@ -2748,7 +2741,7 @@ var _ = Describe("Machine/Consolidation", func() {
 			// Iterate in a loop until we get to the validation action
 			// Then, apply the pods to the cluster and bind them to the nodes
 			for {
-				time.Sleep(250 * time.Millisecond)
+				time.Sleep(100 * time.Millisecond)
 				if fakeClock.HasWaiters() {
 					break
 				}
@@ -2764,20 +2757,13 @@ var _ = Describe("Machine/Consolidation", func() {
 			pdb := test.PodDisruptionBudget(test.PDBOptions{
 				Labels:         labels,
 				MaxUnavailable: fromInt(0),
-				Status: &policyv1.PodDisruptionBudgetStatus{
-					ObservedGeneration: 1,
-					DisruptionsAllowed: 0,
-					CurrentHealthy:     1,
-					DesiredHealthy:     1,
-					ExpectedPods:       1,
-				},
 			})
 			ExpectApplied(ctx, env.Client, blockingPDBPods[0], blockingPDBPods[1], pdb)
 			ExpectManualBinding(ctx, env.Client, blockingPDBPods[0], node1)
 			ExpectManualBinding(ctx, env.Client, blockingPDBPods[1], node2)
 
 			// Step forward to satisfy the validation timeout and wait for the reconcile to finish
-			fakeClock.Step(45 * time.Second)
+			ExpectTriggerVerifyAction(&wg)
 			wg.Wait()
 
 			// we would normally be able to consolidate down to a single node, but we are blocked by the PDB during validation

--- a/pkg/controllers/deprovisioning/nodeclaim_consolidation_test.go
+++ b/pkg/controllers/deprovisioning/nodeclaim_consolidation_test.go
@@ -2291,7 +2291,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 			// Iterate in a loop until we get to the validation action
 			// Then, apply the pods to the cluster and bind them to the nodes
 			for {
-				time.Sleep(250 * time.Millisecond)
+				time.Sleep(100 * time.Millisecond)
 				if fakeClock.HasWaiters() {
 					break
 				}
@@ -2307,7 +2307,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 			ExpectManualBinding(ctx, env.Client, doNotEvictPod, node)
 
 			// Step forward to satisfy the validation timeout and wait for the reconcile to finish
-			fakeClock.Step(45 * time.Second)
+			ExpectTriggerVerifyAction(&wg)
 			wg.Wait()
 
 			// we would normally be able to replace a node, but we are blocked by the do-not-evict pods during validation
@@ -2339,7 +2339,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 			// Iterate in a loop until we get to the validation action
 			// Then, apply the pods to the cluster and bind them to the nodes
 			for {
-				time.Sleep(250 * time.Millisecond)
+				time.Sleep(100 * time.Millisecond)
 				if fakeClock.HasWaiters() {
 					break
 				}
@@ -2355,7 +2355,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 			ExpectManualBinding(ctx, env.Client, doNotEvictPod, node)
 
 			// Step forward to satisfy the validation timeout and wait for the reconcile to finish
-			fakeClock.Step(45 * time.Second)
+			ExpectTriggerVerifyAction(&wg)
 			wg.Wait()
 
 			// we would normally be able to replace a node, but we are blocked by the do-not-evict pods during validation
@@ -2387,7 +2387,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 			// Iterate in a loop until we get to the validation action
 			// Then, apply the pods to the cluster and bind them to the nodes
 			for {
-				time.Sleep(250 * time.Millisecond)
+				time.Sleep(100 * time.Millisecond)
 				if fakeClock.HasWaiters() {
 					break
 				}
@@ -2403,19 +2403,12 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 			pdb := test.PodDisruptionBudget(test.PDBOptions{
 				Labels:         labels,
 				MaxUnavailable: fromInt(0),
-				Status: &policyv1.PodDisruptionBudgetStatus{
-					ObservedGeneration: 1,
-					DisruptionsAllowed: 0,
-					CurrentHealthy:     1,
-					DesiredHealthy:     1,
-					ExpectedPods:       1,
-				},
 			})
 			ExpectApplied(ctx, env.Client, blockingPDBPod, pdb)
 			ExpectManualBinding(ctx, env.Client, blockingPDBPod, node)
 
 			// Step forward to satisfy the validation timeout and wait for the reconcile to finish
-			fakeClock.Step(45 * time.Second)
+			ExpectTriggerVerifyAction(&wg)
 			wg.Wait()
 
 			// we would normally be able to replace a node, but we are blocked by the PDB during validation
@@ -2448,7 +2441,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 			// Iterate in a loop until we get to the validation action
 			// Then, apply the pods to the cluster and bind them to the nodes
 			for {
-				time.Sleep(250 * time.Millisecond)
+				time.Sleep(100 * time.Millisecond)
 				if fakeClock.HasWaiters() {
 					break
 				}
@@ -2465,7 +2458,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 			ExpectManualBinding(ctx, env.Client, doNotEvictPods[1], node2)
 
 			// Step forward to satisfy the validation timeout and wait for the reconcile to finish
-			fakeClock.Step(45 * time.Second)
+			ExpectTriggerVerifyAction(&wg)
 			wg.Wait()
 
 			// we would normally be able to consolidate down to a single node, but we are blocked by the do-not-evict pods during validation
@@ -2499,7 +2492,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 			// Iterate in a loop until we get to the validation action
 			// Then, apply the pods to the cluster and bind them to the nodes
 			for {
-				time.Sleep(250 * time.Millisecond)
+				time.Sleep(100 * time.Millisecond)
 				if fakeClock.HasWaiters() {
 					break
 				}
@@ -2516,7 +2509,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 			ExpectManualBinding(ctx, env.Client, doNotEvictPods[1], node2)
 
 			// Step forward to satisfy the validation timeout and wait for the reconcile to finish
-			fakeClock.Step(45 * time.Second)
+			ExpectTriggerVerifyAction(&wg)
 			wg.Wait()
 
 			// we would normally be able to consolidate down to a single node, but we are blocked by the do-not-evict pods during validation
@@ -2550,7 +2543,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 			// Iterate in a loop until we get to the validation action
 			// Then, apply the pods to the cluster and bind them to the nodes
 			for {
-				time.Sleep(250 * time.Millisecond)
+				time.Sleep(100 * time.Millisecond)
 				if fakeClock.HasWaiters() {
 					break
 				}
@@ -2566,20 +2559,13 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 			pdb := test.PodDisruptionBudget(test.PDBOptions{
 				Labels:         labels,
 				MaxUnavailable: fromInt(0),
-				Status: &policyv1.PodDisruptionBudgetStatus{
-					ObservedGeneration: 1,
-					DisruptionsAllowed: 0,
-					CurrentHealthy:     1,
-					DesiredHealthy:     1,
-					ExpectedPods:       1,
-				},
 			})
 			ExpectApplied(ctx, env.Client, blockingPDBPods[0], blockingPDBPods[1], pdb)
 			ExpectManualBinding(ctx, env.Client, blockingPDBPods[0], node)
 			ExpectManualBinding(ctx, env.Client, blockingPDBPods[1], node2)
 
 			// Step forward to satisfy the validation timeout and wait for the reconcile to finish
-			fakeClock.Step(45 * time.Second)
+			ExpectTriggerVerifyAction(&wg)
 			wg.Wait()
 
 			// we would normally be able to consolidate down to a single node, but we are blocked by the PDB during validation


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes https://github.com/aws/karpenter/issues/4310, https://github.com/aws/karpenter/issues/4758

**Description**

This PR correctly validates that the candidates that we are attempting to deprovision are still eligible to be deprovisioned. It does this by mapping the old candidates onto the new candidates that we pull from state and checking that all of those candidates are still valid for deprovisioning based on PDB criteria, `do-not-evict` annotations, and scheduling criteria.

This PR also removes the caching mechanism for `validationCandidates` since we weren't calling `IsValid` multiple times in code, meaning that storing the candidates like this wasn't necessary for our usage.

https://github.com/aws/karpenter-core/pull/247 had originally intended to fix this issue, but uses the wrong pods for validation within the `filterCandidates` function. This causes validation to pass for candidate nodes that receive pods with blocking PDBs or `do-not-evict` pods within the validation window.

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
