### PR TITLE
test: Remove CEL unit testing for 1.23 and 1.24

### DIFF
--- a/pkg/apis/v1beta1/nodepool_validation_cel_test.go
+++ b/pkg/apis/v1beta1/nodepool_validation_cel_test.go
@@ -32,6 +32,9 @@ var _ = Describe("CEL/Validation", func() {
 	var nodePool *NodePool
 
 	BeforeEach(func() {
+		if env.Version.Minor() < 25 {
+			Skip("CEL Validation is for 1.25>")
+		}
 		nodePool = &NodePool{
 			ObjectMeta: metav1.ObjectMeta{Name: strings.ToLower(randomdata.SillyName())},
 			Spec: NodePoolSpec{

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -106,7 +106,6 @@ func NewEnvironment(scheme *runtime.Scheme, options ...functional.Option[Environ
 		// Ref: https://github.com/aws/karpenter-core/pull/330
 		environment.ControlPlane.GetAPIServer().Configure().Set("feature-gates", "MinDomainsInPodTopologySpread=true")
 	}
-	environment.ControlPlane.GetAPIServer().Configure().Append("feature-gates", "CustomResourceValidationExpressions=true")
 
 	_ = lo.Must(environment.Start())
 	c := lo.Must(client.New(environment.Config, client.Options{Scheme: scheme}))


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
- Since k8s 1.25 will be the only version of karpenter that will support CEL, remove the testing for earlier versions 

**How was this change tested?**
- `make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
