### PR TITLE
chore: Fix calling the named function on the logger twice

### DIFF
--- a/pkg/operator/logging/logging.go
+++ b/pkg/operator/logging/logging.go
@@ -84,14 +84,14 @@ func DefaultZapConfig(component string) zap.Config {
 func NewLogger(ctx context.Context, component string, kubernetesInterface kubernetes.Interface) *zap.SugaredLogger {
 	if logger := loggerFromFile(ctx, component); logger != nil {
 		logger.Debugf("loaded log configuration from file %q", loggerCfgFilePath)
-		return logger.Named(component)
+		return logger
 	}
 	// TODO @joinnis: Drop support for loading logging configuration from the apiserver discovered ConfigMap when
 	// dropping alpha support. At that point, we will only support the environment variables and file-based config
 	if logger := loggerFromConfigMap(ctx, component, kubernetesInterface); logger != nil {
 		logger.Debugf("loaded log configuration from configmap %q", types.NamespacedName{Namespace: system.Namespace(), Name: loggerCfgConfigMapName})
 		logger.Error("loading log configuration through the configmap is deprecated, use file or environment-variable based configuration instead")
-		return logger.Named(component)
+		return logger
 	}
 	return defaultLogger(ctx, component)
 }


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR fixes calling named on logger twice which would result in logs that contained `controller.controller` and `webhook.webhook` as a prefix

### Before PR

```bash
2023-10-12T19:38:19.004Z        DEBUG   controller      loaded log configuration from file "/etc/karpenter/logging/zap-logger-config"   {"commit": "fae826c"}
2023-10-12T19:38:21.658Z        DEBUG   controller.controller   discovered region       {"commit": "fae826c", "region": "us-west-2"}
2023-10-12T19:38:21.664Z        DEBUG   controller.controller   discovered kube dns     {"commit": "fae826c", "kube-dns-ip": "10.100.0.10"}
2023-10-12T19:38:21.665Z        DEBUG   controller.controller   discovered version      {"commit": "fae826c", "version": "v0.31.0-67-gfae826cc7"}
2023-10-12T19:38:21.666Z        INFO    controller.controller   starting server {"commit": "fae826c", "kind": "health probe", "addr": "[::]:8081"}
2023-10-12T19:38:21.766Z        INFO    controller.controller   attempting to acquire leader lease karpenter/karpenter-leader-election...
        {"commit": "fae826c"}
2023-10-12T19:38:21.766Z        INFO    controller.controller   Starting informers...   {"commit": "fae826c"}
```

### After PR

```bash
2023-10-12T19:45:09.767Z        DEBUG   controller      loaded log configuration from file "/etc/karpenter/logging/zap-logger-config"   {"commit": "7df372b"}
2023-10-12T19:45:12.395Z        DEBUG   controller      discovered region       {"commit": "7df372b", "region": "us-west-2"}
2023-10-12T19:45:12.400Z        DEBUG   controller      discovered kube dns     {"commit": "7df372b", "kube-dns-ip": "10.100.0.10"}
2023-10-12T19:45:12.400Z        DEBUG   controller      discovered version      {"commit": "7df372b", "version": "v0.31.0-67-g7df372b00"}
2023-10-12T19:45:12.401Z        INFO    controller      starting server {"commit": "7df372b", "kind": "health probe", "addr": "[::]:8081"}
2023-10-12T19:45:12.501Z        INFO    controller      Starting informers...   {"commit": "7df372b"}
2023-10-12T19:45:12.501Z        INFO    controller      attempting to acquire leader lease karpenter/karpenter-leader-election...
        {"commit": "7df372b"}
```

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
