### PR TITLE
fix: allow queue to clean up if not evict pods

### DIFF
--- a/pkg/controllers/termination/terminator/eviction.go
+++ b/pkg/controllers/termination/terminator/eviction.go
@@ -106,7 +106,6 @@ func (q *Queue) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.R
 	// Get pod from queue. This waits until queue is non-empty.
 	item, shutdown := q.RateLimitingInterface.Get()
 	if shutdown {
-		q.ShutDown()
 		return reconcile.Result{}, fmt.Errorf("EvictionQueue is broken and has shutdown")
 	}
 	nn := item.(types.NamespacedName)

--- a/pkg/controllers/termination/terminator/eviction.go
+++ b/pkg/controllers/termination/terminator/eviction.go
@@ -101,7 +101,7 @@ func (q *Queue) Reconcile(ctx context.Context, _ reconcile.Request) (reconcile.R
 	// get call, but since we're popping items off the queue synchronously, there should be no synchonization
 	// issues.
 	if q.Len() == 0 {
-		return reconcile.Result{RequeueAfter: controller.Immediately}, nil
+		return reconcile.Result{RequeueAfter: 1 * time.Second}, nil
 	}
 	// Get pod from queue. This waits until queue is non-empty.
 	item, shutdown := q.RateLimitingInterface.Get()


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #598 <!-- issue number -->

**Description**
Adds a check into the termination queue before calling `rateLimitingInterface.Get()` so that Karpenter can only call the rateLimitingInterface.Get() call if there's items in the queue. Calling Get() will wait until there's items in the queue, where it'll block Karpenter from shutting down until the shut down times out.

**How was this change tested?**
- make apply
- Ran `kubectl rollout restart deployment karpenter -n karpenter` a couple of times to see it not time out. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
