### PR TITLE
chore: Change deprovisioning to disruption controller and add metrics

### DIFF
--- a/pkg/controllers/controllers.go
+++ b/pkg/controllers/controllers.go
@@ -20,7 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
-	"github.com/aws/karpenter-core/pkg/controllers/deprovisioning"
+	"github.com/aws/karpenter-core/pkg/controllers/disruption"
 	"github.com/aws/karpenter-core/pkg/controllers/leasegarbagecollection"
 	metricsnode "github.com/aws/karpenter-core/pkg/controllers/metrics/node"
 	metricspod "github.com/aws/karpenter-core/pkg/controllers/metrics/pod"
@@ -55,7 +55,7 @@ func NewControllers(
 
 	return []controller.Controller{
 		p, evictionQueue,
-		deprovisioning.NewController(clock, kubeClient, p, cloudProvider, recorder, cluster),
+		disruption.NewController(clock, kubeClient, p, cloudProvider, recorder, cluster),
 		provisioning.NewController(kubeClient, p, recorder),
 		nodepoolhash.NewProvisionerController(kubeClient),
 		informer.NewDaemonSetController(kubeClient, cluster),

--- a/pkg/controllers/disruption/consolidation.go
+++ b/pkg/controllers/disruption/consolidation.go
@@ -33,7 +33,6 @@ import (
 	"github.com/aws/karpenter-core/pkg/controllers/provisioning"
 	"github.com/aws/karpenter-core/pkg/controllers/state"
 	"github.com/aws/karpenter-core/pkg/events"
-	"github.com/aws/karpenter-core/pkg/metrics"
 	"github.com/aws/karpenter-core/pkg/scheduling"
 )
 
@@ -62,11 +61,6 @@ func makeConsolidation(clock clock.Clock, cluster *state.Cluster, kubeClient cli
 		cloudProvider: cloudProvider,
 		recorder:      recorder,
 	}
-}
-
-// String is the string representation of the Method
-func (c *consolidation) String() string {
-	return metrics.ConsolidationReason
 }
 
 // sortAndFilterCandidates orders candidates by the disruptionCost, removing any that we already know won't

--- a/pkg/controllers/disruption/drift.go
+++ b/pkg/controllers/disruption/drift.go
@@ -76,8 +76,11 @@ func (d *Drift) ComputeCommand(ctx context.Context, candidates ...*Candidate) (C
 	if err != nil {
 		return Command{}, err
 	}
-	deprovisioningEligibleMachinesGauge.WithLabelValues(d.String()).Set(float64(len(candidates)))
-	disruptionEligibleNodesGauge.WithLabelValues(d.String()).Set(float64(len(candidates)))
+	deprovisioningEligibleMachinesGauge.WithLabelValues(d.Type()).Set(float64(len(candidates)))
+	disruptionEligibleNodesGauge.With(map[string]string{
+		methodLabel:            d.Type(),
+		consolidationTypeLabel: d.ConsolidationType(),
+	}).Set(float64(len(candidates)))
 
 	// Disrupt all empty drifted candidates, as they require no scheduling simulations.
 	if empty := lo.Filter(candidates, func(c *Candidate, _ int) bool {
@@ -117,7 +120,10 @@ func (d *Drift) ComputeCommand(ctx context.Context, candidates ...*Candidate) (C
 	return Command{}, nil
 }
 
-// String is the string representation of the Method
-func (d *Drift) String() string {
+func (d *Drift) Type() string {
 	return metrics.DriftReason
+}
+
+func (d *Drift) ConsolidationType() string {
+	return ""
 }

--- a/pkg/controllers/disruption/drift.go
+++ b/pkg/controllers/disruption/drift.go
@@ -12,7 +12,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package deprovisioning
+package disruption
 
 import (
 	"context"
@@ -26,7 +26,7 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
-	deprovisioningevents "github.com/aws/karpenter-core/pkg/controllers/deprovisioning/events"
+	disruptionevents "github.com/aws/karpenter-core/pkg/controllers/disruption/events"
 	"github.com/aws/karpenter-core/pkg/controllers/provisioning"
 	"github.com/aws/karpenter-core/pkg/controllers/state"
 	"github.com/aws/karpenter-core/pkg/events"
@@ -51,8 +51,8 @@ func NewDrift(kubeClient client.Client, cluster *state.Cluster, provisioner *pro
 	}
 }
 
-// ShouldDeprovision is a predicate used to filter deprovisionable candidates
-func (d *Drift) ShouldDeprovision(ctx context.Context, c *Candidate) bool {
+// ShouldDisrupt is a predicate used to filter candidates
+func (d *Drift) ShouldDisrupt(ctx context.Context, c *Candidate) bool {
 	return options.FromContext(ctx).FeatureGates.Drift &&
 		c.NodeClaim.StatusConditions().GetCondition(v1beta1.Drifted).IsTrue()
 }
@@ -70,15 +70,16 @@ func (d *Drift) filterAndSortCandidates(ctx context.Context, candidates []*Candi
 	return candidates, nil
 }
 
-// ComputeCommand generates a deprovisioning command given deprovisionable candidates
+// ComputeCommand generates a disruption command given candidates
 func (d *Drift) ComputeCommand(ctx context.Context, candidates ...*Candidate) (Command, error) {
 	candidates, err := d.filterAndSortCandidates(ctx, candidates)
 	if err != nil {
 		return Command{}, err
 	}
 	deprovisioningEligibleMachinesGauge.WithLabelValues(d.String()).Set(float64(len(candidates)))
+	disruptionEligibleNodesGauge.WithLabelValues(d.String()).Set(float64(len(candidates)))
 
-	// Deprovision all empty drifted candidates, as they require no scheduling simulations.
+	// Disrupt all empty drifted candidates, as they require no scheduling simulations.
 	if empty := lo.Filter(candidates, func(c *Candidate, _ int) bool {
 		return len(c.pods) == 0
 	}); len(empty) > 0 {
@@ -100,7 +101,7 @@ func (d *Drift) ComputeCommand(ctx context.Context, candidates ...*Candidate) (C
 		// Log when all pods can't schedule, as the command will get executed immediately.
 		if !results.AllNonPendingPodsScheduled() {
 			logging.FromContext(ctx).With(lo.Ternary(candidate.NodeClaim.IsMachine, "machine", "nodeclaim"), candidate.NodeClaim.Name, "node", candidate.Node.Name).Debugf("cannot terminate since scheduling simulation failed to schedule all pods %s", results.NonPendingPodSchedulingErrors())
-			d.recorder.Publish(deprovisioningevents.Blocked(candidate.Node, candidate.NodeClaim, "Scheduling simulation failed to schedule all pods")...)
+			d.recorder.Publish(disruptionevents.Blocked(candidate.Node, candidate.NodeClaim, "Scheduling simulation failed to schedule all pods")...)
 			continue
 		}
 		if len(results.NewNodeClaims) == 0 {
@@ -116,7 +117,7 @@ func (d *Drift) ComputeCommand(ctx context.Context, candidates ...*Candidate) (C
 	return Command{}, nil
 }
 
-// String is the string representation of the deprovisioner
+// String is the string representation of the Method
 func (d *Drift) String() string {
 	return metrics.DriftReason
 }

--- a/pkg/controllers/disruption/emptiness.go
+++ b/pkg/controllers/disruption/emptiness.go
@@ -50,15 +50,21 @@ func (e *Emptiness) ComputeCommand(_ context.Context, candidates ...*Candidate) 
 	emptyCandidates := lo.Filter(candidates, func(cn *Candidate, _ int) bool {
 		return cn.NodeClaim.DeletionTimestamp.IsZero() && len(cn.pods) == 0
 	})
-	deprovisioningEligibleMachinesGauge.WithLabelValues(e.String()).Set(float64(len(candidates)))
-	disruptionEligibleNodesGauge.WithLabelValues(e.String()).Set(float64(len(candidates)))
+	deprovisioningEligibleMachinesGauge.WithLabelValues(e.Type()).Set(float64(len(candidates)))
+	disruptionEligibleNodesGauge.With(map[string]string{
+		methodLabel:            e.Type(),
+		consolidationTypeLabel: e.ConsolidationType(),
+	}).Set(float64(len(candidates)))
 
 	return Command{
 		candidates: emptyCandidates,
 	}, nil
 }
 
-// String is the string representation of the Method
-func (e *Emptiness) String() string {
+func (e *Emptiness) Type() string {
 	return metrics.EmptinessReason
+}
+
+func (e *Emptiness) ConsolidationType() string {
+	return ""
 }

--- a/pkg/controllers/disruption/emptiness.go
+++ b/pkg/controllers/disruption/emptiness.go
@@ -12,7 +12,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package deprovisioning
+package disruption
 
 import (
 	"context"
@@ -36,8 +36,8 @@ func NewEmptiness(clk clock.Clock) *Emptiness {
 	}
 }
 
-// ShouldDeprovision is a predicate used to filter deprovisionable candidates
-func (e *Emptiness) ShouldDeprovision(_ context.Context, c *Candidate) bool {
+// ShouldDisrupt is a predicate used to filter candidates
+func (e *Emptiness) ShouldDisrupt(_ context.Context, c *Candidate) bool {
 	return c.nodePool.Spec.Disruption.ConsolidateAfter != nil &&
 		c.nodePool.Spec.Disruption.ConsolidateAfter.Duration != nil &&
 		c.nodePool.Spec.Disruption.ConsolidationPolicy == v1beta1.ConsolidationPolicyWhenEmpty &&
@@ -45,19 +45,20 @@ func (e *Emptiness) ShouldDeprovision(_ context.Context, c *Candidate) bool {
 		!e.clock.Now().Before(c.NodeClaim.StatusConditions().GetCondition(v1beta1.Empty).LastTransitionTime.Inner.Add(*c.nodePool.Spec.Disruption.ConsolidateAfter.Duration))
 }
 
-// ComputeCommand generates a deprovisioning command given deprovisionable candidates
+// ComputeCommand generates a disruption command given candidates
 func (e *Emptiness) ComputeCommand(_ context.Context, candidates ...*Candidate) (Command, error) {
 	emptyCandidates := lo.Filter(candidates, func(cn *Candidate, _ int) bool {
 		return cn.NodeClaim.DeletionTimestamp.IsZero() && len(cn.pods) == 0
 	})
 	deprovisioningEligibleMachinesGauge.WithLabelValues(e.String()).Set(float64(len(candidates)))
+	disruptionEligibleNodesGauge.WithLabelValues(e.String()).Set(float64(len(candidates)))
 
 	return Command{
 		candidates: emptyCandidates,
 	}, nil
 }
 
-// string is the string representation of the deprovisioner
+// String is the string representation of the Method
 func (e *Emptiness) String() string {
 	return metrics.EmptinessReason
 }

--- a/pkg/controllers/disruption/emptynodeconsolidation.go
+++ b/pkg/controllers/disruption/emptynodeconsolidation.go
@@ -12,7 +12,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package deprovisioning
+package disruption
 
 import (
 	"context"
@@ -40,7 +40,7 @@ func NewEmptyNodeConsolidation(clk clock.Clock, cluster *state.Cluster, kubeClie
 	return &EmptyNodeConsolidation{consolidation: makeConsolidation(clk, cluster, kubeClient, provisioner, cp, recorder)}
 }
 
-// ComputeCommand generates a deprovisioning command given deprovisionable NodeClaims
+// ComputeCommand generates a disruption command given candidates
 func (c *EmptyNodeConsolidation) ComputeCommand(ctx context.Context, candidates ...*Candidate) (Command, error) {
 	if c.isConsolidated() {
 		return Command{}, nil
@@ -50,6 +50,7 @@ func (c *EmptyNodeConsolidation) ComputeCommand(ctx context.Context, candidates 
 		return Command{}, fmt.Errorf("sorting candidates, %w", err)
 	}
 	deprovisioningEligibleMachinesGauge.WithLabelValues(c.String()).Set(float64(len(candidates)))
+	disruptionEligibleNodesGauge.WithLabelValues(c.String()).Set(float64(len(candidates)))
 
 	// select the entirely empty NodeClaims
 	emptyCandidates := lo.Filter(candidates, func(n *Candidate, _ int) bool { return len(n.pods) == 0 })
@@ -71,7 +72,7 @@ func (c *EmptyNodeConsolidation) ComputeCommand(ctx context.Context, candidates 
 		return Command{}, errors.New("interrupted")
 	case <-c.clock.After(consolidationTTL):
 	}
-	validationCandidates, err := GetCandidates(ctx, c.cluster, c.kubeClient, c.recorder, c.clock, c.cloudProvider, c.ShouldDeprovision)
+	validationCandidates, err := GetCandidates(ctx, c.cluster, c.kubeClient, c.recorder, c.clock, c.cloudProvider, c.ShouldDisrupt)
 	if err != nil {
 		logging.FromContext(ctx).Errorf("computing validation candidates %s", err)
 		return Command{}, err

--- a/pkg/controllers/disruption/expiration.go
+++ b/pkg/controllers/disruption/expiration.go
@@ -80,8 +80,11 @@ func (e *Expiration) ComputeCommand(ctx context.Context, candidates ...*Candidat
 	if err != nil {
 		return Command{}, fmt.Errorf("filtering candidates, %w", err)
 	}
-	deprovisioningEligibleMachinesGauge.WithLabelValues(e.String()).Set(float64(len(candidates)))
-	disruptionEligibleNodesGauge.WithLabelValues(e.String()).Set(float64(len(candidates)))
+	deprovisioningEligibleMachinesGauge.WithLabelValues(e.Type()).Set(float64(len(candidates)))
+	disruptionEligibleNodesGauge.With(map[string]string{
+		methodLabel:            e.Type(),
+		consolidationTypeLabel: e.ConsolidationType(),
+	}).Set(float64(len(candidates)))
 
 	// Disrupt all empty expired candidates, as they require no scheduling simulations.
 	if empty := lo.Filter(candidates, func(c *Candidate, _ int) bool {
@@ -118,7 +121,10 @@ func (e *Expiration) ComputeCommand(ctx context.Context, candidates ...*Candidat
 	return Command{}, nil
 }
 
-// String is the string representation of the Method
-func (e *Expiration) String() string {
+func (e *Expiration) Type() string {
 	return metrics.ExpirationReason
+}
+
+func (e *Expiration) ConsolidationType() string {
+	return ""
 }

--- a/pkg/controllers/disruption/expiration.go
+++ b/pkg/controllers/disruption/expiration.go
@@ -12,7 +12,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package deprovisioning
+package disruption
 
 import (
 	"context"
@@ -28,7 +28,7 @@ import (
 	"github.com/samber/lo"
 
 	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
-	deprovisioningevents "github.com/aws/karpenter-core/pkg/controllers/deprovisioning/events"
+	disruptionevents "github.com/aws/karpenter-core/pkg/controllers/disruption/events"
 	"github.com/aws/karpenter-core/pkg/controllers/provisioning"
 	"github.com/aws/karpenter-core/pkg/controllers/state"
 	"github.com/aws/karpenter-core/pkg/events"
@@ -55,8 +55,8 @@ func NewExpiration(clk clock.Clock, kubeClient client.Client, cluster *state.Clu
 	}
 }
 
-// ShouldDeprovision is a predicate used to filter deprovisionable candidates
-func (e *Expiration) ShouldDeprovision(_ context.Context, c *Candidate) bool {
+// ShouldDisrupt is a predicate used to filter candidates
+func (e *Expiration) ShouldDisrupt(_ context.Context, c *Candidate) bool {
 	return c.nodePool.Spec.Disruption.ExpireAfter.Duration != nil &&
 		c.NodeClaim.StatusConditions().GetCondition(v1beta1.Expired).IsTrue()
 }
@@ -74,15 +74,16 @@ func (e *Expiration) filterAndSortCandidates(ctx context.Context, candidates []*
 	return candidates, nil
 }
 
-// ComputeCommand generates a deprovisioning command given deprovisionable candidates
+// ComputeCommand generates a disrpution command given candidates
 func (e *Expiration) ComputeCommand(ctx context.Context, candidates ...*Candidate) (Command, error) {
 	candidates, err := e.filterAndSortCandidates(ctx, candidates)
 	if err != nil {
 		return Command{}, fmt.Errorf("filtering candidates, %w", err)
 	}
 	deprovisioningEligibleMachinesGauge.WithLabelValues(e.String()).Set(float64(len(candidates)))
+	disruptionEligibleNodesGauge.WithLabelValues(e.String()).Set(float64(len(candidates)))
 
-	// Deprovision all empty expired candidates, as they require no scheduling simulations.
+	// Disrupt all empty expired candidates, as they require no scheduling simulations.
 	if empty := lo.Filter(candidates, func(c *Candidate, _ int) bool {
 		return len(c.pods) == 0
 	}); len(empty) > 0 {
@@ -104,7 +105,7 @@ func (e *Expiration) ComputeCommand(ctx context.Context, candidates ...*Candidat
 		// Log when all pods can't schedule, as the command will get executed immediately.
 		if !results.AllNonPendingPodsScheduled() {
 			logging.FromContext(ctx).With(lo.Ternary(candidate.NodeClaim.IsMachine, "machine", "nodeclaim"), candidate.NodeClaim.Name, "node", candidate.Node.Name).Debugf("cannot terminate since scheduling simulation failed to schedule all pods, %s", results.NonPendingPodSchedulingErrors())
-			e.recorder.Publish(deprovisioningevents.Blocked(candidate.Node, candidate.NodeClaim, "Scheduling simulation failed to schedule all pods")...)
+			e.recorder.Publish(disruptionevents.Blocked(candidate.Node, candidate.NodeClaim, "Scheduling simulation failed to schedule all pods")...)
 			continue
 		}
 
@@ -117,7 +118,7 @@ func (e *Expiration) ComputeCommand(ctx context.Context, candidates ...*Candidat
 	return Command{}, nil
 }
 
-// String is the string representation of the deprovisioner
+// String is the string representation of the Method
 func (e *Expiration) String() string {
 	return metrics.ExpirationReason
 }

--- a/pkg/controllers/disruption/machine_consolidation_test.go
+++ b/pkg/controllers/disruption/machine_consolidation_test.go
@@ -12,7 +12,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package deprovisioning_test
+package disruption_test
 
 import (
 	"fmt"
@@ -40,7 +40,7 @@ import (
 	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
 	"github.com/aws/karpenter-core/pkg/cloudprovider/fake"
-	"github.com/aws/karpenter-core/pkg/controllers/deprovisioning"
+	"github.com/aws/karpenter-core/pkg/controllers/disruption"
 	"github.com/aws/karpenter-core/pkg/events"
 	"github.com/aws/karpenter-core/pkg/scheduling"
 	"github.com/aws/karpenter-core/pkg/test"
@@ -105,7 +105,7 @@ var _ = Describe("Machine/Consolidation", func() {
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Cascade any deletion of the machine to the node
@@ -125,7 +125,7 @@ var _ = Describe("Machine/Consolidation", func() {
 			fakeClock.Step(10 * time.Minute)
 			wg := sync.WaitGroup{}
 			ExpectTriggerVerifyAction(&wg)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+			ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
 			// Cascade any deletion of the machine to the node
 			ExpectMachinesCascadeDeletion(ctx, env.Client, machine1, machine2)
@@ -187,7 +187,7 @@ var _ = Describe("Machine/Consolidation", func() {
 			// inform cluster state about nodes and machines
 			ExpectMakeNodesAndMachinesInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node1}, []*v1alpha5.Machine{machine1})
 
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 
 			// we don't need any new nodes and consolidation should notice the huge pending pod that needs the large
 			// node to schedule, which prevents the large expensive node from being replaced
@@ -246,7 +246,7 @@ var _ = Describe("Machine/Consolidation", func() {
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
 			ExpectMakeNewMachinesReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Cascade any deletion of the machine to the node
@@ -319,7 +319,7 @@ var _ = Describe("Machine/Consolidation", func() {
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
 			ExpectMakeNewMachinesReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Cascade any deletion of the machine to the node
@@ -404,7 +404,7 @@ var _ = Describe("Machine/Consolidation", func() {
 
 			fakeClock.Step(10 * time.Minute)
 
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 
 			// we didn't create a new machine or delete the old one
 			Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(1))
@@ -498,7 +498,7 @@ var _ = Describe("Machine/Consolidation", func() {
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
 			ExpectMakeNewMachinesReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Cascade any deletion of the machine to the node
@@ -580,7 +580,7 @@ var _ = Describe("Machine/Consolidation", func() {
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
 			ExpectMakeNewMachinesReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Cascade any deletion of the machine to the node
@@ -675,7 +675,7 @@ var _ = Describe("Machine/Consolidation", func() {
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
 			ExpectMakeNewMachinesReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Cascade any deletion of the machine to the node
@@ -770,7 +770,7 @@ var _ = Describe("Machine/Consolidation", func() {
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
 			ExpectMakeNewMachinesReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Cascade any deletion of the machine to the node
@@ -845,7 +845,7 @@ var _ = Describe("Machine/Consolidation", func() {
 					},
 				},
 			})
-			// Block this pod from being deprovisioned with karpenter.sh/do-not-evict
+			// Block this pod from being disrupted with karpenter.sh/do-not-evict
 			pods[2].Annotations = lo.Assign(pods[2].Annotations, map[string]string{v1alpha5.DoNotEvictPodAnnotationKey: "true"})
 
 			ExpectApplied(ctx, env.Client, rs, pods[0], pods[1], pods[2], provisioner)
@@ -864,7 +864,7 @@ var _ = Describe("Machine/Consolidation", func() {
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
 			ExpectMakeNewMachinesReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Cascade any deletion of the machine to the node
@@ -939,7 +939,7 @@ var _ = Describe("Machine/Consolidation", func() {
 					},
 				},
 			})
-			// Block this pod from being deprovisioned with karpenter.sh/do-not-evict
+			// Block this pod from being disrupted with karpenter.sh/do-not-evict
 			pods[2].Annotations = lo.Assign(pods[2].Annotations, map[string]string{v1beta1.DoNotDisruptAnnotationKey: "true"})
 
 			ExpectApplied(ctx, env.Client, rs, pods[0], pods[1], pods[2], provisioner)
@@ -958,7 +958,7 @@ var _ = Describe("Machine/Consolidation", func() {
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
 			ExpectMakeNewMachinesReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Cascade any deletion of the machine to the node
@@ -1055,7 +1055,7 @@ var _ = Describe("Machine/Consolidation", func() {
 			fakeClock.Step(10 * time.Minute)
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Expect to not create or delete more machines
@@ -1165,7 +1165,7 @@ var _ = Describe("Machine/Consolidation", func() {
 			fakeClock.Step(10 * time.Minute)
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Expect to not create or delete more machines
@@ -1228,7 +1228,7 @@ var _ = Describe("Machine/Consolidation", func() {
 			var consolidationFinished atomic.Bool
 			go func() {
 				defer GinkgoRecover()
-				ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+				ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 				consolidationFinished.Store(true)
 			}()
 			wg.Wait()
@@ -1334,7 +1334,7 @@ var _ = Describe("Machine/Consolidation", func() {
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Cascade any deletion of the machine to the node
@@ -1381,7 +1381,7 @@ var _ = Describe("Machine/Consolidation", func() {
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Cascade any deletion of the machine to the node
@@ -1435,7 +1435,7 @@ var _ = Describe("Machine/Consolidation", func() {
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Cascade any deletion of the machine to the node
@@ -1500,7 +1500,7 @@ var _ = Describe("Machine/Consolidation", func() {
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Cascade any deletion of the machine to the node
@@ -1553,7 +1553,7 @@ var _ = Describe("Machine/Consolidation", func() {
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Cascade any deletion of the machine to the node
@@ -1604,7 +1604,7 @@ var _ = Describe("Machine/Consolidation", func() {
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Cascade any deletion of the machine to the node
@@ -1637,7 +1637,7 @@ var _ = Describe("Machine/Consolidation", func() {
 							BlockOwnerDeletion: ptr.Bool(true),
 						},
 					}}})
-			// Block this pod from being deprovisioned with karpenter.sh/do-not-evict
+			// Block this pod from being disrupted with karpenter.sh/do-not-evict
 			pods[2].Annotations = lo.Assign(pods[2].Annotations, map[string]string{v1alpha5.DoNotEvictPodAnnotationKey: "true"})
 
 			ExpectApplied(ctx, env.Client, rs, pods[0], pods[1], pods[2], provisioner)
@@ -1655,7 +1655,7 @@ var _ = Describe("Machine/Consolidation", func() {
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Cascade any deletion of the machine to the node
@@ -1688,7 +1688,7 @@ var _ = Describe("Machine/Consolidation", func() {
 							BlockOwnerDeletion: ptr.Bool(true),
 						},
 					}}})
-			// Block this pod from being deprovisioned with karpenter.sh/do-not-disrupt
+			// Block this pod from being disrupted with karpenter.sh/do-not-disrupt
 			pods[2].Annotations = lo.Assign(pods[2].Annotations, map[string]string{v1beta1.DoNotDisruptAnnotationKey: "true"})
 
 			ExpectApplied(ctx, env.Client, rs, pods[0], pods[1], pods[2], provisioner)
@@ -1706,7 +1706,7 @@ var _ = Describe("Machine/Consolidation", func() {
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Cascade any deletion of the machine to the node
@@ -1753,7 +1753,7 @@ var _ = Describe("Machine/Consolidation", func() {
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Cascade any deletion of the machine to the node
@@ -1799,7 +1799,7 @@ var _ = Describe("Machine/Consolidation", func() {
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// shouldn't delete the node
@@ -1948,7 +1948,7 @@ var _ = Describe("Machine/Consolidation", func() {
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			ExpectMachinesCascadeDeletion(ctx, env.Client, consolidatableMachine)
@@ -2005,7 +2005,7 @@ var _ = Describe("Machine/Consolidation", func() {
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Cascade any deletion of the machine to the node
@@ -2061,7 +2061,7 @@ var _ = Describe("Machine/Consolidation", func() {
 
 			fakeClock.Step(10 * time.Minute)
 
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 
 			// No node can be deleted as it would cause one of the three pods to go pending
 			Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(2))
@@ -2072,7 +2072,7 @@ var _ = Describe("Machine/Consolidation", func() {
 				"app": "test",
 			}
 
-			// this invalid provisioner should not be enough to stop all deprovisioning
+			// this invalid provisioner should not be enough to stop all disruption
 			badProvisioner := &v1alpha5.Provisioner{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "bad-provisioner",
@@ -2109,7 +2109,7 @@ var _ = Describe("Machine/Consolidation", func() {
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Cascade any deletion of the machine to the node
@@ -2175,7 +2175,7 @@ var _ = Describe("Machine/Consolidation", func() {
 				defer GinkgoRecover()
 				defer wg.Done()
 				defer finished.Store(true)
-				ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+				ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			}()
 
 			// wait for the controller to block on the validation timeout
@@ -2259,7 +2259,7 @@ var _ = Describe("Machine/Consolidation", func() {
 			go func() {
 				defer wg.Done()
 				defer finished.Store(true)
-				ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+				ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 			}()
 
 			// wait for the controller to block on the validation timeout
@@ -2325,10 +2325,10 @@ var _ = Describe("Machine/Consolidation", func() {
 				defer GinkgoRecover()
 				defer wg.Done()
 				defer finished.Store(true)
-				ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+				ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			}()
 
-			// wait for the deprovisioningController to block on the validation timeout
+			// wait for the disruptionController to block on the validation timeout
 			Eventually(fakeClock.HasWaiters, time.Second*10).Should(BeTrue())
 			// controller should be blocking during the timeout
 			Expect(finished.Load()).To(BeFalse())
@@ -2389,10 +2389,10 @@ var _ = Describe("Machine/Consolidation", func() {
 				defer GinkgoRecover()
 				defer wg.Done()
 				defer finished.Store(true)
-				ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+				ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			}()
 
-			// wait for the deprovisioningController to block on the validation timeout
+			// wait for the disruptionController to block on the validation timeout
 			Eventually(fakeClock.HasWaiters, time.Second*10).Should(BeTrue())
 			// controller should be blocking during the timeout
 			Expect(finished.Load()).To(BeFalse())
@@ -2449,7 +2449,7 @@ var _ = Describe("Machine/Consolidation", func() {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+				ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			}()
 
 			// Iterate in a loop until we get to the validation action
@@ -2514,7 +2514,7 @@ var _ = Describe("Machine/Consolidation", func() {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+				ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			}()
 
 			// Iterate in a loop until we get to the validation action
@@ -2579,7 +2579,7 @@ var _ = Describe("Machine/Consolidation", func() {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+				ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			}()
 
 			// Iterate in a loop until we get to the validation action
@@ -2633,7 +2633,7 @@ var _ = Describe("Machine/Consolidation", func() {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+				ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			}()
 
 			// Iterate in a loop until we get to the validation action
@@ -2684,7 +2684,7 @@ var _ = Describe("Machine/Consolidation", func() {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+				ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			}()
 
 			// Iterate in a loop until we get to the validation action
@@ -2735,7 +2735,7 @@ var _ = Describe("Machine/Consolidation", func() {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+				ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			}()
 
 			// Iterate in a loop until we get to the validation action
@@ -2840,11 +2840,11 @@ var _ = Describe("Machine/Consolidation", func() {
 				defer GinkgoRecover()
 				defer wg.Done()
 				defer finished.Store(true)
-				ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+				ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			}()
 
 			// advance the clock so that the timeout expires
-			fakeClock.Step(deprovisioning.MultiNodeConsolidationTimeoutDuration)
+			fakeClock.Step(disruption.MultiNodeConsolidationTimeoutDuration)
 
 			// wait for the controller to block on the validation timeout
 			Eventually(fakeClock.HasWaiters, time.Second*10).Should(BeTrue())
@@ -2932,13 +2932,13 @@ var _ = Describe("Machine/Consolidation", func() {
 				defer GinkgoRecover()
 				defer wg.Done()
 				defer finished.Store(true)
-				ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+				ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			}()
 
 			// advance the clock so that the timeout expires for multi-machine
-			fakeClock.Step(deprovisioning.MultiNodeConsolidationTimeoutDuration)
+			fakeClock.Step(disruption.MultiNodeConsolidationTimeoutDuration)
 			// advance the clock so that the timeout expires for single-machine
-			fakeClock.Step(deprovisioning.SingleNodeConsolidationTimeoutDuration)
+			fakeClock.Step(disruption.SingleNodeConsolidationTimeoutDuration)
 
 			ExpectTriggerVerifyAction(&wg)
 
@@ -3043,7 +3043,7 @@ var _ = Describe("Machine/Consolidation", func() {
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
 			ExpectMakeNewMachinesReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Cascade any deletion of the machine to the node
@@ -3110,7 +3110,7 @@ var _ = Describe("Machine/Consolidation", func() {
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Cascade any deletion of the machine to the node
@@ -3168,7 +3168,7 @@ var _ = Describe("Machine/Consolidation", func() {
 				defer GinkgoRecover()
 				defer wg.Done()
 				defer finished.Store(true)
-				ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+				ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			}()
 
 			// wait for the controller to block on the validation timeout
@@ -3225,7 +3225,7 @@ var _ = Describe("Machine/Consolidation", func() {
 				defer GinkgoRecover()
 				defer wg.Done()
 				defer finished.Store(true)
-				ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+				ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			}()
 
 			// wait for the controller to block on the validation timeout
@@ -3301,7 +3301,7 @@ var _ = Describe("Machine/Consolidation", func() {
 				defer GinkgoRecover()
 				defer wg.Done()
 				defer finished.Store(true)
-				ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+				ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			}()
 
 			// wait for the controller to block on the validation timeout
@@ -3434,7 +3434,7 @@ var _ = Describe("Machine/Consolidation", func() {
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Cascade any deletion of the machine to the node
@@ -3549,7 +3549,7 @@ var _ = Describe("Machine/Consolidation", func() {
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
 			ExpectMakeNewMachinesReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Cascade any deletion of the machine to the node
@@ -3634,7 +3634,7 @@ var _ = Describe("Machine/Consolidation", func() {
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// our nodes are already the cheapest available, so we can't replace them.  If we delete, it would
@@ -3712,7 +3712,7 @@ var _ = Describe("Machine/Consolidation", func() {
 			ExpectTriggerVerifyAction(&wg)
 			go func() {
 				defer GinkgoRecover()
-				_, _ = deprovisioningController.Reconcile(ctx, reconcile.Request{})
+				_, _ = disruptionController.Reconcile(ctx, reconcile.Request{})
 			}()
 			wg.Wait()
 
@@ -3798,7 +3798,7 @@ var _ = Describe("Machine/Consolidation", func() {
 			// consolidation shouldn't trigger additional actions
 			fakeClock.Step(10 * time.Minute)
 
-			result, err := deprovisioningController.Reconcile(ctx, reconcile.Request{})
+			result, err := disruptionController.Reconcile(ctx, reconcile.Request{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result.RequeueAfter).To(BeNumerically(">", 0))
 		})

--- a/pkg/controllers/disruption/machine_drift_test.go
+++ b/pkg/controllers/disruption/machine_drift_test.go
@@ -12,7 +12,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package deprovisioning_test
+package disruption_test
 
 import (
 	"sync"
@@ -75,7 +75,7 @@ var _ = Describe("Machine/Drift", func() {
 
 		var wg sync.WaitGroup
 		ExpectTriggerVerifyAction(&wg)
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 		wg.Wait()
 
 		// Expect to not create or delete more machines
@@ -127,11 +127,11 @@ var _ = Describe("Machine/Drift", func() {
 		// inform cluster state about nodes and machines
 		ExpectMakeNodesAndMachinesInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node2}, []*v1alpha5.Machine{machine2})
 
-		// deprovisioning won't delete the old node until the new node is ready
+		// disruption won't delete the old node until the new node is ready
 		var wg sync.WaitGroup
 		ExpectTriggerVerifyAction(&wg)
 		ExpectMakeNewMachinesReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 		wg.Wait()
 
 		ExpectMachinesCascadeDeletion(ctx, env.Client, machine, machine2)
@@ -150,7 +150,7 @@ var _ = Describe("Machine/Drift", func() {
 
 		fakeClock.Step(10 * time.Minute)
 
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
 		// Expect to not create or delete more machines
 		Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(1))
@@ -163,7 +163,7 @@ var _ = Describe("Machine/Drift", func() {
 		// inform cluster state about nodes and machines
 		ExpectMakeNodesAndMachinesInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
 
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
 		// Expect to not create or delete more machines
 		Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(1))
@@ -184,7 +184,7 @@ var _ = Describe("Machine/Drift", func() {
 		// inform cluster state about nodes and machines
 		ExpectMakeNodesAndMachinesInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
 
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
 		// Expect to not create or delete more machines
 		Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(1))
@@ -205,7 +205,7 @@ var _ = Describe("Machine/Drift", func() {
 		// inform cluster state about nodes and machines
 		ExpectMakeNodesAndMachinesInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
 
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
 		// Expect to not create or delete more machines
 		Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(1))
@@ -221,7 +221,7 @@ var _ = Describe("Machine/Drift", func() {
 
 		fakeClock.Step(10 * time.Minute)
 
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
 		// Expect to not create or delete more machines
 		Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(1))
@@ -237,7 +237,7 @@ var _ = Describe("Machine/Drift", func() {
 
 		var wg sync.WaitGroup
 		ExpectTriggerVerifyAction(&wg)
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 		wg.Wait()
 
 		// Cascade any deletion of the machine to the node
@@ -248,7 +248,7 @@ var _ = Describe("Machine/Drift", func() {
 		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(0))
 		ExpectNotFound(ctx, env.Client, machine, node)
 	})
-	It("should deprovision all empty drifted nodes in parallel", func() {
+	It("should disrupt all empty drifted nodes in parallel", func() {
 		machines, nodes := test.MachinesAndNodes(100, v1alpha5.Machine{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
@@ -279,7 +279,7 @@ var _ = Describe("Machine/Drift", func() {
 
 		var wg sync.WaitGroup
 		ExpectTriggerVerifyAction(&wg)
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 		wg.Wait()
 
 		// Cascade any deletion of the machine to the node
@@ -321,11 +321,11 @@ var _ = Describe("Machine/Drift", func() {
 
 		fakeClock.Step(10 * time.Minute)
 
-		// deprovisioning won't delete the old machine until the new machine is ready
+		// disruption won't delete the old machine until the new machine is ready
 		var wg sync.WaitGroup
 		ExpectTriggerVerifyAction(&wg)
 		ExpectMakeNewMachinesReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 		wg.Wait()
 
 		// Cascade any deletion of the machine to the node
@@ -421,11 +421,11 @@ var _ = Describe("Machine/Drift", func() {
 
 		fakeClock.Step(10 * time.Minute)
 
-		// deprovisioning won't delete the old node until the new node is ready
+		// disruption won't delete the old node until the new node is ready
 		var wg sync.WaitGroup
 		ExpectTriggerVerifyAction(&wg)
 		ExpectMakeNewMachinesReady(ctx, env.Client, &wg, cluster, cloudProvider, 3)
-		ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+		ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 		wg.Wait()
 
 		// Cascade any deletion of the machine to the node
@@ -486,18 +486,18 @@ var _ = Describe("Machine/Drift", func() {
 
 		ExpectApplied(ctx, env.Client, rs, pods[0], pods[1], machine, node, machine2, node2, provisioner)
 
-		// bind pods to node so that they're not empty and don't deprovision in parallel.
+		// bind pods to node so that they're not empty and don't disrupt in parallel.
 		ExpectManualBinding(ctx, env.Client, pods[0], node)
 		ExpectManualBinding(ctx, env.Client, pods[1], node2)
 
 		// inform cluster state about nodes and machines
 		ExpectMakeNodesAndMachinesInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node, node2}, []*v1alpha5.Machine{machine, machine2})
 
-		// deprovisioning won't delete the old node until the new node is ready
+		// disruption won't delete the old node until the new node is ready
 		var wg sync.WaitGroup
 		ExpectTriggerVerifyAction(&wg)
 		ExpectMakeNewMachinesReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 		wg.Wait()
 
 		// Cascade any deletion of the machine to the node

--- a/pkg/controllers/disruption/machine_emptiness_test.go
+++ b/pkg/controllers/disruption/machine_emptiness_test.go
@@ -13,7 +13,7 @@ limitations under the License.
 */
 
 // nolint:gosec
-package deprovisioning_test
+package disruption_test
 
 import (
 	"sync"
@@ -71,7 +71,7 @@ var _ = Describe("Machine/Emptiness", func() {
 		fakeClock.Step(10 * time.Minute)
 		wg := sync.WaitGroup{}
 		ExpectTriggerVerifyAction(&wg)
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
 		// Cascade any deletion of the machine to the node
 		ExpectMachinesCascadeDeletion(ctx, env.Client, machine)
@@ -88,7 +88,7 @@ var _ = Describe("Machine/Emptiness", func() {
 		// inform cluster state about nodes and machines
 		ExpectMakeNodesAndMachinesInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
 
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
 		// Expect to not create or delete more machines
 		Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(1))
@@ -102,7 +102,7 @@ var _ = Describe("Machine/Emptiness", func() {
 		// inform cluster state about nodes and machines
 		ExpectMakeNodesAndMachinesInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
 
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
 		// Expect to not create or delete more machines
 		Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(1))
@@ -123,7 +123,7 @@ var _ = Describe("Machine/Emptiness", func() {
 		// inform cluster state about nodes and machines
 		ExpectMakeNodesAndMachinesInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
 
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
 		// Expect to not create or delete more machines
 		Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(1))
@@ -144,7 +144,7 @@ var _ = Describe("Machine/Emptiness", func() {
 		// inform cluster state about nodes and machines
 		ExpectMakeNodesAndMachinesInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
 
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
 		// Expect to not create or delete more machines
 		Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(1))
@@ -160,7 +160,7 @@ var _ = Describe("Machine/Emptiness", func() {
 
 		fakeClock.Step(10 * time.Minute)
 
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
 		// Expect to not create or delete more machines
 		Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(1))

--- a/pkg/controllers/disruption/machine_expiration_test.go
+++ b/pkg/controllers/disruption/machine_expiration_test.go
@@ -12,7 +12,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package deprovisioning_test
+package disruption_test
 
 import (
 	"sync"
@@ -76,7 +76,7 @@ var _ = Describe("Machine/Expiration", func() {
 		// inform cluster state about nodes and machines
 		ExpectMakeNodesAndMachinesInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
 
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
 		// Expect to not create or delete more machines
 		Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(1))
@@ -90,7 +90,7 @@ var _ = Describe("Machine/Expiration", func() {
 		// inform cluster state about nodes and machines
 		ExpectMakeNodesAndMachinesInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
 
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
 		// Expect to not create or delete more machines
 		Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(1))
@@ -111,7 +111,7 @@ var _ = Describe("Machine/Expiration", func() {
 		// inform cluster state about nodes and machines
 		ExpectMakeNodesAndMachinesInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
 
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
 		// Expect to not create or delete more machines
 		Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(1))
@@ -132,7 +132,7 @@ var _ = Describe("Machine/Expiration", func() {
 		// inform cluster state about nodes and machines
 		ExpectMakeNodesAndMachinesInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
 
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
 		// Expect to not create or delete more machines
 		Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(1))
@@ -184,11 +184,11 @@ var _ = Describe("Machine/Expiration", func() {
 		// inform cluster state about nodes and machines
 		ExpectMakeNodesAndMachinesInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node2}, []*v1alpha5.Machine{machine2})
 
-		// deprovisioning won't delete the old node until the new node is ready
+		// disruption won't delete the old node until the new node is ready
 		var wg sync.WaitGroup
 		ExpectTriggerVerifyAction(&wg)
 		ExpectMakeNewMachinesReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 		wg.Wait()
 
 		ExpectMachinesCascadeDeletion(ctx, env.Client, machine, machine2)
@@ -207,7 +207,7 @@ var _ = Describe("Machine/Expiration", func() {
 
 		fakeClock.Step(10 * time.Minute)
 
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
 		// Expect to not create or delete more machines
 		Expect(ExpectMachines(ctx, env.Client)).To(HaveLen(1))
@@ -221,7 +221,7 @@ var _ = Describe("Machine/Expiration", func() {
 
 		var wg sync.WaitGroup
 		ExpectTriggerVerifyAction(&wg)
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 		wg.Wait()
 
 		// Cascade any deletion of the machine to the node
@@ -232,7 +232,7 @@ var _ = Describe("Machine/Expiration", func() {
 		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(0))
 		ExpectNotFound(ctx, env.Client, machine, node)
 	})
-	It("should deprovision all empty expired nodes in parallel", func() {
+	It("should disrupt all empty expired nodes in parallel", func() {
 		machines, nodes := test.MachinesAndNodes(100, v1alpha5.Machine{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
@@ -263,7 +263,7 @@ var _ = Describe("Machine/Expiration", func() {
 
 		var wg sync.WaitGroup
 		ExpectTriggerVerifyAction(&wg)
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 		wg.Wait()
 
 		// Cascade any deletion of the machine to the node
@@ -321,18 +321,18 @@ var _ = Describe("Machine/Expiration", func() {
 
 		ExpectApplied(ctx, env.Client, rs, pods[0], pods[1], machine, machine2, node, node2, provisioner)
 
-		// bind pods to node so that they're not empty and don't deprovision in parallel.
+		// bind pods to node so that they're not empty and don't disrupt in parallel.
 		ExpectManualBinding(ctx, env.Client, pods[0], node)
 		ExpectManualBinding(ctx, env.Client, pods[1], node2)
 
 		// inform cluster state about nodes and machines
 		ExpectMakeNodesAndMachinesInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node, node2}, []*v1alpha5.Machine{machine, machine2})
 
-		// deprovisioning won't delete the old node until the new node is ready
+		// disruption won't delete the old node until the new node is ready
 		var wg sync.WaitGroup
 		ExpectTriggerVerifyAction(&wg)
 		ExpectMakeNewMachinesReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 		wg.Wait()
 
 		// Cascade any deletion of the machine to the node
@@ -376,11 +376,11 @@ var _ = Describe("Machine/Expiration", func() {
 		// inform cluster state about nodes and machines
 		ExpectMakeNodesAndMachinesInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
 
-		// deprovisioning won't delete the old node until the new node is ready
+		// disruption won't delete the old node until the new node is ready
 		var wg sync.WaitGroup
 		ExpectTriggerVerifyAction(&wg)
 		ExpectMakeNewMachinesReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 		wg.Wait()
 
 		// Cascade any deletion of the machine to the node
@@ -431,7 +431,7 @@ var _ = Describe("Machine/Expiration", func() {
 		var wg sync.WaitGroup
 		ExpectTriggerVerifyAction(&wg)
 		ExpectNewMachinesDeleted(ctx, env.Client, &wg, 1)
-		_, err := deprovisioningController.Reconcile(ctx, reconcile.Request{})
+		_, err := disruptionController.Reconcile(ctx, reconcile.Request{})
 		Expect(err).To(HaveOccurred())
 		wg.Wait()
 
@@ -516,11 +516,11 @@ var _ = Describe("Machine/Expiration", func() {
 		// inform cluster state about nodes and machines
 		ExpectMakeNodesAndMachinesInitializedAndStateUpdated(ctx, env.Client, nodeStateController, machineStateController, []*v1.Node{node}, []*v1alpha5.Machine{machine})
 
-		// deprovisioning won't delete the old machine until the new machine is ready
+		// disruption won't delete the old machine until the new machine is ready
 		var wg sync.WaitGroup
 		ExpectTriggerVerifyAction(&wg)
 		ExpectMakeNewMachinesReady(ctx, env.Client, &wg, cluster, cloudProvider, 3)
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 		wg.Wait()
 
 		// Cascade any deletion of the machine to the node

--- a/pkg/controllers/disruption/metrics.go
+++ b/pkg/controllers/disruption/metrics.go
@@ -32,16 +32,13 @@ const (
 	deprovisioningSubsystem = "deprovisioning"
 	deprovisionerLabel      = "deprovisioner"
 
-	disruptionSubsystem = "disruption"
-	disruptionTypeLabel = "disruption_type"
-	actionLabel         = "action"
-	consolidationType   = "consolidation_type"
+	disruptionSubsystem    = "disruption"
+	actionLabel            = "action"
+	methodLabel            = "method"
+	consolidationTypeLabel = "consolidation_type"
 
 	multiMachineConsolidationLabelValue  = "multi-machine"
 	singleMachineConsolidationLabelValue = "single-machine"
-
-	multiNodeConsolidationLabelValue  = "multi_node"
-	singleNodeConsolidationLabelValue = "single_node"
 )
 
 var (
@@ -88,7 +85,7 @@ var (
 			Name:      "consolidation_timeouts",
 			Help:      "Number of times the Consolidation algorithm has reached a timeout. Labeled by consolidation type.",
 		},
-		[]string{consolidationType},
+		[]string{consolidationTypeLabel},
 	)
 	deprovisioningReplacementNodeLaunchFailedCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -106,11 +103,11 @@ var (
 		prometheus.HistogramOpts{
 			Namespace: metrics.Namespace,
 			Subsystem: disruptionSubsystem,
-			Name:      "evluation_duration_seconds",
+			Name:      "evaluation_duration_seconds",
 			Help:      "Duration of the disruption evaluation process in seconds.",
 			Buckets:   metrics.DurationBuckets(),
 		},
-		[]string{disruptionTypeLabel},
+		[]string{methodLabel, consolidationTypeLabel},
 	)
 	disruptionReplacementNodeClaimInitializedHistogram = prometheus.NewHistogram(
 		prometheus.HistogramOpts{
@@ -124,37 +121,37 @@ var (
 	disruptionReplacementNodeClaimFailedCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: metrics.Namespace,
-			Subsystem: deprovisioningSubsystem,
-			Name:      "replacement_nodeclaim_failures",
+			Subsystem: disruptionSubsystem,
+			Name:      "replacement_nodeclaim_failures_total",
 			Help:      "The number of times that Karpenter failed to launch a replacement node for disruption. Labeled by disruption type.",
 		},
-		[]string{disruptionTypeLabel},
+		[]string{methodLabel, consolidationTypeLabel},
 	)
 	disruptionActionsPerformedCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: metrics.Namespace,
 			Subsystem: disruptionSubsystem,
-			Name:      "actions_performed",
-			Help:      "Number of deprovisioning actions performed. Labeled by disruption type.",
+			Name:      "actions_performed_total",
+			Help:      "Number of disruption methods performed. Labeled by disruption type.",
 		},
-		[]string{actionLabel, disruptionTypeLabel},
+		[]string{actionLabel, methodLabel, consolidationTypeLabel},
 	)
 	disruptionEligibleNodesGauge = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
 			Namespace: metrics.Namespace,
 			Subsystem: disruptionSubsystem,
 			Name:      "eligible_nodes",
-			Help:      "Number of nodes eligible for disruption by Karpenter. Labeled by disruption type",
+			Help:      "Number of nodes eligible for disruption by Karpenter. Labeled by disruption type.",
 		},
-		[]string{disruptionTypeLabel},
+		[]string{methodLabel, consolidationTypeLabel},
 	)
 	disruptionConsolidationTimeoutTotalCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: metrics.Namespace,
 			Subsystem: disruptionSubsystem,
-			Name:      "consolidation_timeout_total",
+			Name:      "consolidation_timeouts_total",
 			Help:      "Number of times the Consolidation algorithm has reached a timeout. Labeled by consolidation type.",
 		},
-		[]string{consolidationType},
+		[]string{consolidationTypeLabel},
 	)
 )

--- a/pkg/controllers/disruption/nodeclaim_consolidation_test.go
+++ b/pkg/controllers/disruption/nodeclaim_consolidation_test.go
@@ -12,7 +12,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package deprovisioning_test
+package disruption_test
 
 import (
 	"fmt"
@@ -40,7 +40,7 @@ import (
 	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
 	"github.com/aws/karpenter-core/pkg/cloudprovider/fake"
-	"github.com/aws/karpenter-core/pkg/controllers/deprovisioning"
+	"github.com/aws/karpenter-core/pkg/controllers/disruption"
 	"github.com/aws/karpenter-core/pkg/events"
 	"github.com/aws/karpenter-core/pkg/scheduling"
 	"github.com/aws/karpenter-core/pkg/test"
@@ -107,7 +107,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Cascade any deletion of the nodeclaim to the node
@@ -127,7 +127,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 			fakeClock.Step(10 * time.Minute)
 			wg := sync.WaitGroup{}
 			ExpectTriggerVerifyAction(&wg)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+			ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
 			// Cascade any deletion of the nodeclaim to the node
 			ExpectNodeClaimsCascadeDeletion(ctx, env.Client, nodeClaim, nodeClaim2)
@@ -189,7 +189,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 			// inform cluster state about nodes and nodeclaims
 			ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
 
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 
 			// we don't need any new nodes and consolidation should notice the huge pending pod that needs the large
 			// node to schedule, which prevents the large expensive node from being replaced
@@ -234,7 +234,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
 			ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Cascade any deletion of the nodeclaim to the node
@@ -292,7 +292,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
 			ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Cascade any deletion of the nodeclaim to the node
@@ -358,7 +358,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 
 			fakeClock.Step(10 * time.Minute)
 
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 
 			// we didn't create a new nodeclaim or delete the old one
 			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
@@ -435,7 +435,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
 			ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Cascade any deletion of the nodeclaim to the node
@@ -503,7 +503,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
 			ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Cascade any deletion of the nodeclaim to the node
@@ -581,7 +581,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
 			ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Cascade any deletion of the nodeclaim to the node
@@ -659,7 +659,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
 			ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Cascade any deletion of the machine to the node
@@ -717,7 +717,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 					},
 				},
 			})
-			// Block this pod from being deprovisioned with karpenter.sh/do-not-evict
+			// Block this pod from being disrupted with karpenter.sh/do-not-evict
 			pods[2].Annotations = lo.Assign(pods[2].Annotations, map[string]string{v1alpha5.DoNotEvictPodAnnotationKey: "true"})
 
 			ExpectApplied(ctx, env.Client, rs, pods[0], pods[1], pods[2], nodePool)
@@ -736,7 +736,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
 			ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Cascade any deletion of the machine to the node
@@ -794,7 +794,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 					},
 				},
 			})
-			// Block this pod from being deprovisioned with karpenter.sh/do-not-evict
+			// Block this pod from being disrupted with karpenter.sh/do-not-evict
 			pods[2].Annotations = lo.Assign(pods[2].Annotations, map[string]string{v1beta1.DoNotDisruptAnnotationKey: "true"})
 
 			ExpectApplied(ctx, env.Client, rs, pods[0], pods[1], pods[2], nodePool)
@@ -813,7 +813,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
 			ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Cascade any deletion of the machine to the node
@@ -910,7 +910,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 			fakeClock.Step(10 * time.Minute)
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Expect to not create or delete more nodeclaims
@@ -1021,7 +1021,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 			fakeClock.Step(10 * time.Minute)
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Expect to not create or delete more nodeclaims
@@ -1072,7 +1072,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 			var consolidationFinished atomic.Bool
 			go func() {
 				defer GinkgoRecover()
-				ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+				ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 				consolidationFinished.Store(true)
 			}()
 			wg.Wait()
@@ -1179,7 +1179,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Cascade any deletion of the nodeclaim to the node
@@ -1226,7 +1226,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Cascade any deletion of the nodeclaim to the node
@@ -1280,7 +1280,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Cascade any deletion of the nodeclaim to the node
@@ -1342,7 +1342,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Cascade any deletion of the nodeclaim to the node
@@ -1395,7 +1395,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Cascade any deletion of the machine to the node
@@ -1446,7 +1446,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Cascade any deletion of the machine to the node
@@ -1479,7 +1479,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 							BlockOwnerDeletion: ptr.Bool(true),
 						},
 					}}})
-			// Block this pod from being deprovisioned with karpenter.sh/do-not-evict
+			// Block this pod from being disrupted with karpenter.sh/do-not-evict
 			pods[2].Annotations = lo.Assign(pods[2].Annotations, map[string]string{v1alpha5.DoNotEvictPodAnnotationKey: "true"})
 
 			ExpectApplied(ctx, env.Client, rs, pods[0], pods[1], pods[2], nodePool)
@@ -1497,7 +1497,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Cascade any deletion of the nodeclaim to the node
@@ -1530,7 +1530,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 							BlockOwnerDeletion: ptr.Bool(true),
 						},
 					}}})
-			// Block this pod from being deprovisioned with karpenter.sh/do-not-disrupt
+			// Block this pod from being disrupted with karpenter.sh/do-not-disrupt
 			pods[2].Annotations = lo.Assign(pods[2].Annotations, map[string]string{v1beta1.DoNotDisruptAnnotationKey: "true"})
 
 			ExpectApplied(ctx, env.Client, rs, pods[0], pods[1], pods[2], nodePool)
@@ -1548,7 +1548,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Cascade any deletion of the machine to the node
@@ -1595,7 +1595,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Cascade any deletion of the nodeclaim to the node
@@ -1641,7 +1641,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// shouldn't delete the node
@@ -1790,7 +1790,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			ExpectNodeClaimsCascadeDeletion(ctx, env.Client, consolidatableNodeClaim)
@@ -1847,7 +1847,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Cascade any deletion of the nodeclaim to the node
@@ -1903,7 +1903,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 
 			fakeClock.Step(10 * time.Minute)
 
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 
 			// No node can be deleted as it would cause one of the three pods to go pending
 			Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(2))
@@ -1914,7 +1914,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 				"app": "test",
 			}
 
-			// this invalid node pool should not be enough to stop all deprovisioning
+			// this invalid node pool should not be enough to stop all disruption
 			badNodePool := &v1beta1.NodePool{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "bad-nodepool",
@@ -1961,7 +1961,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Cascade any deletion of the machine to the node
@@ -2027,7 +2027,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 				defer GinkgoRecover()
 				defer wg.Done()
 				defer finished.Store(true)
-				ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+				ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			}()
 
 			// wait for the controller to block on the validation timeout
@@ -2111,7 +2111,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 			go func() {
 				defer wg.Done()
 				defer finished.Store(true)
-				ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+				ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 			}()
 
 			// wait for the controller to block on the validation timeout
@@ -2178,10 +2178,10 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 				defer GinkgoRecover()
 				defer wg.Done()
 				defer finished.Store(true)
-				ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+				ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			}()
 
-			// wait for the deprovisioningController to block on the validation timeout
+			// wait for the disruptionController to block on the validation timeout
 			Eventually(fakeClock.HasWaiters, time.Second*10).Should(BeTrue())
 			// controller should be blocking during the timeout
 			Expect(finished.Load()).To(BeFalse())
@@ -2242,10 +2242,10 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 				defer GinkgoRecover()
 				defer wg.Done()
 				defer finished.Store(true)
-				ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+				ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			}()
 
-			// wait for the deprovisioningController to block on the validation timeout
+			// wait for the disruptionController to block on the validation timeout
 			Eventually(fakeClock.HasWaiters, time.Second*10).Should(BeTrue())
 			// controller should be blocking during the timeout
 			Expect(finished.Load()).To(BeFalse())
@@ -2285,7 +2285,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+				ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			}()
 
 			// Iterate in a loop until we get to the validation action
@@ -2333,7 +2333,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+				ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			}()
 
 			// Iterate in a loop until we get to the validation action
@@ -2381,7 +2381,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+				ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			}()
 
 			// Iterate in a loop until we get to the validation action
@@ -2435,7 +2435,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+				ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			}()
 
 			// Iterate in a loop until we get to the validation action
@@ -2486,7 +2486,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+				ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			}()
 
 			// Iterate in a loop until we get to the validation action
@@ -2537,7 +2537,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+				ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			}()
 
 			// Iterate in a loop until we get to the validation action
@@ -2642,11 +2642,11 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 				defer GinkgoRecover()
 				defer wg.Done()
 				defer finished.Store(true)
-				ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+				ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			}()
 
 			// advance the clock so that the timeout expires
-			fakeClock.Step(deprovisioning.MultiNodeConsolidationTimeoutDuration)
+			fakeClock.Step(disruption.MultiNodeConsolidationTimeoutDuration)
 
 			// wait for the controller to block on the validation timeout
 			Eventually(fakeClock.HasWaiters, time.Second*10).Should(BeTrue())
@@ -2734,13 +2734,13 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 				defer GinkgoRecover()
 				defer wg.Done()
 				defer finished.Store(true)
-				ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+				ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			}()
 
 			// advance the clock so that the timeout expires for multi-nodeClaim
-			fakeClock.Step(deprovisioning.MultiNodeConsolidationTimeoutDuration)
+			fakeClock.Step(disruption.MultiNodeConsolidationTimeoutDuration)
 			// advance the clock so that the timeout expires for single-nodeClaim
-			fakeClock.Step(deprovisioning.SingleNodeConsolidationTimeoutDuration)
+			fakeClock.Step(disruption.SingleNodeConsolidationTimeoutDuration)
 
 			ExpectTriggerVerifyAction(&wg)
 
@@ -2845,7 +2845,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
 			ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Cascade any deletion of the nodeclaim to the node
@@ -2912,7 +2912,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Cascade any deletion of the nodeclaim to the node
@@ -2970,7 +2970,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 				defer GinkgoRecover()
 				defer wg.Done()
 				defer finished.Store(true)
-				ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+				ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			}()
 
 			// wait for the controller to block on the validation timeout
@@ -3027,7 +3027,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 				defer GinkgoRecover()
 				defer wg.Done()
 				defer finished.Store(true)
-				ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+				ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			}()
 
 			// wait for the controller to block on the validation timeout
@@ -3103,7 +3103,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 				defer GinkgoRecover()
 				defer wg.Done()
 				defer finished.Store(true)
-				ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+				ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			}()
 
 			// wait for the controller to block on the validation timeout
@@ -3236,7 +3236,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Cascade any deletion of the nodeclaim to the node
@@ -3351,7 +3351,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
 			ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// Cascade any deletion of the nodeclaim to the node
@@ -3436,7 +3436,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 
 			var wg sync.WaitGroup
 			ExpectTriggerVerifyAction(&wg)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 			wg.Wait()
 
 			// our nodes are already the cheapest available, so we can't replace them.  If we delete, it would
@@ -3492,7 +3492,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 			ExpectTriggerVerifyAction(&wg)
 			go func() {
 				defer GinkgoRecover()
-				_, _ = deprovisioningController.Reconcile(ctx, reconcile.Request{})
+				_, _ = disruptionController.Reconcile(ctx, reconcile.Request{})
 			}()
 			wg.Wait()
 
@@ -3577,7 +3577,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 			// consolidation shouldn't trigger additional actions
 			fakeClock.Step(10 * time.Minute)
 
-			result, err := deprovisioningController.Reconcile(ctx, reconcile.Request{})
+			result, err := disruptionController.Reconcile(ctx, reconcile.Request{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result.RequeueAfter).To(BeNumerically(">", 0))
 		})

--- a/pkg/controllers/disruption/nodeclaim_emptiness_test.go
+++ b/pkg/controllers/disruption/nodeclaim_emptiness_test.go
@@ -13,7 +13,7 @@ limitations under the License.
 */
 
 // nolint:gosec
-package deprovisioning_test
+package disruption_test
 
 import (
 	"sync"
@@ -76,7 +76,7 @@ var _ = Describe("NodeClaim/Emptiness", func() {
 		fakeClock.Step(10 * time.Minute)
 		wg := sync.WaitGroup{}
 		ExpectTriggerVerifyAction(&wg)
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
 		// Cascade any deletion of the nodeClaim to the node
 		ExpectNodeClaimsCascadeDeletion(ctx, env.Client, nodeClaim)
@@ -93,7 +93,7 @@ var _ = Describe("NodeClaim/Emptiness", func() {
 		// inform cluster state about nodes and nodeclaims
 		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
 
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
 		// Expect to not create or delete more nodeclaims
 		Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
@@ -107,7 +107,7 @@ var _ = Describe("NodeClaim/Emptiness", func() {
 		// inform cluster state about nodes and nodeclaims
 		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
 
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
 		// Expect to not create or delete more nodeclaims
 		Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
@@ -128,7 +128,7 @@ var _ = Describe("NodeClaim/Emptiness", func() {
 		// inform cluster state about nodes and nodeclaims
 		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
 
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
 		// Expect to not create or delete more nodeclaims
 		Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
@@ -149,7 +149,7 @@ var _ = Describe("NodeClaim/Emptiness", func() {
 		// inform cluster state about nodes and nodeclaims
 		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
 
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
 		// Expect to not create or delete more nodeclaims
 		Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
@@ -165,7 +165,7 @@ var _ = Describe("NodeClaim/Emptiness", func() {
 
 		fakeClock.Step(10 * time.Minute)
 
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
 		// Expect to not create or delete more nodeclaims
 		Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))

--- a/pkg/controllers/disruption/nodeclaim_expiration_test.go
+++ b/pkg/controllers/disruption/nodeclaim_expiration_test.go
@@ -12,7 +12,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package deprovisioning_test
+package disruption_test
 
 import (
 	"sync"
@@ -28,17 +28,17 @@ import (
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
 	"github.com/aws/karpenter-core/pkg/cloudprovider/fake"
-	"github.com/aws/karpenter-core/pkg/operator/options"
 	"github.com/aws/karpenter-core/pkg/test"
 	. "github.com/aws/karpenter-core/pkg/test/expectations"
 )
 
-var _ = Describe("NodeClaim/Drift", func() {
+var _ = Describe("NodeClaim/Expiration", func() {
 	var nodePool *v1beta1.NodePool
 	var nodeClaim *v1beta1.NodeClaim
 	var node *v1.Node
@@ -48,7 +48,7 @@ var _ = Describe("NodeClaim/Drift", func() {
 			Spec: v1beta1.NodePoolSpec{
 				Disruption: v1beta1.Disruption{
 					ConsolidateAfter: &v1beta1.NillableDuration{Duration: nil},
-					ExpireAfter:      v1beta1.NillableDuration{Duration: nil},
+					ExpireAfter:      v1beta1.NillableDuration{Duration: lo.ToPtr(time.Second * 30)},
 				},
 			},
 		})
@@ -69,27 +69,79 @@ var _ = Describe("NodeClaim/Drift", func() {
 				},
 			},
 		})
-		nodeClaim.StatusConditions().MarkTrue(v1beta1.Drifted)
+		nodeClaim.StatusConditions().MarkTrue(v1beta1.Expired)
 	})
-	It("should ignore drifted nodes if the feature flag is disabled", func() {
-		ctx = options.ToContext(ctx, test.Options(test.OptionsFields{FeatureGates: test.FeatureGates{Drift: lo.ToPtr(false)}}))
+	It("should ignore nodes without the expired status condition", func() {
+		_ = nodeClaim.StatusConditions().ClearCondition(v1beta1.Expired)
 		ExpectApplied(ctx, env.Client, nodeClaim, node, nodePool)
 
 		// inform cluster state about nodes and nodeclaims
 		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
 
-		fakeClock.Step(10 * time.Minute)
-
-		var wg sync.WaitGroup
-		ExpectTriggerVerifyAction(&wg)
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
-		wg.Wait()
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
 		// Expect to not create or delete more nodeclaims
 		Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
+		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
 		ExpectExists(ctx, env.Client, nodeClaim)
 	})
-	It("should continue to the next drifted node if the first cannot reschedule all pods", func() {
+	It("should ignore nodes with the karpenter.sh/do-not-disrupt annotation", func() {
+		node.Annotations = lo.Assign(node.Annotations, map[string]string{v1beta1.DoNotDisruptAnnotationKey: "true"})
+		ExpectApplied(ctx, env.Client, nodeClaim, node, nodePool)
+
+		// inform cluster state about nodes and nodeclaims
+		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
+
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
+
+		// Expect to not create or delete more nodeclaims
+		Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
+		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
+		ExpectExists(ctx, env.Client, nodeClaim)
+	})
+	It("should ignore nodes that have pods with the karpenter.sh/do-not-evict annotation", func() {
+		pod := test.Pod(test.PodOptions{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					v1alpha5.DoNotEvictPodAnnotationKey: "true",
+				},
+			},
+		})
+		ExpectApplied(ctx, env.Client, nodeClaim, node, nodePool, pod)
+		ExpectManualBinding(ctx, env.Client, pod, node)
+
+		// inform cluster state about nodes and nodeclaims
+		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
+
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
+
+		// Expect to not create or delete more nodeclaims
+		Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
+		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
+		ExpectExists(ctx, env.Client, nodeClaim)
+	})
+	It("should ignore nodes that have pods with the karpenter.sh/do-not-disrupt annotation", func() {
+		pod := test.Pod(test.PodOptions{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					v1beta1.DoNotDisruptAnnotationKey: "true",
+				},
+			},
+		})
+		ExpectApplied(ctx, env.Client, nodeClaim, node, nodePool, pod)
+		ExpectManualBinding(ctx, env.Client, pod, node)
+
+		// inform cluster state about nodes and nodeclaims
+		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
+
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
+
+		// Expect to not create or delete more nodeclaims
+		Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
+		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
+		ExpectExists(ctx, env.Client, nodeClaim)
+	})
+	It("should continue to the next expired node if the first cannot reschedule all pods", func() {
 		pod := test.Pod(test.PodOptions{
 			ResourceRequirements: v1.ResourceRequirements{
 				Requests: v1.ResourceList{
@@ -127,18 +179,18 @@ var _ = Describe("NodeClaim/Drift", func() {
 				},
 			},
 		})
-		nodeClaim2.StatusConditions().MarkTrue(v1beta1.Drifted)
+		nodeClaim2.StatusConditions().MarkTrue(v1beta1.Expired)
 		ExpectApplied(ctx, env.Client, nodeClaim2, node2, podToExpire)
 		ExpectManualBinding(ctx, env.Client, podToExpire, node2)
 
 		// inform cluster state about nodes and nodeclaims
 		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node2}, []*v1beta1.NodeClaim{nodeClaim2})
 
-		// deprovisioning won't delete the old node until the new node is ready
+		// disruption won't delete the old node until the new node is ready
 		var wg sync.WaitGroup
 		ExpectTriggerVerifyAction(&wg)
 		ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 		wg.Wait()
 
 		ExpectNodeClaimsCascadeDeletion(ctx, env.Client, nodeClaim, nodeClaim2)
@@ -148,8 +200,8 @@ var _ = Describe("NodeClaim/Drift", func() {
 		ExpectExists(ctx, env.Client, nodeClaim)
 		ExpectNotFound(ctx, env.Client, nodeClaim2)
 	})
-	It("should ignore nodes without the drifted status condition", func() {
-		_ = nodeClaim.StatusConditions().ClearCondition(v1beta1.Drifted)
+	It("should ignore nodes with the expired status condition set to false", func() {
+		nodeClaim.StatusConditions().MarkFalse(v1beta1.Expired, "", "")
 		ExpectApplied(ctx, env.Client, nodeClaim, node, nodePool)
 
 		// inform cluster state about nodes and nodeclaims
@@ -157,105 +209,32 @@ var _ = Describe("NodeClaim/Drift", func() {
 
 		fakeClock.Step(10 * time.Minute)
 
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
 		// Expect to not create or delete more nodeclaims
 		Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
 		ExpectExists(ctx, env.Client, nodeClaim)
 	})
-	It("should ignore nodes with the karpenter.sh/do-not-disrupt annotation", func() {
-		node.Annotations = lo.Assign(node.Annotations, map[string]string{v1beta1.DoNotDisruptAnnotationKey: "true"})
+	It("can delete expired nodes", func() {
 		ExpectApplied(ctx, env.Client, nodeClaim, node, nodePool)
 
 		// inform cluster state about nodes and nodeclaims
 		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
-
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
-
-		// Expect to not create or delete more nodeclaims
-		Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
-		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
-		ExpectExists(ctx, env.Client, nodeClaim)
-	})
-	It("should ignore nodes that have pods with the karpenter.sh/do-not-evict annotation", func() {
-		pod := test.Pod(test.PodOptions{
-			ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{
-					v1alpha5.DoNotEvictPodAnnotationKey: "true",
-				},
-			},
-		})
-		ExpectApplied(ctx, env.Client, nodeClaim, node, nodePool, pod)
-		ExpectManualBinding(ctx, env.Client, pod, node)
-
-		// inform cluster state about nodes and nodeclaims
-		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
-
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
-
-		// Expect to not create or delete more nodeclaims
-		Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
-		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
-		ExpectExists(ctx, env.Client, nodeClaim)
-	})
-	It("should ignore nodes that have pods with the karpenter.sh/do-not-disrupt annotation", func() {
-		pod := test.Pod(test.PodOptions{
-			ObjectMeta: metav1.ObjectMeta{
-				Annotations: map[string]string{
-					v1beta1.DoNotDisruptAnnotationKey: "true",
-				},
-			},
-		})
-		ExpectApplied(ctx, env.Client, nodeClaim, node, nodePool, pod)
-		ExpectManualBinding(ctx, env.Client, pod, node)
-
-		// inform cluster state about nodes and nodeclaims
-		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
-
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
-
-		// Expect to not create or delete more nodeclaims
-		Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
-		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
-		ExpectExists(ctx, env.Client, nodeClaim)
-	})
-	It("should ignore nodes with the drifted status condition set to false", func() {
-		nodeClaim.StatusConditions().MarkFalse(v1beta1.Drifted, "", "")
-		ExpectApplied(ctx, env.Client, nodeClaim, node, nodePool)
-
-		// inform cluster state about nodes and nodeclaims
-		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
-
-		fakeClock.Step(10 * time.Minute)
-
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
-
-		// Expect to not create or delete more nodeclaims
-		Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
-		ExpectExists(ctx, env.Client, nodeClaim)
-	})
-	It("can delete drifted nodes", func() {
-		ExpectApplied(ctx, env.Client, nodeClaim, node, nodePool)
-
-		// inform cluster state about nodes and nodeclaims
-		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
-
-		fakeClock.Step(10 * time.Minute)
 
 		var wg sync.WaitGroup
 		ExpectTriggerVerifyAction(&wg)
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 		wg.Wait()
 
 		// Cascade any deletion of the nodeClaim to the node
 		ExpectNodeClaimsCascadeDeletion(ctx, env.Client, nodeClaim)
 
-		// We should delete the nodeClaim that has drifted
+		// Expect that the expired nodeClaim is gone
 		Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(0))
 		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(0))
 		ExpectNotFound(ctx, env.Client, nodeClaim, node)
 	})
-	It("should deprovision all empty drifted nodes in parallel", func() {
+	It("should disrupt all empty expired nodes in parallel", func() {
 		nodeClaims, nodes := test.NodeClaimsAndNodes(100, v1beta1.NodeClaim{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{
@@ -273,7 +252,7 @@ var _ = Describe("NodeClaim/Drift", func() {
 			},
 		})
 		for _, m := range nodeClaims {
-			m.StatusConditions().MarkTrue(v1beta1.Drifted)
+			m.StatusConditions().MarkTrue(v1beta1.Expired)
 			ExpectApplied(ctx, env.Client, m)
 		}
 		for _, n := range nodes {
@@ -286,7 +265,7 @@ var _ = Describe("NodeClaim/Drift", func() {
 
 		var wg sync.WaitGroup
 		ExpectTriggerVerifyAction(&wg)
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 		wg.Wait()
 
 		// Cascade any deletion of the nodeClaim to the node
@@ -296,7 +275,130 @@ var _ = Describe("NodeClaim/Drift", func() {
 		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(0))
 		Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(0))
 	})
-	It("can replace drifted nodes", func() {
+	It("should expire one non-empty node at a time, starting with most expired", func() {
+		labels := map[string]string{
+			"app": "test",
+		}
+		// create our RS so we can link a pod to it
+		rs := test.ReplicaSet()
+		ExpectApplied(ctx, env.Client, rs)
+
+		pods := test.Pods(2, test.PodOptions{
+			ObjectMeta: metav1.ObjectMeta{Labels: labels,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion:         "apps/v1",
+						Kind:               "ReplicaSet",
+						Name:               rs.Name,
+						UID:                rs.UID,
+						Controller:         ptr.Bool(true),
+						BlockOwnerDeletion: ptr.Bool(true),
+					},
+				},
+			},
+			// Make each pod request only fit on a single node
+			ResourceRequirements: v1.ResourceRequirements{
+				Requests: map[v1.ResourceName]resource.Quantity{v1.ResourceCPU: resource.MustParse("30")},
+			},
+		})
+		nodeClaim2, node2 := test.NodeClaimAndNode(v1beta1.NodeClaim{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					v1beta1.NodePoolLabelKey:     nodePool.Name,
+					v1.LabelInstanceTypeStable:   mostExpensiveInstance.Name,
+					v1beta1.CapacityTypeLabelKey: mostExpensiveOffering.CapacityType,
+					v1.LabelTopologyZone:         mostExpensiveOffering.Zone,
+				},
+			},
+			Status: v1beta1.NodeClaimStatus{
+				ProviderID:  test.RandomProviderID(),
+				Allocatable: map[v1.ResourceName]resource.Quantity{v1.ResourceCPU: resource.MustParse("32")},
+			},
+		})
+		nodeClaim2.Status.Conditions = append(nodeClaim2.Status.Conditions, apis.Condition{
+			Type:               v1beta1.Expired,
+			Status:             v1.ConditionTrue,
+			LastTransitionTime: apis.VolatileTime{Inner: metav1.Time{Time: time.Now().Add(-time.Hour)}},
+		})
+
+		ExpectApplied(ctx, env.Client, rs, pods[0], pods[1], nodeClaim, nodeClaim2, node, node2, nodePool)
+
+		// bind pods to node so that they're not empty and don't disrupt in parallel.
+		ExpectManualBinding(ctx, env.Client, pods[0], node)
+		ExpectManualBinding(ctx, env.Client, pods[1], node2)
+
+		// inform cluster state about nodes and nodeclaims
+		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node, node2}, []*v1beta1.NodeClaim{nodeClaim, nodeClaim2})
+
+		// disruption won't delete the old node until the new node is ready
+		var wg sync.WaitGroup
+		ExpectTriggerVerifyAction(&wg)
+		ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
+		wg.Wait()
+
+		// Cascade any deletion of the nodeClaim to the node
+		ExpectNodeClaimsCascadeDeletion(ctx, env.Client, nodeClaim2)
+
+		// Expect that one of the expired nodeclaims is gone
+		Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(2))
+		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(2))
+		ExpectNotFound(ctx, env.Client, nodeClaim2, node2)
+		ExpectExists(ctx, env.Client, nodeClaim)
+		ExpectExists(ctx, env.Client, node)
+	})
+	It("can replace node for expiration", func() {
+		labels := map[string]string{
+			"app": "test",
+		}
+		// create our RS so we can link a pod to it
+		rs := test.ReplicaSet()
+		ExpectApplied(ctx, env.Client, rs)
+
+		pod := test.Pod(test.PodOptions{
+			ObjectMeta: metav1.ObjectMeta{Labels: labels,
+				OwnerReferences: []metav1.OwnerReference{
+					{
+						APIVersion:         "apps/v1",
+						Kind:               "ReplicaSet",
+						Name:               rs.Name,
+						UID:                rs.UID,
+						Controller:         ptr.Bool(true),
+						BlockOwnerDeletion: ptr.Bool(true),
+					},
+				},
+			},
+		})
+		ExpectApplied(ctx, env.Client, rs, pod, nodeClaim, node, nodePool)
+
+		// bind pods to node
+		ExpectManualBinding(ctx, env.Client, pod, node)
+
+		// inform cluster state about nodes and nodeclaims
+		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
+
+		// disruption won't delete the old node until the new node is ready
+		var wg sync.WaitGroup
+		ExpectTriggerVerifyAction(&wg)
+		ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
+		wg.Wait()
+
+		// Cascade any deletion of the nodeClaim to the node
+		ExpectNodeClaimsCascadeDeletion(ctx, env.Client, nodeClaim)
+
+		// Expect that the new nodeClaim was created, and it's different than the original
+		ExpectNotFound(ctx, env.Client, nodeClaim, node)
+		nodeclaims := ExpectNodeClaims(ctx, env.Client)
+		nodes := ExpectNodes(ctx, env.Client)
+		Expect(nodeclaims).To(HaveLen(1))
+		Expect(nodes).To(HaveLen(1))
+		Expect(nodeclaims[0].Name).ToNot(Equal(nodeClaim.Name))
+		Expect(nodes[0].Name).ToNot(Equal(node.Name))
+	})
+	It("should uncordon nodes when expiration replacement fails", func() {
+		cloudProvider.AllowedCreateCalls = 0 // fail the replacement and expect it to uncordon
+
 		labels := map[string]string{
 			"app": "test",
 		}
@@ -316,39 +418,29 @@ var _ = Describe("NodeClaim/Drift", func() {
 						Controller:         ptr.Bool(true),
 						BlockOwnerDeletion: ptr.Bool(true),
 					},
-				}}})
+				},
+			},
+		})
+		ExpectApplied(ctx, env.Client, rs, nodeClaim, node, nodePool, pod)
 
-		ExpectApplied(ctx, env.Client, rs, pod, nodeClaim, node, nodePool)
-
-		// bind the pods to the node
+		// bind pods to node
 		ExpectManualBinding(ctx, env.Client, pod, node)
 
 		// inform cluster state about nodes and nodeclaims
 		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
 
-		fakeClock.Step(10 * time.Minute)
-
-		// deprovisioning won't delete the old nodeClaim until the new nodeClaim is ready
 		var wg sync.WaitGroup
 		ExpectTriggerVerifyAction(&wg)
-		ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectNewNodeClaimsDeleted(ctx, env.Client, &wg, 1)
+		_, err := disruptionController.Reconcile(ctx, reconcile.Request{})
+		Expect(err).To(HaveOccurred())
 		wg.Wait()
 
-		// Cascade any deletion of the nodeClaim to the node
-		ExpectNodeClaimsCascadeDeletion(ctx, env.Client, nodeClaim)
-
-		ExpectNotFound(ctx, env.Client, nodeClaim, node)
-
-		// Expect that the new nodeClaim was created and its different than the original
-		nodeclaims := ExpectNodeClaims(ctx, env.Client)
-		nodes := ExpectNodes(ctx, env.Client)
-		Expect(nodeclaims).To(HaveLen(1))
-		Expect(nodes).To(HaveLen(1))
-		Expect(nodeclaims[0].Name).ToNot(Equal(nodeClaim.Name))
-		Expect(nodes[0].Name).ToNot(Equal(node.Name))
+		// We should have tried to create a new nodeClaim but failed to do so; therefore, we uncordoned the existing node
+		node = ExpectExists(ctx, env.Client, node)
+		Expect(node.Spec.Unschedulable).To(BeFalse())
 	})
-	It("can replace drifted nodes with multiple nodes", func() {
+	It("can replace node for expiration with multiple nodes", func() {
 		currentInstance := fake.NewInstanceType(fake.InstanceTypeOptions{
 			Name: "current-on-demand",
 			Offerings: []cloudprovider.Offering{
@@ -402,7 +494,6 @@ var _ = Describe("NodeClaim/Drift", func() {
 				Requests: map[v1.ResourceName]resource.Quantity{v1.ResourceCPU: resource.MustParse("2")},
 			},
 		})
-
 		nodeClaim.Labels = lo.Assign(nodeClaim.Labels, map[string]string{
 			v1.LabelInstanceTypeStable:   currentInstance.Name,
 			v1beta1.CapacityTypeLabelKey: currentInstance.Offerings[0].CapacityType,
@@ -418,7 +509,7 @@ var _ = Describe("NodeClaim/Drift", func() {
 
 		ExpectApplied(ctx, env.Client, rs, nodeClaim, node, nodePool, pods[0], pods[1], pods[2])
 
-		// bind the pods to the node
+		// bind pods to node
 		ExpectManualBinding(ctx, env.Client, pods[0], node)
 		ExpectManualBinding(ctx, env.Client, pods[1], node)
 		ExpectManualBinding(ctx, env.Client, pods[2], node)
@@ -426,94 +517,18 @@ var _ = Describe("NodeClaim/Drift", func() {
 		// inform cluster state about nodes and nodeclaims
 		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node}, []*v1beta1.NodeClaim{nodeClaim})
 
-		fakeClock.Step(10 * time.Minute)
-
-		// deprovisioning won't delete the old node until the new node is ready
+		// disruption won't delete the old nodeClaim until the new nodeClaim is ready
 		var wg sync.WaitGroup
 		ExpectTriggerVerifyAction(&wg)
 		ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 3)
-		ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 		wg.Wait()
 
 		// Cascade any deletion of the nodeClaim to the node
 		ExpectNodeClaimsCascadeDeletion(ctx, env.Client, nodeClaim)
 
-		// expect that drift provisioned three nodes, one for each pod
-		ExpectNotFound(ctx, env.Client, nodeClaim, node)
 		Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(3))
 		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(3))
-	})
-	It("should drift one non-empty node at a time, starting with the earliest drift", func() {
-		labels := map[string]string{
-			"app": "test",
-		}
-
-		// create our RS so we can link a pod to it
-		rs := test.ReplicaSet()
-		ExpectApplied(ctx, env.Client, rs)
-
-		pods := test.Pods(2, test.PodOptions{
-			ObjectMeta: metav1.ObjectMeta{Labels: labels,
-				OwnerReferences: []metav1.OwnerReference{
-					{
-						APIVersion:         "apps/v1",
-						Kind:               "ReplicaSet",
-						Name:               rs.Name,
-						UID:                rs.UID,
-						Controller:         ptr.Bool(true),
-						BlockOwnerDeletion: ptr.Bool(true),
-					},
-				},
-			},
-			// Make each pod request only fit on a single node
-			ResourceRequirements: v1.ResourceRequirements{
-				Requests: map[v1.ResourceName]resource.Quantity{v1.ResourceCPU: resource.MustParse("30")},
-			},
-		})
-
-		nodeClaim2, node2 := test.NodeClaimAndNode(v1beta1.NodeClaim{
-			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{
-					v1beta1.NodePoolLabelKey:     nodePool.Name,
-					v1.LabelInstanceTypeStable:   mostExpensiveInstance.Name,
-					v1beta1.CapacityTypeLabelKey: mostExpensiveOffering.CapacityType,
-					v1.LabelTopologyZone:         mostExpensiveOffering.Zone,
-				},
-			},
-			Status: v1beta1.NodeClaimStatus{
-				ProviderID:  test.RandomProviderID(),
-				Allocatable: map[v1.ResourceName]resource.Quantity{v1.ResourceCPU: resource.MustParse("32")},
-			},
-		})
-		nodeClaim2.Status.Conditions = append(nodeClaim2.Status.Conditions, apis.Condition{
-			Type:               v1beta1.Drifted,
-			Status:             v1.ConditionTrue,
-			LastTransitionTime: apis.VolatileTime{Inner: metav1.Time{Time: time.Now().Add(-time.Hour)}},
-		})
-
-		ExpectApplied(ctx, env.Client, rs, pods[0], pods[1], nodeClaim, node, nodeClaim2, node2, nodePool)
-
-		// bind pods to node so that they're not empty and don't deprovision in parallel.
-		ExpectManualBinding(ctx, env.Client, pods[0], node)
-		ExpectManualBinding(ctx, env.Client, pods[1], node2)
-
-		// inform cluster state about nodes and nodeclaims
-		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{node, node2}, []*v1beta1.NodeClaim{nodeClaim, nodeClaim2})
-
-		// deprovisioning won't delete the old node until the new node is ready
-		var wg sync.WaitGroup
-		ExpectTriggerVerifyAction(&wg)
-		ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
-		wg.Wait()
-
-		// Cascade any deletion of the nodeClaim to the node
-		ExpectNodeClaimsCascadeDeletion(ctx, env.Client, nodeClaim, nodeClaim2)
-
-		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(2))
-		Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(2))
-		ExpectNotFound(ctx, env.Client, nodeClaim2, node2)
-		ExpectExists(ctx, env.Client, nodeClaim)
-		ExpectExists(ctx, env.Client, node)
+		ExpectNotFound(ctx, env.Client, nodeClaim, node)
 	})
 })

--- a/pkg/controllers/disruption/pdblimits.go
+++ b/pkg/controllers/disruption/pdblimits.go
@@ -12,7 +12,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package deprovisioning
+package disruption
 
 import (
 	"context"

--- a/pkg/controllers/disruption/singlenodeconsolidation.go
+++ b/pkg/controllers/disruption/singlenodeconsolidation.go
@@ -27,6 +27,7 @@ import (
 	"github.com/aws/karpenter-core/pkg/controllers/provisioning"
 	"github.com/aws/karpenter-core/pkg/controllers/state"
 	"github.com/aws/karpenter-core/pkg/events"
+	"github.com/aws/karpenter-core/pkg/metrics"
 )
 
 const SingleNodeConsolidationTimeoutDuration = 3 * time.Minute
@@ -51,8 +52,11 @@ func (s *SingleNodeConsolidation) ComputeCommand(ctx context.Context, candidates
 	if err != nil {
 		return Command{}, fmt.Errorf("sorting candidates, %w", err)
 	}
-	deprovisioningEligibleMachinesGauge.WithLabelValues(s.String()).Set(float64(len(candidates)))
-	disruptionEligibleNodesGauge.WithLabelValues(s.String()).Set(float64(len(candidates)))
+	deprovisioningEligibleMachinesGauge.WithLabelValues(s.Type()).Set(float64(len(candidates)))
+	disruptionEligibleNodesGauge.With(map[string]string{
+		methodLabel:            s.Type(),
+		consolidationTypeLabel: s.ConsolidationType(),
+	}).Set(float64(len(candidates)))
 
 	v := NewValidation(consolidationTTL, s.clock, s.cluster, s.kubeClient, s.provisioner, s.cloudProvider, s.recorder)
 
@@ -62,7 +66,7 @@ func (s *SingleNodeConsolidation) ComputeCommand(ctx context.Context, candidates
 	for i, candidate := range candidates {
 		if s.clock.Now().After(timeout) {
 			deprovisioningConsolidationTimeoutsCounter.WithLabelValues(singleMachineConsolidationLabelValue).Inc()
-			deprovisioningConsolidationTimeoutsCounter.WithLabelValues(singleNodeConsolidationLabelValue).Inc()
+			deprovisioningConsolidationTimeoutsCounter.WithLabelValues(s.ConsolidationType()).Inc()
 			logging.FromContext(ctx).Debugf("abandoning single-node consolidation due to timeout after evaluating %d candidates", i)
 			return Command{}, nil
 		}
@@ -88,4 +92,12 @@ func (s *SingleNodeConsolidation) ComputeCommand(ctx context.Context, candidates
 	// couldn't remove any candidate
 	s.markConsolidated()
 	return Command{}, nil
+}
+
+func (s *SingleNodeConsolidation) Type() string {
+	return metrics.ConsolidationReason
+}
+
+func (s *SingleNodeConsolidation) ConsolidationType() string {
+	return "single"
 }

--- a/pkg/controllers/disruption/suite_test.go
+++ b/pkg/controllers/disruption/suite_test.go
@@ -1249,7 +1249,7 @@ var _ = Describe("Combined/Disruption", func() {
 		fakeClock.Step(10 * time.Minute)
 		wg := sync.WaitGroup{}
 		ExpectTriggerVerifyAction(&wg)
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
 		// Expect that the expired nodeclaim is not gone
 		Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))

--- a/pkg/controllers/disruption/suite_test.go
+++ b/pkg/controllers/disruption/suite_test.go
@@ -12,7 +12,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package deprovisioning_test
+package disruption_test
 
 import (
 	"context"
@@ -41,7 +41,7 @@ import (
 	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
 	"github.com/aws/karpenter-core/pkg/cloudprovider/fake"
-	"github.com/aws/karpenter-core/pkg/controllers/deprovisioning"
+	"github.com/aws/karpenter-core/pkg/controllers/disruption"
 	"github.com/aws/karpenter-core/pkg/controllers/provisioning"
 	"github.com/aws/karpenter-core/pkg/controllers/state"
 	"github.com/aws/karpenter-core/pkg/controllers/state/informer"
@@ -58,7 +58,7 @@ import (
 var ctx context.Context
 var env *test.Environment
 var cluster *state.Cluster
-var deprovisioningController *deprovisioning.Controller
+var disruptionController *disruption.Controller
 var prov *provisioning.Provisioner
 var cloudProvider *fake.CloudProvider
 var nodeStateController controller.Controller
@@ -88,7 +88,7 @@ var _ = BeforeSuite(func() {
 	nodeClaimStateController = informer.NewNodeClaimController(env.Client, cluster)
 	recorder = test.NewEventRecorder()
 	prov = provisioning.NewProvisioner(env.Client, env.KubernetesInterface.CoreV1(), recorder, cloudProvider, cluster)
-	deprovisioningController = deprovisioning.NewController(fakeClock, env.Client, prov, cloudProvider, recorder, cluster)
+	disruptionController = disruption.NewController(fakeClock, env.Client, prov, cloudProvider, recorder, cluster)
 })
 
 var _ = AfterSuite(func() {
@@ -217,7 +217,7 @@ var _ = Describe("Disruption Taints", func() {
 			replacementInstance,
 		}
 	})
-	It("should remove taints from NodeClaims that were left tainted from a previous deprovisioning action", func() {
+	It("should remove taints from NodeClaims that were left tainted from a previous disruption action", func() {
 		pod := test.Pod(test.PodOptions{
 			ResourceRequirements: v1.ResourceRequirements{
 				Requests: v1.ResourceList{
@@ -240,13 +240,13 @@ var _ = Describe("Disruption Taints", func() {
 		go func() {
 			defer wg.Done()
 			ExpectTriggerVerifyAction(&wg)
-			ExpectReconcileSucceeded(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileSucceeded(ctx, disruptionController, client.ObjectKey{})
 		}()
 		wg.Wait()
 		nodeClaimNode = ExpectNodeExists(ctx, env.Client, nodeClaimNode.Name)
 		Expect(nodeClaimNode.Spec.Taints).ToNot(ContainElement(v1beta1.DisruptionNoScheduleTaint))
 	})
-	It("should add and remove taints from NodeClaims that fail to deprovision", func() {
+	It("should add and remove taints from NodeClaims that fail to disrupt", func() {
 		nodePool.Spec.Disruption.ConsolidationPolicy = v1beta1.ConsolidationPolicyWhenUnderutilized
 		pod := test.Pod(test.PodOptions{
 			ResourceRequirements: v1.ResourceRequirements{
@@ -268,7 +268,7 @@ var _ = Describe("Disruption Taints", func() {
 		go func() {
 			defer wg.Done()
 			ExpectTriggerVerifyAction(&wg)
-			ExpectReconcileFailed(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileFailed(ctx, disruptionController, client.ObjectKey{})
 		}()
 
 		// Iterate in a loop until we get to the validation action
@@ -293,7 +293,7 @@ var _ = Describe("Disruption Taints", func() {
 		nodeClaimNode = ExpectNodeExists(ctx, env.Client, nodeClaimNode.Name)
 		Expect(nodeClaimNode.Spec.Taints).ToNot(ContainElement(v1beta1.DisruptionNoScheduleTaint))
 	})
-	It("should add and remove taints from Machines that fail to deprovision", func() {
+	It("should add and remove taints from Machines that fail to disrupt", func() {
 		provisioner.Spec.Consolidation = &v1alpha5.Consolidation{Enabled: lo.ToPtr(true)}
 		pod := test.Pod(test.PodOptions{
 			ResourceRequirements: v1.ResourceRequirements{
@@ -317,7 +317,7 @@ var _ = Describe("Disruption Taints", func() {
 		go func() {
 			defer wg.Done()
 			ExpectTriggerVerifyAction(&wg)
-			ExpectReconcileFailed(ctx, deprovisioningController, client.ObjectKey{})
+			ExpectReconcileFailed(ctx, disruptionController, client.ObjectKey{})
 		}()
 
 		// Iterate in a loop until we get to the validation action
@@ -343,7 +343,7 @@ var _ = Describe("Disruption Taints", func() {
 	})
 })
 
-var _ = Describe("Combined/Deprovisioning", func() {
+var _ = Describe("Combined/Disruption", func() {
 	var provisioner *v1alpha5.Provisioner
 	var machine *v1alpha5.Machine
 	var nodePool *v1beta1.NodePool
@@ -387,7 +387,7 @@ var _ = Describe("Combined/Deprovisioning", func() {
 			},
 		})
 	})
-	It("should deprovision all empty Machine and NodeClaims in parallel (Emptiness)", func() {
+	It("should disrupt all empty Machine and NodeClaims in parallel (Emptiness)", func() {
 		provisioner.Spec.TTLSecondsAfterEmpty = lo.ToPtr[int64](30)
 		nodePool.Spec.Disruption.ConsolidationPolicy = v1beta1.ConsolidationPolicyWhenEmpty
 		nodePool.Spec.Disruption.ConsolidateAfter = &v1beta1.NillableDuration{Duration: lo.ToPtr(time.Second * 30)}
@@ -403,7 +403,7 @@ var _ = Describe("Combined/Deprovisioning", func() {
 		fakeClock.Step(10 * time.Minute)
 		wg := sync.WaitGroup{}
 		ExpectTriggerVerifyAction(&wg)
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
 		// Cascade any deletion of the machine to the node
 		ExpectMachinesCascadeDeletion(ctx, env.Client, machine)
@@ -418,7 +418,7 @@ var _ = Describe("Combined/Deprovisioning", func() {
 		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(0))
 		ExpectNotFound(ctx, env.Client, machine, nodeClaim, machineNode, nodeClaimNode)
 	})
-	It("should deprovision all empty Machine and NodeClaims in parallel (Expiration)", func() {
+	It("should disrupt all empty Machine and NodeClaims in parallel (Expiration)", func() {
 		provisioner.Spec.TTLSecondsUntilExpired = lo.ToPtr[int64](30)
 		nodePool.Spec.Disruption.ExpireAfter = v1beta1.NillableDuration{Duration: lo.ToPtr(time.Second * 30)}
 		machine.StatusConditions().MarkTrue(v1alpha5.MachineExpired)
@@ -433,7 +433,7 @@ var _ = Describe("Combined/Deprovisioning", func() {
 		fakeClock.Step(10 * time.Minute)
 		wg := sync.WaitGroup{}
 		ExpectTriggerVerifyAction(&wg)
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
 		// Cascade any deletion of the machine to the node
 		ExpectMachinesCascadeDeletion(ctx, env.Client, machine)
@@ -448,7 +448,7 @@ var _ = Describe("Combined/Deprovisioning", func() {
 		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(0))
 		ExpectNotFound(ctx, env.Client, machine, nodeClaim, machineNode, nodeClaimNode)
 	})
-	It("should deprovision all empty Machine and NodeClaims in parallel (Drift)", func() {
+	It("should disrupt all empty Machine and NodeClaims in parallel (Drift)", func() {
 		machine.StatusConditions().MarkTrue(v1alpha5.MachineDrifted)
 		nodeClaim.StatusConditions().MarkTrue(v1beta1.Drifted)
 
@@ -462,7 +462,7 @@ var _ = Describe("Combined/Deprovisioning", func() {
 		fakeClock.Step(10 * time.Minute)
 		wg := sync.WaitGroup{}
 		ExpectTriggerVerifyAction(&wg)
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
 		// Cascade any deletion of the machine to the node
 		ExpectMachinesCascadeDeletion(ctx, env.Client, machine)
@@ -477,7 +477,7 @@ var _ = Describe("Combined/Deprovisioning", func() {
 		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(0))
 		ExpectNotFound(ctx, env.Client, machine, nodeClaim, machineNode, nodeClaimNode)
 	})
-	It("should deprovision all empty Machine and NodeClaims in parallel (Consolidation)", func() {
+	It("should disrupt all empty Machine and NodeClaims in parallel (Consolidation)", func() {
 		provisioner.Spec.Consolidation = &v1alpha5.Consolidation{Enabled: lo.ToPtr(true)}
 		nodePool.Spec.Disruption.ConsolidationPolicy = v1beta1.ConsolidationPolicyWhenUnderutilized
 		ExpectApplied(ctx, env.Client, provisioner, nodePool, machine, nodeClaim, machineNode, nodeClaimNode)
@@ -490,7 +490,7 @@ var _ = Describe("Combined/Deprovisioning", func() {
 		fakeClock.Step(10 * time.Minute)
 		wg := sync.WaitGroup{}
 		ExpectTriggerVerifyAction(&wg)
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
 		// Cascade any deletion of the machine to the node
 		ExpectMachinesCascadeDeletion(ctx, env.Client, machine)
@@ -505,7 +505,7 @@ var _ = Describe("Combined/Deprovisioning", func() {
 		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(0))
 		ExpectNotFound(ctx, env.Client, machine, nodeClaim, machineNode, nodeClaimNode)
 	})
-	It("should deprovision a Machine and replace with a cheaper NodeClaim", func() {
+	It("should disrupt a Machine and replace with a cheaper NodeClaim", func() {
 		provisioner.Spec.Consolidation = &v1alpha5.Consolidation{Enabled: lo.ToPtr(true)}
 		nodePool.Spec.Disruption.ConsolidationPolicy = v1beta1.ConsolidationPolicyWhenUnderutilized
 		currentInstance := fake.NewInstanceType(fake.InstanceTypeOptions{
@@ -592,7 +592,7 @@ var _ = Describe("Combined/Deprovisioning", func() {
 		wg := sync.WaitGroup{}
 		ExpectTriggerVerifyAction(&wg)
 		ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
 		// Cascade any deletion of the machine to the node
 		ExpectMachinesCascadeDeletion(ctx, env.Client, machine)
@@ -603,7 +603,7 @@ var _ = Describe("Combined/Deprovisioning", func() {
 		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
 		ExpectNotFound(ctx, env.Client, machine, machineNode)
 	})
-	It("should deprovision multiple Machines and replace with a single cheaper NodeClaim", func() {
+	It("should disrupt multiple Machines and replace with a single cheaper NodeClaim", func() {
 		provisioner.Spec.Consolidation = &v1alpha5.Consolidation{Enabled: lo.ToPtr(true)}
 		nodePool.Spec.Disruption.ConsolidationPolicy = v1beta1.ConsolidationPolicyWhenUnderutilized
 		currentInstance := fake.NewInstanceType(fake.InstanceTypeOptions{
@@ -706,7 +706,7 @@ var _ = Describe("Combined/Deprovisioning", func() {
 		wg := sync.WaitGroup{}
 		ExpectTriggerVerifyAction(&wg)
 		ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
 		// Cascade any deletion of the machines to the nodes
 		ExpectMachinesCascadeDeletion(ctx, env.Client, machines...)
@@ -719,7 +719,7 @@ var _ = Describe("Combined/Deprovisioning", func() {
 		ExpectNotFound(ctx, env.Client, lo.Map(machines, func(m *v1alpha5.Machine, _ int) client.Object { return m })...)
 		ExpectNotFound(ctx, env.Client, lo.Map(nodes, func(n *v1.Node, _ int) client.Object { return n })...)
 	})
-	It("should deprovision a NodeClaim and replace with a cheaper Machine", func() {
+	It("should disrupt a NodeClaim and replace with a cheaper Machine", func() {
 		provisioner.Spec.Consolidation = &v1alpha5.Consolidation{Enabled: lo.ToPtr(true)}
 		nodePool.Spec.Disruption.ConsolidationPolicy = v1beta1.ConsolidationPolicyWhenUnderutilized
 		currentInstance := fake.NewInstanceType(fake.InstanceTypeOptions{
@@ -806,7 +806,7 @@ var _ = Describe("Combined/Deprovisioning", func() {
 		wg := sync.WaitGroup{}
 		ExpectTriggerVerifyAction(&wg)
 		ExpectMakeNewMachinesReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
 		// Cascade any deletion of the nodeclaim to the node
 		ExpectNodeClaimsCascadeDeletion(ctx, env.Client, nodeClaim)
@@ -817,7 +817,7 @@ var _ = Describe("Combined/Deprovisioning", func() {
 		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
 		ExpectNotFound(ctx, env.Client, nodeClaim, nodeClaimNode)
 	})
-	It("should deprovision multiple NodeClaims and replace with a single cheaper Machine", func() {
+	It("should disrupt multiple NodeClaims and replace with a single cheaper Machine", func() {
 		provisioner.Spec.Consolidation = &v1alpha5.Consolidation{Enabled: lo.ToPtr(true)}
 		nodePool.Spec.Disruption.ConsolidationPolicy = v1beta1.ConsolidationPolicyWhenUnderutilized
 		currentInstance := fake.NewInstanceType(fake.InstanceTypeOptions{
@@ -920,7 +920,7 @@ var _ = Describe("Combined/Deprovisioning", func() {
 		wg := sync.WaitGroup{}
 		ExpectTriggerVerifyAction(&wg)
 		ExpectMakeNewMachinesReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
 		// Cascade any deletion of the nodeclaims to the nodes
 		ExpectNodeClaimsCascadeDeletion(ctx, env.Client, nodeClaims...)
@@ -933,7 +933,7 @@ var _ = Describe("Combined/Deprovisioning", func() {
 		ExpectNotFound(ctx, env.Client, lo.Map(nodeClaims, func(nc *v1beta1.NodeClaim, _ int) client.Object { return nc })...)
 		ExpectNotFound(ctx, env.Client, lo.Map(nodes, func(n *v1.Node, _ int) client.Object { return n })...)
 	})
-	It("should deprovision Machines and NodeClaims to consolidate pods onto a single NodeClaim", func() {
+	It("should disrupt Machines and NodeClaims to consolidate pods onto a single NodeClaim", func() {
 		provisioner.Spec.Consolidation = &v1alpha5.Consolidation{Enabled: lo.ToPtr(true)}
 		nodePool.Spec.Disruption.ConsolidationPolicy = v1beta1.ConsolidationPolicyWhenUnderutilized
 		currentInstance := fake.NewInstanceType(fake.InstanceTypeOptions{
@@ -1069,7 +1069,7 @@ var _ = Describe("Combined/Deprovisioning", func() {
 		wg := sync.WaitGroup{}
 		ExpectTriggerVerifyAction(&wg)
 		ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
 		// Cascade any deletion of the machines to the nodes
 		ExpectMachinesCascadeDeletion(ctx, env.Client, machines...)
@@ -1084,7 +1084,7 @@ var _ = Describe("Combined/Deprovisioning", func() {
 		ExpectNotFound(ctx, env.Client, lo.Map(nodeClaims, func(nc *v1beta1.NodeClaim, _ int) client.Object { return nc })...)
 		ExpectNotFound(ctx, env.Client, lo.Map(nodes, func(n *v1.Node, _ int) client.Object { return n })...)
 	})
-	It("should deprovision Machines and NodeClaims to consolidate pods onto a single Machine", func() {
+	It("should disrupt Machines and NodeClaims to consolidate pods onto a single Machine", func() {
 		provisioner.Spec.Consolidation = &v1alpha5.Consolidation{Enabled: lo.ToPtr(true)}
 		nodePool.Spec.Disruption.ConsolidationPolicy = v1beta1.ConsolidationPolicyWhenUnderutilized
 		currentInstance := fake.NewInstanceType(fake.InstanceTypeOptions{
@@ -1220,7 +1220,7 @@ var _ = Describe("Combined/Deprovisioning", func() {
 		wg := sync.WaitGroup{}
 		ExpectTriggerVerifyAction(&wg)
 		ExpectMakeNewMachinesReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
-		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 
 		// Cascade any deletion of the machines to the nodes
 		ExpectMachinesCascadeDeletion(ctx, env.Client, machines...)
@@ -1263,11 +1263,11 @@ var _ = Describe("Combined/Deprovisioning", func() {
 var _ = Describe("Pod Eviction Cost", func() {
 	const standardPodCost = 1.0
 	It("should have a standard disruptionCost for a pod with no priority or disruptionCost specified", func() {
-		cost := deprovisioning.GetPodEvictionCost(ctx, &v1.Pod{})
+		cost := disruption.GetPodEvictionCost(ctx, &v1.Pod{})
 		Expect(cost).To(BeNumerically("==", standardPodCost))
 	})
 	It("should have a higher disruptionCost for a pod with a positive deletion disruptionCost", func() {
-		cost := deprovisioning.GetPodEvictionCost(ctx, &v1.Pod{
+		cost := disruption.GetPodEvictionCost(ctx, &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
 				v1.PodDeletionCost: "100",
 			}},
@@ -1275,7 +1275,7 @@ var _ = Describe("Pod Eviction Cost", func() {
 		Expect(cost).To(BeNumerically(">", standardPodCost))
 	})
 	It("should have a lower disruptionCost for a pod with a positive deletion disruptionCost", func() {
-		cost := deprovisioning.GetPodEvictionCost(ctx, &v1.Pod{
+		cost := disruption.GetPodEvictionCost(ctx, &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
 				v1.PodDeletionCost: "-100",
 			}},
@@ -1283,17 +1283,17 @@ var _ = Describe("Pod Eviction Cost", func() {
 		Expect(cost).To(BeNumerically("<", standardPodCost))
 	})
 	It("should have higher costs for higher deletion costs", func() {
-		cost1 := deprovisioning.GetPodEvictionCost(ctx, &v1.Pod{
+		cost1 := disruption.GetPodEvictionCost(ctx, &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
 				v1.PodDeletionCost: "101",
 			}},
 		})
-		cost2 := deprovisioning.GetPodEvictionCost(ctx, &v1.Pod{
+		cost2 := disruption.GetPodEvictionCost(ctx, &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
 				v1.PodDeletionCost: "100",
 			}},
 		})
-		cost3 := deprovisioning.GetPodEvictionCost(ctx, &v1.Pod{
+		cost3 := disruption.GetPodEvictionCost(ctx, &v1.Pod{
 			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
 				v1.PodDeletionCost: "99",
 			}},
@@ -1302,13 +1302,13 @@ var _ = Describe("Pod Eviction Cost", func() {
 		Expect(cost2).To(BeNumerically(">", cost3))
 	})
 	It("should have a higher disruptionCost for a pod with a higher priority", func() {
-		cost := deprovisioning.GetPodEvictionCost(ctx, &v1.Pod{
+		cost := disruption.GetPodEvictionCost(ctx, &v1.Pod{
 			Spec: v1.PodSpec{Priority: ptr.Int32(1)},
 		})
 		Expect(cost).To(BeNumerically(">", standardPodCost))
 	})
 	It("should have a lower disruptionCost for a pod with a lower priority", func() {
-		cost := deprovisioning.GetPodEvictionCost(ctx, &v1.Pod{
+		cost := disruption.GetPodEvictionCost(ctx, &v1.Pod{
 			Spec: v1.PodSpec{Priority: ptr.Int32(-1)},
 		})
 		Expect(cost).To(BeNumerically("<", standardPodCost))

--- a/pkg/controllers/disruption/types.go
+++ b/pkg/controllers/disruption/types.go
@@ -38,7 +38,8 @@ import (
 type Method interface {
 	ShouldDisrupt(context.Context, *Candidate) bool
 	ComputeCommand(context.Context, ...*Candidate) (Command, error)
-	String() string
+	Type() string
+	ConsolidationType() string
 }
 
 type CandidateFilter func(context.Context, *Candidate) bool

--- a/pkg/controllers/disruption/types.go
+++ b/pkg/controllers/disruption/types.go
@@ -12,7 +12,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package deprovisioning
+package disruption
 
 import (
 	"bytes"
@@ -27,7 +27,7 @@ import (
 
 	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
-	deprovisioningevents "github.com/aws/karpenter-core/pkg/controllers/deprovisioning/events"
+	disruptionevents "github.com/aws/karpenter-core/pkg/controllers/disruption/events"
 	"github.com/aws/karpenter-core/pkg/controllers/provisioning/scheduling"
 	"github.com/aws/karpenter-core/pkg/controllers/state"
 	"github.com/aws/karpenter-core/pkg/events"
@@ -35,15 +35,15 @@ import (
 	nodepoolutil "github.com/aws/karpenter-core/pkg/utils/nodepool"
 )
 
-type Deprovisioner interface {
-	ShouldDeprovision(context.Context, *Candidate) bool
+type Method interface {
+	ShouldDisrupt(context.Context, *Candidate) bool
 	ComputeCommand(context.Context, ...*Candidate) (Command, error)
 	String() string
 }
 
 type CandidateFilter func(context.Context, *Candidate) bool
 
-// Candidate is a state.StateNode that we are considering for deprovisioning along with extra information to be used in
+// Candidate is a state.StateNode that we are considering for disruption along with extra information to be used in
 // making that determination
 type Candidate struct {
 	*state.StateNode
@@ -71,7 +71,7 @@ func NewCandidate(ctx context.Context, kubeClient client.Client, recorder events
 		return nil, fmt.Errorf("state node isn't initialized")
 	}
 	if _, ok := node.Annotations()[v1beta1.DoNotDisruptAnnotationKey]; ok {
-		recorder.Publish(deprovisioningevents.Blocked(node.Node, node.NodeClaim, fmt.Sprintf("Disruption is blocked with the %q annotation", v1beta1.DoNotDisruptAnnotationKey))...)
+		recorder.Publish(disruptionevents.Blocked(node.Node, node.NodeClaim, fmt.Sprintf("Disruption is blocked with the %q annotation", v1beta1.DoNotDisruptAnnotationKey))...)
 		return nil, fmt.Errorf("disruption is blocked through the %q annotation", v1beta1.DoNotDisruptAnnotationKey)
 	}
 	// check whether the node has all the labels we need
@@ -80,7 +80,7 @@ func NewCandidate(ctx context.Context, kubeClient client.Client, recorder events
 		v1.LabelTopologyZone,
 	} {
 		if _, ok := node.Labels()[label]; !ok {
-			recorder.Publish(deprovisioningevents.Blocked(node.Node, node.NodeClaim, fmt.Sprintf("Required label %q doesn't exist", label))...)
+			recorder.Publish(disruptionevents.Blocked(node.Node, node.NodeClaim, fmt.Sprintf("Required label %q doesn't exist", label))...)
 			return nil, fmt.Errorf("state node doesn't have required label %q", label)
 		}
 	}
@@ -92,18 +92,18 @@ func NewCandidate(ctx context.Context, kubeClient client.Client, recorder events
 	instanceTypeMap := nodePoolToInstanceTypesMap[ownerKey]
 	// skip any candidates where we can't determine the nodePool
 	if nodePool == nil || instanceTypeMap == nil {
-		recorder.Publish(deprovisioningevents.Blocked(node.Node, node.NodeClaim, fmt.Sprintf("Owning %s %q not found", lo.Ternary(ownerKey.IsProvisioner, "provisioner", "nodepool"), ownerKey.Name))...)
+		recorder.Publish(disruptionevents.Blocked(node.Node, node.NodeClaim, fmt.Sprintf("Owning %s %q not found", lo.Ternary(ownerKey.IsProvisioner, "provisioner", "nodepool"), ownerKey.Name))...)
 		return nil, fmt.Errorf("%s %q can't be resolved for state node", lo.Ternary(ownerKey.IsProvisioner, "provisioner", "nodepool"), ownerKey.Name)
 	}
 	instanceType := instanceTypeMap[node.Labels()[v1.LabelInstanceTypeStable]]
 	// skip any candidates that we can't determine the instance of
 	if instanceType == nil {
-		recorder.Publish(deprovisioningevents.Blocked(node.Node, node.NodeClaim, fmt.Sprintf("Instance type %q not found", node.Labels()[v1.LabelInstanceTypeStable]))...)
+		recorder.Publish(disruptionevents.Blocked(node.Node, node.NodeClaim, fmt.Sprintf("Instance type %q not found", node.Labels()[v1.LabelInstanceTypeStable]))...)
 		return nil, fmt.Errorf("instance type '%s' can't be resolved", node.Labels()[v1.LabelInstanceTypeStable])
 	}
 	// skip the node if it is nominated by a recent provisioning pass to be the target of a pending pod.
 	if node.Nominated() {
-		recorder.Publish(deprovisioningevents.Blocked(node.Node, node.NodeClaim, "Nominated for a pending pod")...)
+		recorder.Publish(disruptionevents.Blocked(node.Node, node.NodeClaim, "Nominated for a pending pod")...)
 		return nil, fmt.Errorf("state node is nominated for a pending pod")
 	}
 	pods, err := node.Pods(ctx, kubeClient)

--- a/pkg/controllers/disruption/validation.go
+++ b/pkg/controllers/disruption/validation.go
@@ -12,7 +12,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package deprovisioning
+package disruption
 
 import (
 	"context"
@@ -73,7 +73,7 @@ func (v *Validation) IsValid(ctx context.Context, cmd Command) (bool, error) {
 		case <-v.clock.After(waitDuration):
 		}
 	}
-	validationCandidates, err := GetCandidates(ctx, v.cluster, v.kubeClient, v.recorder, v.clock, v.cloudProvider, v.ShouldDeprovision)
+	validationCandidates, err := GetCandidates(ctx, v.cluster, v.kubeClient, v.recorder, v.clock, v.cloudProvider, v.ShouldDisrupt)
 	if err != nil {
 		return false, fmt.Errorf("constructing validation candidates, %w", err)
 	}
@@ -102,15 +102,15 @@ func (v *Validation) IsValid(ctx context.Context, cmd Command) (bool, error) {
 	return isValid, nil
 }
 
-// ShouldDeprovision is a predicate used to filter deprovisionable candidates
-func (v *Validation) ShouldDeprovision(_ context.Context, c *Candidate) bool {
+// ShouldDisrupt is a predicate used to filter candidates
+func (v *Validation) ShouldDisrupt(_ context.Context, c *Candidate) bool {
 	if c.Annotations()[v1alpha5.DoNotConsolidateNodeAnnotationKey] == "true" {
 		return false
 	}
 	return c.nodePool.Spec.Disruption.ConsolidationPolicy == v1beta1.ConsolidationPolicyWhenUnderutilized
 }
 
-// ValidateCommand validates a command for a deprovisioner
+// ValidateCommand validates a command for a Method
 func (v *Validation) ValidateCommand(ctx context.Context, cmd Command, candidates []*Candidate) (bool, error) {
 	// None of the chosen candidate are valid for execution, so retry
 	if len(candidates) == 0 {

--- a/pkg/controllers/nodeclaim/consistency/termination.go
+++ b/pkg/controllers/nodeclaim/consistency/termination.go
@@ -22,7 +22,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
-	"github.com/aws/karpenter-core/pkg/controllers/deprovisioning"
+	"github.com/aws/karpenter-core/pkg/controllers/disruption"
 	nodeutils "github.com/aws/karpenter-core/pkg/utils/node"
 )
 
@@ -42,7 +42,7 @@ func (t *Termination) Check(ctx context.Context, node *v1.Node, nodeClaim *v1bet
 	if nodeClaim.DeletionTimestamp.IsZero() {
 		return nil, nil
 	}
-	pdbs, err := deprovisioning.NewPDBLimits(ctx, t.kubeClient)
+	pdbs, err := disruption.NewPDBLimits(ctx, t.kubeClient)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR changes the name of the deprovisioning controller to the disruption controller to match the `spec.disruption` block in the NodePool and aligns metrics with this naming convention:

1. `disruption_evaluation_duration_seconds`
2. `disruption_replacement_nodeclaim_initialized_seconds`
3. `disruption_replacement_nodeclaim_failures_total`
4. `disruption_actions_performed_total`
5. `disruption_eligible_nodes`
6. `disruption_consolidation_timeouts_total`

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
