### PR TITLE
chore: Ensure controller-runtime logger is configured

### DIFF
--- a/pkg/operator/logging/logging.go
+++ b/pkg/operator/logging/logging.go
@@ -39,6 +39,8 @@ import (
 	"knative.dev/pkg/logging/logkey"
 	"knative.dev/pkg/system"
 
+	ctrl "sigs.k8s.io/controller-runtime/pkg/log"
+
 	"github.com/aws/karpenter-core/pkg/operator/injection"
 	"github.com/aws/karpenter-core/pkg/operator/options"
 )
@@ -181,6 +183,7 @@ func loggerFromConfigMap(ctx context.Context, component string, kubernetesInterf
 // to use the configured *zap.SugaredLogger from the context
 func ConfigureGlobalLoggers(ctx context.Context) {
 	klog.SetLogger(zapr.NewLogger(logging.FromContext(ctx).Desugar()))
+	ctrl.SetLogger(zapr.NewLogger(logging.FromContext(ctx).Desugar()))
 	w := &zapio.Writer{Log: logging.FromContext(ctx).Desugar(), Level: zap.DebugLevel}
 	log.SetFlags(0)
 	log.SetOutput(w)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR ensures that the controller-runtime logger is configured so that logs properly appear from controller runtime

### Before PR

```console
        {"commit": "be86a6f-dirty"}
[controller-runtime] log.SetLogger(...) was never called; logs will not be displayed.
Detected at:
        >  goroutine 2291 [running]:
        >  runtime/debug.Stack()
        >       runtime/debug/stack.go:24 +0x5e
        >  sigs.k8s.io/controller-runtime/pkg/log.eventuallyFulfillRoot()
        >       sigs.k8s.io/controller-runtime@v0.16.2/pkg/log/log.go:60 +0xcd
        >  sigs.k8s.io/controller-runtime/pkg/log.(*delegatingLogSink).Enabled(0xc0002bd400, 0x10?)
        >       sigs.k8s.io/controller-runtime@v0.16.2/pkg/log/deleg.go:111 +0x32
        >  github.com/go-logr/logr.Logger.Enabled(...)
        >       github.com/go-logr/logr@v1.2.4/logr.go:261
        >  github.com/go-logr/logr.Logger.Info({{0x3072510?, 0xc0002bd400?}, 0x2a369a6?}, {0x2a53e4d, 0x14}, {0xc00ea09280, 0x4, 0x4})
        >       github.com/go-logr/logr@v1.2.4/logr.go:274 +0x72
        >  sigs.k8s.io/controller-runtime/pkg/healthz.(*Handler).serveAggregated(0xc0006f0818, {0x305eca0, 0xc00127ea80}, 0xc001140400)
        >       sigs.k8s.io/controller-runtime@v0.16.2/pkg/healthz/healthz.go:60 +0x3d1
        >  sigs.k8s.io/controller-runtime/pkg/healthz.(*Handler).ServeHTTP(0xc0006f0818, {0x305eca0, 0xc00127ea80}, 0xc001140400)
        >       sigs.k8s.io/controller-runtime@v0.16.2/pkg/healthz/healthz.go:148 +0x8a
        >  sigs.k8s.io/controller-runtime/pkg/manager.(*controllerManager).addHealthProbeServer.StripPrefix.func1({0x305eca0, 0xc00127ea80}, 0xc001140300)
        >       net/http/server.go:2179 +0x262
        >  net/http.HandlerFunc.ServeHTTP(0x446500?, {0x305eca0?, 0xc00127ea80?}, 0x6e3f1a?)
        >       net/http/server.go:2136 +0x29
        >  net/http.(*ServeMux).ServeHTTP(0x4771340?, {0x305eca0, 0xc00127ea80}, 0xc001140300)
        >       net/http/server.go:2514 +0x142
        >  net/http.serverHandler.ServeHTTP({0xc0069f1740?}, {0x305eca0?, 0xc00127ea80?}, 0x6?)
        >       net/http/server.go:2938 +0x8e
        >  net/http.(*conn).serve(0xc00580e120, {0x306d240, 0xc000d76ed0})
        >       net/http/server.go:2009 +0x5f4
        >  created by net/http.(*Server).Serve in goroutine 304
        >       net/http/server.go:3086 +0x5cb
```

### After PR

```console
2023-10-13T07:03:54.435Z        DEBUG   controller.controller-runtime.healthz   healthz check failed    {"commit": "be86a6f-dirty", "checker": "manager", "error": "failed to sync caches"}
2023-10-13T07:03:54.435Z        INFO    controller.controller-runtime.healthz   healthz check failed    {"commit": "be86a6f-dirty", "statuses": [{},{},{}]}
2023-10-13T07:03:56.607Z        INFO    controller      k8s.io/client-go@v0.28.2/tools/cache/reflector.go:229: failed to list *v1beta1.NodePool: nodepools.karpenter.sh is forbidden: User "system:serviceaccount:karpenter:karpenter" cannot list resource "nodepools" in API group "karpenter.sh" at the cluster scope
        {"commit": "be86a6f-dirty"}
2023-10-13T07:03:56.607Z        ERROR   controller      k8s.io/client-go@v0.28.2/tools/cache/reflector.go:229: Failed to watch *v1beta1.NodePool: failed to list *v1beta1.NodePool: nodepools.karpenter.sh is forbidden: User "system:serviceaccount:karpenter:karpenter" cannot list resource "nodepools" in API group "karpenter.sh" at the cluster scope
```

**How was this change tested?**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
