### PR TITLE
fix: Handle NodeClaims existing but being unknown in earlier versions

### DIFF
--- a/pkg/controllers/deprovisioning/suite_test.go
+++ b/pkg/controllers/deprovisioning/suite_test.go
@@ -51,6 +51,8 @@ import (
 	"github.com/aws/karpenter-core/pkg/scheduling"
 	"github.com/aws/karpenter-core/pkg/test"
 	. "github.com/aws/karpenter-core/pkg/test/expectations"
+	nodeclaimutil "github.com/aws/karpenter-core/pkg/utils/nodeclaim"
+	nodepoolutil "github.com/aws/karpenter-core/pkg/utils/nodepool"
 )
 
 var ctx context.Context
@@ -124,6 +126,9 @@ var _ = BeforeEach(func() {
 	})
 	leastExpensiveInstance, mostExpensiveInstance = onDemandInstances[0], onDemandInstances[len(onDemandInstances)-1]
 	leastExpensiveOffering, mostExpensiveOffering = leastExpensiveInstance.Offerings[0], mostExpensiveInstance.Offerings[0]
+
+	nodepoolutil.EnableNodePools = true
+	nodeclaimutil.EnableNodeClaims = true
 })
 
 var _ = AfterEach(func() {
@@ -1229,6 +1234,29 @@ var _ = Describe("Combined/Deprovisioning", func() {
 		ExpectNotFound(ctx, env.Client, lo.Map(machines, func(m *v1alpha5.Machine, _ int) client.Object { return m })...)
 		ExpectNotFound(ctx, env.Client, lo.Map(nodeClaims, func(nc *v1beta1.NodeClaim, _ int) client.Object { return nc })...)
 		ExpectNotFound(ctx, env.Client, lo.Map(nodes, func(n *v1.Node, _ int) client.Object { return n })...)
+	})
+	It("shouldn't consider a NodeClaim as a candidate if EnableNodePools/EnableNodeClaims isn't enabled", func() {
+		nodepoolutil.EnableNodePools = false
+		nodeclaimutil.EnableNodeClaims = false
+
+		nodePool.Spec.Disruption.ExpireAfter = v1beta1.NillableDuration{Duration: lo.ToPtr(time.Second * 30)}
+		nodeClaim.StatusConditions().MarkTrue(v1beta1.Expired)
+		ExpectApplied(ctx, env.Client, nodePool, nodeClaim, nodeClaimNode)
+
+		// inform cluster state about nodes and nodeclaims
+		ExpectMakeNodesAndNodeClaimsInitializedAndStateUpdated(ctx, env.Client, nodeStateController, nodeClaimStateController, []*v1.Node{nodeClaimNode}, []*v1beta1.NodeClaim{nodeClaim})
+
+		fakeClock.Step(10 * time.Minute)
+		wg := sync.WaitGroup{}
+		ExpectTriggerVerifyAction(&wg)
+		ExpectReconcileSucceeded(ctx, deprovisioningController, types.NamespacedName{})
+
+		// Expect that the expired nodeclaim is not gone
+		Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))
+
+		Expect(ExpectNodes(ctx, env.Client)).To(HaveLen(1))
+		ExpectExists(ctx, env.Client, nodeClaim)
+		ExpectExists(ctx, env.Client, nodeClaimNode)
 	})
 })
 

--- a/pkg/controllers/state/cluster.go
+++ b/pkg/controllers/state/cluster.go
@@ -41,6 +41,7 @@ import (
 	"github.com/aws/karpenter-core/pkg/cloudprovider"
 	"github.com/aws/karpenter-core/pkg/scheduling"
 	nodeclaimutil "github.com/aws/karpenter-core/pkg/utils/nodeclaim"
+	nodepoolutil "github.com/aws/karpenter-core/pkg/utils/nodepool"
 	podutils "github.com/aws/karpenter-core/pkg/utils/pod"
 )
 
@@ -266,7 +267,7 @@ func (c *Cluster) UpdateNode(ctx context.Context, node *v1.Node) error {
 
 	if node.Spec.ProviderID == "" {
 		// If we know that we own this node, we shouldn't allow the providerID to be empty
-		if node.Labels[v1alpha5.ProvisionerNameLabelKey] != "" || node.Labels[v1beta1.NodePoolLabelKey] != "" {
+		if node.Labels[v1alpha5.ProvisionerNameLabelKey] != "" || (node.Labels[v1beta1.NodePoolLabelKey] != "" && nodepoolutil.EnableNodePools) {
 			return nil
 		}
 		node.Spec.ProviderID = node.Name
@@ -509,7 +510,7 @@ func (c *Cluster) populateInflight(ctx context.Context, n *StateNode) error {
 	if n.inflightInitialized {
 		return nil
 	}
-	// If the node ies already initialized, we don't need to populate its inflight capacity
+	// If the node is already initialized, we don't need to populate its inflight capacity
 	// since its capacity is already represented by the node status
 	if n.Initialized() {
 		return nil

--- a/pkg/controllers/state/statenode.go
+++ b/pkg/controllers/state/statenode.go
@@ -116,7 +116,7 @@ func NewNode() *StateNode {
 }
 
 func (in *StateNode) OwnerKey() nodepoolutil.Key {
-	if in.Labels()[v1beta1.NodePoolLabelKey] != "" {
+	if in.Labels()[v1beta1.NodePoolLabelKey] != "" && nodepoolutil.EnableNodePools {
 		return nodepoolutil.Key{Name: in.Labels()[v1beta1.NodePoolLabelKey], IsProvisioner: false}
 	}
 	if in.Labels()[v1alpha5.ProvisionerNameLabelKey] != "" {
@@ -362,7 +362,7 @@ func (in *StateNode) Nominated() bool {
 func (in *StateNode) Managed() bool {
 	return in.NodeClaim != nil ||
 		(in.Node != nil && in.Node.Labels[v1alpha5.ProvisionerNameLabelKey] != "") ||
-		(in.Node != nil && in.Node.Labels[v1beta1.NodePoolLabelKey] != "")
+		(in.Node != nil && in.Node.Labels[v1beta1.NodePoolLabelKey] != "" && nodepoolutil.EnableNodePools)
 }
 
 func (in *StateNode) updateForPod(ctx context.Context, kubeClient client.Client, pod *v1.Pod) error {

--- a/pkg/utils/nodeclaim/nodeclaim.go
+++ b/pkg/utils/nodeclaim/nodeclaim.go
@@ -474,7 +474,7 @@ func UpdateNodeOwnerReferences(nodeClaim *v1beta1.NodeClaim, node *v1.Node) *v1.
 }
 
 func Owner(ctx context.Context, c client.Client, obj interface{ GetLabels() map[string]string }) (*v1beta1.NodePool, error) {
-	if v, ok := obj.GetLabels()[v1beta1.NodePoolLabelKey]; ok {
+	if v, ok := obj.GetLabels()[v1beta1.NodePoolLabelKey]; ok && EnableNodeClaims {
 		nodePool := &v1beta1.NodePool{}
 		if err := c.Get(ctx, types.NamespacedName{Name: v}, nodePool); err != nil {
 			return nil, err
@@ -492,7 +492,7 @@ func Owner(ctx context.Context, c client.Client, obj interface{ GetLabels() map[
 }
 
 func OwnerKey(obj interface{ GetLabels() map[string]string }) nodepoolutil.Key {
-	if v, ok := obj.GetLabels()[v1beta1.NodePoolLabelKey]; ok {
+	if v, ok := obj.GetLabels()[v1beta1.NodePoolLabelKey]; ok && EnableNodeClaims {
 		return nodepoolutil.Key{Name: v, IsProvisioner: false}
 	}
 	if v, ok := obj.GetLabels()[v1alpha5.ProvisionerNameLabelKey]; ok {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR makes a change so that reconciliations do not fail if you create some NodePools and NodeClaims with v1beta1 and then choose to rollback to an earlier version of Karpenter where these concepts are not understood.

**How was this change tested?**

`make presubmit`
`make apply`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
