### PR TITLE
chore: Fix a couple misses where the entire disruption method was printed

### DIFF
--- a/pkg/controllers/disruption/controller.go
+++ b/pkg/controllers/disruption/controller.go
@@ -181,7 +181,7 @@ func (c *Controller) disrupt(ctx context.Context, disruption Method) (bool, erro
 
 func (c *Controller) executeCommand(ctx context.Context, m Method, cmd Command) error {
 	deprovisioningActionsPerformedCounter.With(map[string]string{
-		actionLabel:        fmt.Sprintf("%s/%s", m, cmd.Action()),
+		actionLabel:        fmt.Sprintf("%s/%s", m.Type(), cmd.Action()),
 		deprovisionerLabel: m.Type(),
 	}).Inc()
 	disruptionActionsPerformedCounter.With(map[string]string{
@@ -189,7 +189,7 @@ func (c *Controller) executeCommand(ctx context.Context, m Method, cmd Command) 
 		methodLabel:            m.Type(),
 		consolidationTypeLabel: m.ConsolidationType(),
 	}).Inc()
-	logging.FromContext(ctx).Infof("disrupting via %s %s", m, cmd)
+	logging.FromContext(ctx).Infof("disrupting via %s %s", m.Type(), cmd)
 
 	reason := fmt.Sprintf("%s/%s", m.Type(), cmd.Action())
 	if cmd.Action() == ReplaceAction {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR fixes a couple of places in the disruption code where the entire method struct was printed out rather than just the type of the method

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
