### PR TITLE
fix: add in v1beta1 termination metrics label

### DIFF
--- a/pkg/controllers/node/termination/controller.go
+++ b/pkg/controllers/node/termination/controller.go
@@ -148,7 +148,7 @@ func (c *Controller) removeFinalizer(ctx context.Context, n *v1.Node) error {
 		// We use stored.DeletionTimestamp since the api-server may give back a node after the patch without a deletionTimestamp
 		TerminationSummary.With(prometheus.Labels{
 			metrics.ProvisionerLabel: n.Labels[v1alpha5.ProvisionerNameLabelKey],
-			metrics.NodePoolLabel: n.Labels[v1beta1.NodePoolLabelKey],
+			metrics.NodePoolLabel:    n.Labels[v1beta1.NodePoolLabelKey],
 		}).Observe(time.Since(stored.DeletionTimestamp.Time).Seconds())
 		logging.FromContext(ctx).Infof("deleted node")
 	}

--- a/pkg/controllers/node/termination/controller.go
+++ b/pkg/controllers/node/termination/controller.go
@@ -148,6 +148,7 @@ func (c *Controller) removeFinalizer(ctx context.Context, n *v1.Node) error {
 		// We use stored.DeletionTimestamp since the api-server may give back a node after the patch without a deletionTimestamp
 		TerminationSummary.With(prometheus.Labels{
 			metrics.ProvisionerLabel: n.Labels[v1alpha5.ProvisionerNameLabelKey],
+			metrics.NodePoolLabel: n.Labels[v1beta1.NodePoolLabelKey],
 		}).Observe(time.Since(stored.DeletionTimestamp.Time).Seconds())
 		logging.FromContext(ctx).Infof("deleted node")
 	}

--- a/pkg/controllers/node/termination/metrics.go
+++ b/pkg/controllers/node/termination/metrics.go
@@ -30,7 +30,7 @@ var (
 			Help:       "The time taken between a node's deletion request and the removal of its finalizer",
 			Objectives: metrics.SummaryObjectives(),
 		},
-		[]string{metrics.ProvisionerLabel},
+		[]string{metrics.ProvisionerLabel, metrics.NodePoolLabel},
 	)
 )
 


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
Adds in the node pool name label key into the termination metric that was left out of the previous metrics migration PRs.

**How was this change tested?**
- make presubmit

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
