### PR TITLE
test: Handling concurrency for disruption controller tests

### DIFF
--- a/pkg/controllers/disruption/machine_consolidation_test.go
+++ b/pkg/controllers/disruption/machine_consolidation_test.go
@@ -126,6 +126,7 @@ var _ = Describe("Machine/Consolidation", func() {
 			wg := sync.WaitGroup{}
 			ExpectTriggerVerifyAction(&wg)
 			ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
+			wg.Wait()
 
 			// Cascade any deletion of the machine to the node
 			ExpectMachinesCascadeDeletion(ctx, env.Client, machine1, machine2)

--- a/pkg/controllers/disruption/machine_emptiness_test.go
+++ b/pkg/controllers/disruption/machine_emptiness_test.go
@@ -72,6 +72,7 @@ var _ = Describe("Machine/Emptiness", func() {
 		wg := sync.WaitGroup{}
 		ExpectTriggerVerifyAction(&wg)
 		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
+		wg.Wait()
 
 		// Cascade any deletion of the machine to the node
 		ExpectMachinesCascadeDeletion(ctx, env.Client, machine)

--- a/pkg/controllers/disruption/nodeclaim_consolidation_test.go
+++ b/pkg/controllers/disruption/nodeclaim_consolidation_test.go
@@ -128,6 +128,7 @@ var _ = Describe("NodeClaim/Consolidation", func() {
 			wg := sync.WaitGroup{}
 			ExpectTriggerVerifyAction(&wg)
 			ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
+			wg.Wait()
 
 			// Cascade any deletion of the nodeclaim to the node
 			ExpectNodeClaimsCascadeDeletion(ctx, env.Client, nodeClaim, nodeClaim2)

--- a/pkg/controllers/disruption/nodeclaim_emptiness_test.go
+++ b/pkg/controllers/disruption/nodeclaim_emptiness_test.go
@@ -77,6 +77,7 @@ var _ = Describe("NodeClaim/Emptiness", func() {
 		wg := sync.WaitGroup{}
 		ExpectTriggerVerifyAction(&wg)
 		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
+		wg.Wait()
 
 		// Cascade any deletion of the nodeClaim to the node
 		ExpectNodeClaimsCascadeDeletion(ctx, env.Client, nodeClaim)

--- a/pkg/controllers/disruption/suite_test.go
+++ b/pkg/controllers/disruption/suite_test.go
@@ -1232,7 +1232,6 @@ var _ = Describe("Combined/Disruption", func() {
 		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
 		wg.Wait()
 
-
 		// Cascade any deletion of the machines to the nodes
 		ExpectMachinesCascadeDeletion(ctx, env.Client, machines...)
 		ExpectNodeClaimsCascadeDeletion(ctx, env.Client, nodeClaims...)

--- a/pkg/controllers/disruption/suite_test.go
+++ b/pkg/controllers/disruption/suite_test.go
@@ -404,6 +404,7 @@ var _ = Describe("Combined/Disruption", func() {
 		wg := sync.WaitGroup{}
 		ExpectTriggerVerifyAction(&wg)
 		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
+		wg.Wait()
 
 		// Cascade any deletion of the machine to the node
 		ExpectMachinesCascadeDeletion(ctx, env.Client, machine)
@@ -434,6 +435,7 @@ var _ = Describe("Combined/Disruption", func() {
 		wg := sync.WaitGroup{}
 		ExpectTriggerVerifyAction(&wg)
 		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
+		wg.Wait()
 
 		// Cascade any deletion of the machine to the node
 		ExpectMachinesCascadeDeletion(ctx, env.Client, machine)
@@ -463,6 +465,7 @@ var _ = Describe("Combined/Disruption", func() {
 		wg := sync.WaitGroup{}
 		ExpectTriggerVerifyAction(&wg)
 		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
+		wg.Wait()
 
 		// Cascade any deletion of the machine to the node
 		ExpectMachinesCascadeDeletion(ctx, env.Client, machine)
@@ -491,6 +494,7 @@ var _ = Describe("Combined/Disruption", func() {
 		wg := sync.WaitGroup{}
 		ExpectTriggerVerifyAction(&wg)
 		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
+		wg.Wait()
 
 		// Cascade any deletion of the machine to the node
 		ExpectMachinesCascadeDeletion(ctx, env.Client, machine)
@@ -593,6 +597,7 @@ var _ = Describe("Combined/Disruption", func() {
 		ExpectTriggerVerifyAction(&wg)
 		ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
 		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
+		wg.Wait()
 
 		// Cascade any deletion of the machine to the node
 		ExpectMachinesCascadeDeletion(ctx, env.Client, machine)
@@ -707,6 +712,7 @@ var _ = Describe("Combined/Disruption", func() {
 		ExpectTriggerVerifyAction(&wg)
 		ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
 		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
+		wg.Wait()
 
 		// Cascade any deletion of the machines to the nodes
 		ExpectMachinesCascadeDeletion(ctx, env.Client, machines...)
@@ -807,6 +813,7 @@ var _ = Describe("Combined/Disruption", func() {
 		ExpectTriggerVerifyAction(&wg)
 		ExpectMakeNewMachinesReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
 		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
+		wg.Wait()
 
 		// Cascade any deletion of the nodeclaim to the node
 		ExpectNodeClaimsCascadeDeletion(ctx, env.Client, nodeClaim)
@@ -921,6 +928,7 @@ var _ = Describe("Combined/Disruption", func() {
 		ExpectTriggerVerifyAction(&wg)
 		ExpectMakeNewMachinesReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
 		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
+		wg.Wait()
 
 		// Cascade any deletion of the nodeclaims to the nodes
 		ExpectNodeClaimsCascadeDeletion(ctx, env.Client, nodeClaims...)
@@ -1070,6 +1078,7 @@ var _ = Describe("Combined/Disruption", func() {
 		ExpectTriggerVerifyAction(&wg)
 		ExpectMakeNewNodeClaimsReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
 		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
+		wg.Wait()
 
 		// Cascade any deletion of the machines to the nodes
 		ExpectMachinesCascadeDeletion(ctx, env.Client, machines...)
@@ -1221,6 +1230,8 @@ var _ = Describe("Combined/Disruption", func() {
 		ExpectTriggerVerifyAction(&wg)
 		ExpectMakeNewMachinesReady(ctx, env.Client, &wg, cluster, cloudProvider, 1)
 		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
+		wg.Wait()
+
 
 		// Cascade any deletion of the machines to the nodes
 		ExpectMachinesCascadeDeletion(ctx, env.Client, machines...)
@@ -1250,6 +1261,7 @@ var _ = Describe("Combined/Disruption", func() {
 		wg := sync.WaitGroup{}
 		ExpectTriggerVerifyAction(&wg)
 		ExpectReconcileSucceeded(ctx, disruptionController, types.NamespacedName{})
+		wg.Wait()
 
 		// Expect that the expired nodeclaim is not gone
 		Expect(ExpectNodeClaims(ctx, env.Client)).To(HaveLen(1))


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Some parts of the test were missing mistakenly ```wg.wait()```  after adding ```wg.add()``` this might not be the case we want in terms of concurrency.
This pr attempts to fix that

**How was this change tested?**

```make presubmit```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
