### PR TITLE
chore: always inject settings

### DIFF
--- a/pkg/apis/settings/settings.go
+++ b/pkg/apis/settings/settings.go
@@ -49,6 +49,10 @@ func (*Settings) ConfigMap() string {
 // Inject creates a Settings from the supplied ConfigMap
 func (*Settings) Inject(ctx context.Context, cm *v1.ConfigMap) (context.Context, error) {
 	s := defaultSettings.DeepCopy()
+	if cm == nil {
+		return ToContext(ctx, s), nil
+	}
+
 	if err := configmap.Parse(cm.Data,
 		configmap.AsDuration("batchMaxDuration", &s.BatchMaxDuration),
 		configmap.AsDuration("batchIdleDuration", &s.BatchIdleDuration),
@@ -79,7 +83,7 @@ func ToContext(ctx context.Context, s *Settings) context.Context {
 func FromContext(ctx context.Context) *Settings {
 	data := ctx.Value(ContextKey)
 	if data == nil {
-		return nil
+		panic("settings not in context")
 	}
 	return data.(*Settings)
 }

--- a/pkg/operator/injection/injection.go
+++ b/pkg/operator/injection/injection.go
@@ -79,13 +79,9 @@ func WithSettingsOrDie(ctx context.Context, kubernetesInterface kubernetes.Inter
 
 	for _, setting := range settings {
 		cm, err := WaitForConfigMap(ctx, setting.ConfigMap(), informer)
-		if err != nil {
-			if !errors.IsNotFound(err) {
-				panic(fmt.Errorf("failed to get configmap %s, %w", setting.ConfigMap(), err))
-			}
-			continue
+		if err != nil && !errors.IsNotFound(err) {
+			panic(fmt.Errorf("failed to get configmap %s, %w", setting.ConfigMap(), err))
 		}
-
 		ctx = lo.Must(setting.Inject(ctx, cm))
 	}
 	return ctx

--- a/pkg/operator/injection/injection.go
+++ b/pkg/operator/injection/injection.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 	"knative.dev/pkg/system"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/aws/karpenter-core/pkg/apis/settings"
 	"github.com/aws/karpenter-core/pkg/operator/options"
@@ -79,7 +80,7 @@ func WithSettingsOrDie(ctx context.Context, kubernetesInterface kubernetes.Inter
 
 	for _, setting := range settings {
 		cm, err := WaitForConfigMap(ctx, setting.ConfigMap(), informer)
-		if err != nil && !errors.IsNotFound(err) {
+		if client.IgnoreNotFound(err) != nil {
 			panic(fmt.Errorf("failed to get configmap %s, %w", setting.ConfigMap(), err))
 		}
 		ctx = lo.Must(setting.Inject(ctx, cm))

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -120,10 +120,6 @@ func (o *Options) ToContext(ctx context.Context) context.Context {
 
 func (o *Options) MergeSettings(ctx context.Context) {
 	s := settings.FromContext(ctx)
-	if s == nil {
-		return
-	}
-
 	if !o.setFlags["batch-max-duration"] {
 		o.BatchMaxDuration = s.BatchMaxDuration
 	}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
This PR changes the injection behavior such that `settings` are always injected into the context, even when the `karpenter-global-settings` configmap is not present. In that case, the default settings are injected.

**How was this change tested?**
`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
