### PR TITLE
chore: correctly parse boolean CLI flags

### DIFF
--- a/pkg/operator/injection/injection.go
+++ b/pkg/operator/injection/injection.go
@@ -53,7 +53,9 @@ func GetControllerName(ctx context.Context) string {
 }
 
 func WithOptionsOrDie(ctx context.Context, opts ...options.Injectable) context.Context {
-	fs := flag.NewFlagSet("karpenter", flag.ContinueOnError)
+	fs := &options.FlagSet{
+		FlagSet: flag.NewFlagSet("karpenter", flag.ContinueOnError),
+	}
 	for _, opt := range opts {
 		opt.AddFlags(fs)
 	}

--- a/pkg/operator/options/injectable.go
+++ b/pkg/operator/options/injectable.go
@@ -14,19 +14,16 @@ limitations under the License.
 
 package options
 
-import (
-	"context"
-	"flag"
-)
+import "context"
 
 // Injectable defines a set of flag based options to be parsed and injected
 // into Karpenter's contexts
 type Injectable interface {
 	// AddFlags adds the injectable's flags to karpenter's flag set
-	AddFlags(*flag.FlagSet)
+	AddFlags(*FlagSet)
 	// Parse parses the flag set and handles any required post-processing on
 	// the flags
-	Parse(*flag.FlagSet, ...string) error
+	Parse(*FlagSet, ...string) error
 	// ToContext injects the callee into the given context
 	ToContext(context.Context) context.Context
 	// MergeSettings extracts settings from the given context and merges them

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -83,15 +83,15 @@ func (fs *FlagSet) BoolVarWithEnv(p *bool, name string, envVar string, val bool,
 
 func (o *Options) AddFlags(fs *FlagSet) {
 	fs.StringVar(&o.ServiceName, "karpenter-service", env.WithDefaultString("KARPENTER_SERVICE", ""), "The Karpenter Service name for the dynamic webhook certificate")
-	fs.BoolVarWithEnv(&o.DisableWebhook, "disable-webhook", false, "DISABLE_WEBHOOK", "Disable the admission and validation webhooks")
+	fs.BoolVarWithEnv(&o.DisableWebhook, "disable-webhook", "DISABLE_WEBHOOK", false, "Disable the admission and validation webhooks")
 	fs.IntVar(&o.WebhookPort, "webhook-port", env.WithDefaultInt("WEBHOOK_PORT", 8443), "The port the webhook endpoint binds to for validation and mutation of resources")
 	fs.IntVar(&o.MetricsPort, "metrics-port", env.WithDefaultInt("METRICS_PORT", 8000), "The port the metric endpoint binds to for operating metrics about the controller itself")
 	fs.IntVar(&o.WebhookMetricsPort, "webhook-metrics-port", env.WithDefaultInt("WEBHOOK_METRICS_PORT", 8001), "The port the webhook metric endpoing binds to for operating metrics about the webhook")
 	fs.IntVar(&o.HealthProbePort, "health-probe-port", env.WithDefaultInt("HEALTH_PROBE_PORT", 8081), "The port the health probe endpoint binds to for reporting controller health")
 	fs.IntVar(&o.KubeClientQPS, "kube-client-qps", env.WithDefaultInt("KUBE_CLIENT_QPS", 200), "The smoothed rate of qps to kube-apiserver")
 	fs.IntVar(&o.KubeClientBurst, "kube-client-burst", env.WithDefaultInt("KUBE_CLIENT_BURST", 300), "The maximum allowed burst of queries to the kube-apiserver")
-	fs.BoolVar(&o.EnableProfiling, "enable-profiling", env.WithDefaultBool("ENABLE_PROFILING", false), "Enable the profiling on the metric endpoint")
-	fs.BoolVar(&o.EnableLeaderElection, "leader-elect", env.WithDefaultBool("LEADER_ELECT", true), "Start leader election client and gain leadership before executing the main loop. Enable this when running replicated components for high availability.")
+	fs.BoolVarWithEnv(&o.EnableProfiling, "enable-profiling", "ENABLE_PROFILING", false, "Enable the profiling on the metric endpoint")
+	fs.BoolVarWithEnv(&o.EnableLeaderElection, "leader-elect", "LEADER_ELECT", true, "Start leader election client and gain leadership before executing the main loop. Enable this when running replicated components for high availability.")
 	fs.Int64Var(&o.MemoryLimit, "memory-limit", env.WithDefaultInt64("MEMORY_LIMIT", -1), "Memory limit on the container running the controller. The GC soft memory limit is set to 90% of this value.")
 	fs.StringVar(&o.LogLevel, "log-level", env.WithDefaultString("LOG_LEVEL", ""), "Log verbosity level. Can be one of 'debug', 'info', or 'error'")
 	fs.DurationVar(&o.BatchMaxDuration, "batch-max-duration", env.WithDefaultDuration("BATCH_MAX_DURATION", 10*time.Second), "The maximum length of a batch window. The longer this is, the more pods we can consider for provisioning at one time which usually results in fewer but larger nodes.")

--- a/pkg/operator/options/options.go
+++ b/pkg/operator/options/options.go
@@ -70,7 +70,7 @@ type FlagSet struct {
 
 // BoolVarWithEnv defines a bool flag with a specified name, default value, usage string, and fallback environment
 // variable.
-func (fs *FlagSet) BoolVarWithEnv(p *bool, name string, val bool, envVar string, usage string) {
+func (fs *FlagSet) BoolVarWithEnv(p *bool, name string, envVar string, val bool, usage string) {
 	*p = env.WithDefaultBool(envVar, val)
 	fs.BoolFunc(name, usage, func(val string) error {
 		if val != "true" && val != "false" {

--- a/pkg/operator/options/suite_test.go
+++ b/pkg/operator/options/suite_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 var ctx context.Context
-var fs *flag.FlagSet
+var fs *options.FlagSet
 var opts *options.Options
 
 func TestOptions(t *testing.T) {
@@ -40,7 +40,9 @@ func TestOptions(t *testing.T) {
 
 var _ = Describe("Options", func() {
 	BeforeEach(func() {
-		fs = flag.NewFlagSet("karpenter", flag.ContinueOnError)
+		fs = &options.FlagSet{
+			FlagSet: flag.NewFlagSet("karpenter", flag.ContinueOnError),
+		}
 		opts = &options.Options{}
 		opts.AddFlags(fs)
 	})

--- a/pkg/operator/options/suite_test.go
+++ b/pkg/operator/options/suite_test.go
@@ -17,15 +17,18 @@ package options_test
 import (
 	"context"
 	"flag"
+	"os"
 	"testing"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
 	. "knative.dev/pkg/logging/testing"
 
 	"github.com/aws/karpenter-core/pkg/apis/settings"
 	"github.com/aws/karpenter-core/pkg/operator/options"
+	"github.com/aws/karpenter-core/pkg/test"
 )
 
 var ctx context.Context
@@ -39,12 +42,48 @@ func TestOptions(t *testing.T) {
 }
 
 var _ = Describe("Options", func() {
+	var envState map[string]string
+	var environmentVariables = []string{
+		"KARPENTER_SERVICE",
+		"DISABLE_WEBHOOK",
+		"WEBHOOK_PORT",
+		"METRICS_PORT",
+		"WEBHOOK_METRICS_PORT",
+		"HEALTH_PROBE_PORT",
+		"KUBE_CLIENT_BURST",
+		"ENABLE_PROFILING",
+		"LEADER_ELECT",
+		"MEMORY_LIMIT",
+		"LOG_LEVEL",
+		"BATCH_MAX_DURATION",
+		"BATCH_IDLE_DURATION",
+		"FEATURE_GATES",
+	}
+
 	BeforeEach(func() {
+		envState = map[string]string{}
+		for _, ev := range environmentVariables {
+			val, ok := os.LookupEnv(ev)
+			if ok {
+				envState[ev] = val
+			}
+			os.Unsetenv(ev)
+		}
+
 		fs = &options.FlagSet{
 			FlagSet: flag.NewFlagSet("karpenter", flag.ContinueOnError),
 		}
 		opts = &options.Options{}
 		opts.AddFlags(fs)
+	})
+
+	AfterEach(func() {
+		for _, ev := range environmentVariables {
+			os.Unsetenv(ev)
+		}
+		for ev, val := range envState {
+			os.Setenv(ev, val)
+		}
 	})
 
 	Context("FeatureGates", func() {
@@ -61,26 +100,173 @@ var _ = Describe("Options", func() {
 			Entry("multiple values", "Hello=true,Drift=false,World=true", false),
 		)
 	})
+
 	Context("Parse", func() {
 		It("should use the correct default values", func() {
 			err := opts.Parse(fs)
 			Expect(err).To(BeNil())
-			Expect(opts.ServiceName).To(Equal(""))
-			Expect(opts.DisableWebhook).To(BeFalse())
-			Expect(opts.WebhookPort).To(Equal(8443))
-			Expect(opts.MetricsPort).To(Equal(8000))
-			Expect(opts.WebhookMetricsPort).To(Equal(8001))
-			Expect(opts.HealthProbePort).To(Equal(8081))
-			Expect(opts.KubeClientQPS).To(Equal(200))
-			Expect(opts.KubeClientBurst).To(Equal(300))
-			Expect(opts.EnableProfiling).To(BeFalse())
-			Expect(opts.EnableLeaderElection).To(BeTrue())
-			Expect(opts.MemoryLimit).To(Equal(int64(-1)))
-			Expect(opts.LogLevel).To(Equal(""))
-			Expect(opts.BatchMaxDuration).To(Equal(10 * time.Second))
-			Expect(opts.BatchIdleDuration).To(Equal(time.Second))
-			Expect(opts.FeatureGates.Drift).To(BeFalse())
+			expectOptionsMatch(opts, test.Options(test.OptionsFields{
+				ServiceName:          lo.ToPtr(""),
+				DisableWebhook:       lo.ToPtr(false),
+				WebhookPort:          lo.ToPtr(8443),
+				MetricsPort:          lo.ToPtr(8000),
+				WebhookMetricsPort:   lo.ToPtr(8001),
+				HealthProbePort:      lo.ToPtr(8081),
+				KubeClientQPS:        lo.ToPtr(200),
+				KubeClientBurst:      lo.ToPtr(300),
+				EnableProfiling:      lo.ToPtr(false),
+				EnableLeaderElection: lo.ToPtr(true),
+				MemoryLimit:          lo.ToPtr[int64](-1),
+				LogLevel:             lo.ToPtr(""),
+				BatchMaxDuration:     lo.ToPtr(10 * time.Second),
+				BatchIdleDuration:    lo.ToPtr(time.Second),
+				FeatureGates: test.FeatureGates{
+					Drift: lo.ToPtr(false),
+				},
+			}))
 		})
+
+		It("shouldn't overwrite CLI flags with environment variables", func() {
+			err := opts.Parse(
+				fs,
+				"--karpenter-service", "cli",
+				"--disable-webhook",
+				"--webhook-port", "0",
+				"--metrics-port", "0",
+				"--webhook-metrics-port", "0",
+				"--health-probe-port", "0",
+				"--kube-client-qps", "0",
+				"--kube-client-burst", "0",
+				"--enable-profiling",
+				"--leader-elect=false",
+				"--memory-limit", "0",
+				"--log-level", "debug",
+				"--batch-max-duration", "5s",
+				"--batch-idle-duration", "5s",
+				"--feature-gates", "Drift=true",
+			)
+			Expect(err).To(BeNil())
+			expectOptionsMatch(opts, test.Options(test.OptionsFields{
+				ServiceName:          lo.ToPtr("cli"),
+				DisableWebhook:       lo.ToPtr(true),
+				WebhookPort:          lo.ToPtr(0),
+				MetricsPort:          lo.ToPtr(0),
+				WebhookMetricsPort:   lo.ToPtr(0),
+				HealthProbePort:      lo.ToPtr(0),
+				KubeClientQPS:        lo.ToPtr(0),
+				KubeClientBurst:      lo.ToPtr(0),
+				EnableProfiling:      lo.ToPtr(true),
+				EnableLeaderElection: lo.ToPtr(false),
+				MemoryLimit:          lo.ToPtr[int64](0),
+				LogLevel:             lo.ToPtr("debug"),
+				BatchMaxDuration:     lo.ToPtr(5 * time.Second),
+				BatchIdleDuration:    lo.ToPtr(5 * time.Second),
+				FeatureGates: test.FeatureGates{
+					Drift: lo.ToPtr(true),
+				},
+			}))
+		})
+
+		It("should use environment variables when CLI flags aren't set", func() {
+			os.Setenv("KARPENTER_SERVICE", "env")
+			os.Setenv("DISABLE_WEBHOOK", "true")
+			os.Setenv("WEBHOOK_PORT", "0")
+			os.Setenv("METRICS_PORT", "0")
+			os.Setenv("WEBHOOK_METRICS_PORT", "0")
+			os.Setenv("HEALTH_PROBE_PORT", "0")
+			os.Setenv("KUBE_CLIENT_QPS", "0")
+			os.Setenv("KUBE_CLIENT_BURST", "0")
+			os.Setenv("ENABLE_PROFILING", "true")
+			os.Setenv("LEADER_ELECT", "false")
+			os.Setenv("MEMORY_LIMIT", "0")
+			os.Setenv("LOG_LEVEL", "debug")
+			os.Setenv("BATCH_MAX_DURATION", "5s")
+			os.Setenv("BATCH_IDLE_DURATION", "5s")
+			os.Setenv("FEATURE_GATES", "Drift=true")
+			fs = &options.FlagSet{
+				FlagSet: flag.NewFlagSet("karpenter", flag.ContinueOnError),
+			}
+			opts.AddFlags(fs)
+			err := opts.Parse(fs)
+			Expect(err).To(BeNil())
+			expectOptionsMatch(opts, test.Options(test.OptionsFields{
+				ServiceName:          lo.ToPtr("env"),
+				DisableWebhook:       lo.ToPtr(true),
+				WebhookPort:          lo.ToPtr(0),
+				MetricsPort:          lo.ToPtr(0),
+				WebhookMetricsPort:   lo.ToPtr(0),
+				HealthProbePort:      lo.ToPtr(0),
+				KubeClientQPS:        lo.ToPtr(0),
+				KubeClientBurst:      lo.ToPtr(0),
+				EnableProfiling:      lo.ToPtr(true),
+				EnableLeaderElection: lo.ToPtr(false),
+				MemoryLimit:          lo.ToPtr[int64](0),
+				LogLevel:             lo.ToPtr("debug"),
+				BatchMaxDuration:     lo.ToPtr(5 * time.Second),
+				BatchIdleDuration:    lo.ToPtr(5 * time.Second),
+				FeatureGates: test.FeatureGates{
+					Drift: lo.ToPtr(true),
+				},
+			}))
+		})
+
+		It("should correctly merge CLI flags and environment variables", func() {
+			os.Setenv("WEBHOOK_PORT", "0")
+			os.Setenv("METRICS_PORT", "0")
+			os.Setenv("WEBHOOK_METRICS_PORT", "0")
+			os.Setenv("HEALTH_PROBE_PORT", "0")
+			os.Setenv("KUBE_CLIENT_QPS", "0")
+			os.Setenv("KUBE_CLIENT_BURST", "0")
+			os.Setenv("ENABLE_PROFILING", "true")
+			os.Setenv("LEADER_ELECT", "false")
+			os.Setenv("MEMORY_LIMIT", "0")
+			os.Setenv("LOG_LEVEL", "debug")
+			os.Setenv("BATCH_MAX_DURATION", "5s")
+			os.Setenv("BATCH_IDLE_DURATION", "5s")
+			os.Setenv("FEATURE_GATES", "Drift=true")
+			fs = &options.FlagSet{
+				FlagSet: flag.NewFlagSet("karpenter", flag.ContinueOnError),
+			}
+			opts.AddFlags(fs)
+			err := opts.Parse(
+				fs,
+				"--karpenter-service", "cli",
+				"--disable-webhook",
+			)
+			Expect(err).To(BeNil())
+			expectOptionsMatch(opts, test.Options(test.OptionsFields{
+				ServiceName:          lo.ToPtr("cli"),
+				DisableWebhook:       lo.ToPtr(true),
+				WebhookPort:          lo.ToPtr(0),
+				MetricsPort:          lo.ToPtr(0),
+				WebhookMetricsPort:   lo.ToPtr(0),
+				HealthProbePort:      lo.ToPtr(0),
+				KubeClientQPS:        lo.ToPtr(0),
+				KubeClientBurst:      lo.ToPtr(0),
+				EnableProfiling:      lo.ToPtr(true),
+				EnableLeaderElection: lo.ToPtr(false),
+				MemoryLimit:          lo.ToPtr[int64](0),
+				LogLevel:             lo.ToPtr("debug"),
+				BatchMaxDuration:     lo.ToPtr(5 * time.Second),
+				BatchIdleDuration:    lo.ToPtr(5 * time.Second),
+				FeatureGates: test.FeatureGates{
+					Drift: lo.ToPtr(true),
+				},
+			}))
+		})
+
+		DescribeTable(
+			"should correctly parse boolean values",
+			func(arg string, expected bool) {
+				err := opts.Parse(fs, arg)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(opts.DisableWebhook).To(Equal(expected))
+			},
+			Entry("explicit true", "--disable-webhook=true", true),
+			Entry("explicit false", "--disable-webhook=false", false),
+			Entry("implicit true", "--disable-webhook", true),
+			Entry("implicit false", "", false),
+		)
 	})
 
 	Context("Merge", func() {
@@ -136,3 +322,27 @@ var _ = Describe("Options", func() {
 		})
 	})
 })
+
+func expectOptionsMatch(optsA, optsB *options.Options) {
+	GinkgoHelper()
+	if optsA == nil && optsB == nil {
+		return
+	}
+	Expect(optsA).ToNot(BeNil())
+	Expect(optsB).ToNot(BeNil())
+	Expect(optsA.ServiceName).To(Equal(optsB.ServiceName))
+	Expect(optsA.DisableWebhook).To(Equal(optsB.DisableWebhook))
+	Expect(optsA.WebhookPort).To(Equal(optsB.WebhookPort))
+	Expect(optsA.MetricsPort).To(Equal(optsB.MetricsPort))
+	Expect(optsA.WebhookMetricsPort).To(Equal(optsB.WebhookMetricsPort))
+	Expect(optsA.HealthProbePort).To(Equal(optsB.HealthProbePort))
+	Expect(optsA.KubeClientQPS).To(Equal(optsB.KubeClientQPS))
+	Expect(optsA.KubeClientBurst).To(Equal(optsB.KubeClientBurst))
+	Expect(optsA.EnableProfiling).To(Equal(optsB.EnableProfiling))
+	Expect(optsA.EnableLeaderElection).To(Equal(optsB.EnableLeaderElection))
+	Expect(optsA.MemoryLimit).To(Equal(optsB.MemoryLimit))
+	Expect(optsA.LogLevel).To(Equal(optsB.LogLevel))
+	Expect(optsA.BatchMaxDuration).To(Equal(optsB.BatchMaxDuration))
+	Expect(optsA.BatchIdleDuration).To(Equal(optsB.BatchIdleDuration))
+	Expect(optsA.FeatureGates.Drift).To(Equal(optsB.FeatureGates.Drift))
+}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
This PR adds a wrapper to `BoolFunc` which enables merging CLI flags with environment variables correctly. With the previous implementation, the following is possible:
```
DISABLE_WEBHOOK=true ./karpenter --disable-webhook
# disable-webhook resolves to false in options
```
This is because of the way that `flag` handles default values for booleans. 

**How was this change tested?**
`make test`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
