### PR TITLE
chore: Fix returning non-empty reconcile result and error

### DIFF
--- a/pkg/controllers/node/termination/controller.go
+++ b/pkg/controllers/node/termination/controller.go
@@ -99,11 +99,13 @@ func (c *Controller) Finalize(ctx context.Context, node *v1.Node) (reconcile.Res
 		}
 		return reconcile.Result{RequeueAfter: 1 * time.Second}, nil
 	}
-
 	if err := c.cloudProvider.Delete(ctx, nodeclaimutil.NewFromNode(node)); cloudprovider.IgnoreNodeClaimNotFoundError(err) != nil {
 		return reconcile.Result{}, fmt.Errorf("terminating cloudprovider instance, %w", err)
 	}
-	return reconcile.Result{}, c.removeFinalizer(ctx, node)
+	if err := c.removeFinalizer(ctx, node); err != nil {
+		return reconcile.Result{}, err
+	}
+	return reconcile.Result{}, nil
 }
 
 func (c *Controller) deleteAllMachines(ctx context.Context, node *v1.Node) error {

--- a/pkg/controllers/nodeclaim/disruption/controller.go
+++ b/pkg/controllers/nodeclaim/disruption/controller.go
@@ -96,7 +96,10 @@ func (c *Controller) Reconcile(ctx context.Context, nodeClaim *v1beta1.NodeClaim
 			return reconcile.Result{}, client.IgnoreNotFound(err)
 		}
 	}
-	return result.Min(results...), errs
+	if errs != nil {
+		return reconcile.Result{}, errs
+	}
+	return result.Min(results...), nil
 }
 
 var _ corecontroller.TypedController[*v1beta1.NodeClaim] = (*NodeClaimController)(nil)

--- a/pkg/controllers/nodeclaim/garbagecollection/controller.go
+++ b/pkg/controllers/nodeclaim/garbagecollection/controller.go
@@ -89,7 +89,10 @@ func (c *Controller) Reconcile(ctx context.Context, _ reconcile.Request) (reconc
 			Debugf("garbage collecting %s with no cloudprovider representation", lo.Ternary(nodeClaims[i].IsMachine, "machine", "nodeclaim"))
 		nodeclaimutil.TerminatedCounter(nodeClaims[i], "garbage_collected").Inc()
 	})
-	return reconcile.Result{RequeueAfter: time.Minute * 2}, multierr.Combine(errs...)
+	if err = multierr.Combine(errs...); err != nil {
+		return reconcile.Result{}, err
+	}
+	return reconcile.Result{RequeueAfter: time.Minute * 2}, nil
 }
 
 func (c *Controller) Builder(_ context.Context, m manager.Manager) corecontroller.Builder {

--- a/pkg/controllers/nodeclaim/lifecycle/controller.go
+++ b/pkg/controllers/nodeclaim/lifecycle/controller.go
@@ -116,7 +116,10 @@ func (c *Controller) Reconcile(ctx context.Context, nodeClaim *v1beta1.NodeClaim
 		// USE CAUTION when determining whether to increase this timeout or remove this line
 		time.Sleep(time.Second)
 	}
-	return result.Min(results...), errs
+	if errs != nil {
+		return reconcile.Result{}, errs
+	}
+	return result.Min(results...), nil
 }
 
 var _ corecontroller.TypedController[*v1beta1.NodeClaim] = (*NodeClaimController)(nil)

--- a/pkg/controllers/state/informer/daemonset.go
+++ b/pkg/controllers/state/informer/daemonset.go
@@ -58,8 +58,10 @@ func (c *Controller) Reconcile(ctx context.Context, req reconcile.Request) (reco
 		}
 		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}
-
-	return reconcile.Result{RequeueAfter: time.Minute}, c.cluster.UpdateDaemonSet(ctx, &daemonSet)
+	if err := c.cluster.UpdateDaemonSet(ctx, &daemonSet); err != nil {
+		return reconcile.Result{}, err
+	}
+	return reconcile.Result{RequeueAfter: time.Minute}, nil
 }
 
 func (c *Controller) Builder(_ context.Context, m manager.Manager) corecontroller.Builder {


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

Since controller-runtime https://github.com/kubernetes-sigs/controller-runtime/pull/2451, a warning will be logged if a controller returns an error and a non-zero result (i.e. a result with a RequeueAfter).

This PR changes the logic of our current controllers to not return both a non-zero result and an error at the same time to prevent warnings from being fired.

```bash
2023-10-20T01:28:53.2764885Z     logger.go:130: 2023-10-20T01:28:53.275Z	INFO	common/expectations.go:573	2023-10-20T01:28:49.102Z	DEBUG	controller.awsnodetemplate	discovered security groups	{"commit": "dce7385", "awsnodetemplate": "serpentsunset-29-ahjs7gn4mu", "security-groups": ["sg-0273da947dae25bb0", "sg-09513f2623d9d9b79"]}
2023-10-20T01:28:53.2773218Z         2023-10-20T01:28:49.158Z	INFO	controller	Warning: Reconciler returned both a non-zero result and a non-nil error. The result will always be ignored if the error is non-nil and the non-nil error causes reqeueuing with exponential backoff. For more details, see: https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/reconcile#Reconciler	{"commit": "dce7385", "controller": "awsnodetemplate", "controllerGroup": "karpenter.k8s.aws", "controllerKind": "***NodeTemplate", "***NodeTemplate": {"name":"serpentsunset-29-ahjs7gn4mu"}, "namespace": "", "name": "serpentsunset-29-ahjs7gn4mu", "reconcileID": "60c54480-e547-4b51-b312-4f2a603b1520"}
2023-10-20T01:28:53.2781222Z         2023-10-20T01:28:49.158Z	ERROR	controller	Reconciler error	{"commit": "dce7385", "controller": "awsnodetemplate", "controllerGroup": "karpenter.k8s.aws", "controllerKind": "***NodeTemplate", "***NodeTemplate": {"name":"serpentsunset-29-ahjs7gn4mu"}, "namespace": "", "name": "serpentsunset-29-ahjs7gn4mu", "reconcileID": "60c54480-e547-4b51-b312-4f2a603b1520", "error": "describing images, InvalidUserID.Malformed: Invalid user id: \"fakeOwnerValue\"\n\tstatus code: 400, request id: 197b5477-2067-4b51-9c8e-9162f8816402"}
```

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
