### PR TITLE
chore: Allow the `karpenter.sh/nodepool` labelSelector and validate nodeSelector on pods

### DIFF
--- a/pkg/apis/v1beta1/nodeclaim_validation.go
+++ b/pkg/apis/v1beta1/nodeclaim_validation.go
@@ -124,14 +124,14 @@ func (in *NodeClaimSpec) validateTaintsField(taints []v1.Taint, existing map[tai
 // NodeClaim requirements only support well known labels.
 func (in *NodeClaimSpec) validateRequirements() (errs *apis.FieldError) {
 	for i, requirement := range in.Requirements {
-		if err := in.validateRequirement(requirement); err != nil {
+		if err := ValidateRequirement(requirement); err != nil {
 			errs = errs.Also(apis.ErrInvalidArrayValue(err, "requirements", i))
 		}
 	}
 	return errs
 }
 
-func (in *NodeClaimSpec) validateRequirement(requirement v1.NodeSelectorRequirement) error { //nolint:gocyclo
+func ValidateRequirement(requirement v1.NodeSelectorRequirement) error { //nolint:gocyclo
 	var errs error
 	if normalized, ok := NormalizedLabels[requirement.Key]; ok {
 		requirement.Key = normalized

--- a/pkg/controllers/provisioning/nodepool_test.go
+++ b/pkg/controllers/provisioning/nodepool_test.go
@@ -58,7 +58,7 @@ var _ = Describe("NodePool/Provisioning", func() {
 	It("should provision nodes for pods with supported node selectors", func() {
 		nodePool := test.NodePool()
 		schedulable := []*v1.Pod{
-			// Constrained by provisioner
+			// Constrained by nodepool
 			test.UnschedulablePod(test.PodOptions{NodeSelector: map[string]string{v1beta1.NodePoolLabelKey: nodePool.Name}}),
 			// Constrained by zone
 			test.UnschedulablePod(test.PodOptions{NodeSelector: map[string]string{v1.LabelTopologyZone: "test-zone-1"}}),
@@ -70,7 +70,7 @@ var _ = Describe("NodePool/Provisioning", func() {
 			test.UnschedulablePod(test.PodOptions{NodeSelector: map[string]string{v1.LabelOSStable: string(v1.Linux)}}),
 		}
 		unschedulable := []*v1.Pod{
-			// Ignored, matches another provisioner
+			// Ignored, matches another nodepool
 			test.UnschedulablePod(test.PodOptions{NodeSelector: map[string]string{v1beta1.NodePoolLabelKey: "unknown"}}),
 			// Ignored, invalid zone
 			test.UnschedulablePod(test.PodOptions{NodeSelector: map[string]string{v1.LabelTopologyZone: "unknown"}}),
@@ -84,6 +84,46 @@ var _ = Describe("NodePool/Provisioning", func() {
 			test.UnschedulablePod(test.PodOptions{NodeSelector: map[string]string{v1beta1.CapacityTypeLabelKey: "unknown"}}),
 			// Ignored, label selector does not match
 			test.UnschedulablePod(test.PodOptions{NodeSelector: map[string]string{"foo": "bar"}}),
+		}
+		ExpectApplied(ctx, env.Client, nodePool)
+		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, schedulable...)
+		for _, pod := range schedulable {
+			ExpectScheduled(ctx, env.Client, pod)
+		}
+		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, unschedulable...)
+		for _, pod := range unschedulable {
+			ExpectNotScheduled(ctx, env.Client, pod)
+		}
+	})
+	It("should provision nodes for pods with supported node affinities", func() {
+		nodePool := test.NodePool()
+		schedulable := []*v1.Pod{
+			// Constrained by nodepool
+			test.UnschedulablePod(test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{{Key: v1beta1.NodePoolLabelKey, Operator: v1.NodeSelectorOpIn, Values: []string{nodePool.Name}}}}),
+			// Constrained by zone
+			test.UnschedulablePod(test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"test-zone-1"}}}}),
+			// Constrained by instanceType
+			test.UnschedulablePod(test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{{Key: v1.LabelInstanceTypeStable, Operator: v1.NodeSelectorOpIn, Values: []string{"default-instance-type"}}}}),
+			// Constrained by architecture
+			test.UnschedulablePod(test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{{Key: v1.LabelArchStable, Operator: v1.NodeSelectorOpIn, Values: []string{"arm64"}}}}),
+			// Constrained by operatingSystem
+			test.UnschedulablePod(test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{{Key: v1.LabelOSStable, Operator: v1.NodeSelectorOpIn, Values: []string{string(v1.Linux)}}}}),
+		}
+		unschedulable := []*v1.Pod{
+			// Ignored, matches another nodepool
+			test.UnschedulablePod(test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{{Key: v1beta1.NodePoolLabelKey, Operator: v1.NodeSelectorOpIn, Values: []string{"unknown"}}}}),
+			// Ignored, invalid zone
+			test.UnschedulablePod(test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{{Key: v1.LabelTopologyZone, Operator: v1.NodeSelectorOpIn, Values: []string{"unknown"}}}}),
+			// Ignored, invalid instance type
+			test.UnschedulablePod(test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{{Key: v1.LabelInstanceTypeStable, Operator: v1.NodeSelectorOpIn, Values: []string{"unknown"}}}}),
+			// Ignored, invalid architecture
+			test.UnschedulablePod(test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{{Key: v1.LabelArchStable, Operator: v1.NodeSelectorOpIn, Values: []string{"unknown"}}}}),
+			// Ignored, invalid operating system
+			test.UnschedulablePod(test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{{Key: v1.LabelOSStable, Operator: v1.NodeSelectorOpIn, Values: []string{"unknown"}}}}),
+			// Ignored, invalid capacity type
+			test.UnschedulablePod(test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{{Key: v1beta1.CapacityTypeLabelKey, Operator: v1.NodeSelectorOpIn, Values: []string{"unknown"}}}}),
+			// Ignored, label selector does not match
+			test.UnschedulablePod(test.PodOptions{NodeRequirements: []v1.NodeSelectorRequirement{{Key: "foo", Operator: v1.NodeSelectorOpIn, Values: []string{"bar"}}}}),
 		}
 		ExpectApplied(ctx, env.Client, nodePool)
 		ExpectProvisioned(ctx, env.Client, cluster, cloudProvider, prov, schedulable...)


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR adds the ability to use the `karpenter.sh/nodepool` on nodeSelectors and nodeAffinities. This change also validates the `nodeSelector` alongside the node affinities that we already validate

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
