### PR TITLE
chore: Drop usage pct metric for nodepool

### DIFF
--- a/pkg/controllers/metrics/nodepool/suite_test.go
+++ b/pkg/controllers/metrics/nodepool/suite_test.go
@@ -108,34 +108,8 @@ var _ = Describe("Metrics", func() {
 			Expect(m.GetGauge().GetValue()).To(BeNumerically("~", v.AsApproximateFloat64()))
 		}
 	})
-	It("should update the usage percentage metrics correctly", func() {
-		resources := v1.ResourceList{
-			v1.ResourceCPU:              resource.MustParse("10"),
-			v1.ResourceMemory:           resource.MustParse("10Mi"),
-			v1.ResourceEphemeralStorage: resource.MustParse("100Gi"),
-		}
-		limits := v1beta1.Limits{
-			v1.ResourceCPU:              resource.MustParse("100"),
-			v1.ResourceMemory:           resource.MustParse("100Mi"),
-			v1.ResourceEphemeralStorage: resource.MustParse("1000Gi"),
-		}
-		nodePool.Spec.Limits = limits
-		nodePool.Status.Resources = resources
-
-		ExpectApplied(ctx, env.Client, nodePool)
-		ExpectReconcileSucceeded(ctx, nodePoolController, client.ObjectKeyFromObject(nodePool))
-
-		for k := range resources {
-			m, found := FindMetricWithLabelValues("karpenter_nodepool_usage_pct", map[string]string{
-				"nodepool":      nodePool.GetName(),
-				"resource_type": strings.ReplaceAll(k.String(), "-", "_"),
-			})
-			Expect(found).To(BeTrue())
-			Expect(m.GetGauge().GetValue()).To(BeNumerically("~", 10))
-		}
-	})
 	It("should delete the nodepool state metrics on nodepool delete", func() {
-		expectedMetrics := []string{"karpenter_nodepool_limit", "karpenter_nodepool_usage", "karpenter_nodepool_usage_pct"}
+		expectedMetrics := []string{"karpenter_nodepool_limit", "karpenter_nodepool_usage"}
 		nodePool.Spec.Limits = v1beta1.Limits{
 			v1.ResourceCPU:              resource.MustParse("100"),
 			v1.ResourceMemory:           resource.MustParse("100Mi"),


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This change drops the usage percentage metric for NodePools since this metric can be formed by combining the `nodepool_usage` and `nodepool_limits` metrics today

**How was this change tested?**

`make presubmit

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
