### PR TITLE
chore: Only consider node shape for requested resources

### DIFF
--- a/pkg/controllers/nodeclaim/consistency/machine_test.go
+++ b/pkg/controllers/nodeclaim/consistency/machine_test.go
@@ -79,6 +79,15 @@ var _ = Describe("MachineController", func() {
 						v1alpha5.LabelNodeInitialized:    "true",
 					},
 				},
+				Spec: v1alpha5.MachineSpec{
+					Resources: v1alpha5.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("8"),
+							v1.ResourceMemory: resource.MustParse("64Gi"),
+							v1.ResourcePods:   resource.MustParse("5"),
+						},
+					},
+				},
 				Status: v1alpha5.MachineStatus{
 					ProviderID: test.RandomProviderID(),
 					Capacity: v1.ResourceList{

--- a/pkg/controllers/nodeclaim/consistency/nodeclaim_test.go
+++ b/pkg/controllers/nodeclaim/consistency/nodeclaim_test.go
@@ -79,6 +79,15 @@ var _ = Describe("NodeClaimController", func() {
 						v1beta1.NodeInitializedLabelKey: "true",
 					},
 				},
+				Spec: v1beta1.NodeClaimSpec{
+					Resources: v1beta1.ResourceRequirements{
+						Requests: v1.ResourceList{
+							v1.ResourceCPU:    resource.MustParse("8"),
+							v1.ResourceMemory: resource.MustParse("64Gi"),
+							v1.ResourcePods:   resource.MustParse("5"),
+						},
+					},
+				},
 				Status: v1beta1.NodeClaimStatus{
 					ProviderID: test.RandomProviderID(),
 					Capacity: v1.ResourceList{


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

- Only consider the node shape for requested resources. This means that we will only do resource checks when we know that a node's pods have specifically asked for certain resources during scheduling. This ensures that extended resources are only checked if the pod specifically asks for these resources.

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
