### PR TITLE
ci: Scope goveralls to one k8s version of `presubmit` 

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -19,6 +19,8 @@ jobs:
       run: echo "::add-matcher::.github/actionlint-matcher.json"
     - run: K8S_VERSION=${{ matrix.k8sVersion }} make presubmit
     - name: Send coverage
+      # should only send converage once https://docs.coveralls.io/parallel-builds
+      if: matrix.k8sVersion == '1.28.x'
       env:
         COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: goveralls -coverprofile=coverage.out -service=github


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

Description
- Due the multiple runs of the CI-test goveralls was failing to send reports.

How was this change tested?
- N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
