### PR TITLE
chore: Add NodePool readiness defined by the CloudProvider

### DIFF
--- a/pkg/cloudprovider/fake/cloudprovider.go
+++ b/pkg/cloudprovider/fake/cloudprovider.go
@@ -51,6 +51,7 @@ type CloudProvider struct {
 
 	CreatedNodeClaims map[string]*v1beta1.NodeClaim
 	Drifted           cloudprovider.DriftReason
+	Ready             error
 }
 
 func NewCloudProvider() *CloudProvider {
@@ -75,6 +76,7 @@ func (c *CloudProvider) Reset() {
 	c.NextCreateErr = nil
 	c.DeleteCalls = []*v1beta1.NodeClaim{}
 	c.Drifted = "drifted"
+	c.Ready = nil
 }
 
 func (c *CloudProvider) Create(ctx context.Context, nodeClaim *v1beta1.NodeClaim) (*v1beta1.NodeClaim, error) {
@@ -230,6 +232,13 @@ func (c *CloudProvider) IsDrifted(context.Context, *v1beta1.NodeClaim) (cloudpro
 	defer c.mu.RUnlock()
 
 	return c.Drifted, nil
+}
+
+func (c *CloudProvider) IsReady(context.Context, *v1beta1.NodePool) error {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return c.Ready
 }
 
 // Name returns the CloudProvider implementation name.

--- a/pkg/cloudprovider/metrics/cloudprovider.go
+++ b/pkg/cloudprovider/metrics/cloudprovider.go
@@ -36,7 +36,6 @@ const (
 	MetricLabelErrorDefaultVal = ""
 	// Well-known metricLabelError values
 	NodeClaimNotFoundError    = "NodeClaimNotFoundError"
-	NodeClassNotReadyError    = "NodeClassNotReadyError"
 	InsufficientCapacityError = "InsufficientCapacityError"
 )
 
@@ -182,8 +181,6 @@ func GetErrorTypeLabelValue(err error) string {
 		return InsufficientCapacityError
 	case cloudprovider.IsNodeClaimNotFoundError(err):
 		return NodeClaimNotFoundError
-	case cloudprovider.IsNodeClassNotReadyError(err):
-		return NodeClassNotReadyError
 	default:
 		return MetricLabelErrorDefaultVal
 	}

--- a/pkg/cloudprovider/metrics/cloudprovider_test.go
+++ b/pkg/cloudprovider/metrics/cloudprovider_test.go
@@ -27,7 +27,6 @@ import (
 var _ = Describe("Cloudprovider", func() {
 	var nodeClaimNotFoundErr = cloudprovider.NewNodeClaimNotFoundError(errors.New("not found"))
 	var insufficientCapacityErr = cloudprovider.NewInsufficientCapacityError(errors.New("not enough capacity"))
-	var nodeClassNotReadyErr = cloudprovider.NewNodeClassNotReadyError(errors.New("not ready"))
 	var unknownErr = errors.New("this is an error we don't know about")
 
 	Describe("CloudProvider machine errors via GetErrorTypeLabelValue()", func() {
@@ -37,9 +36,6 @@ var _ = Describe("Cloudprovider", func() {
 			})
 			It("insufficient capacity should be recognized", func() {
 				Expect(metrics.GetErrorTypeLabelValue(insufficientCapacityErr)).To(Equal(metrics.InsufficientCapacityError))
-			})
-			It("nodeclass not ready should be recognized", func() {
-				Expect(metrics.GetErrorTypeLabelValue(nodeClassNotReadyErr)).To(Equal(metrics.NodeClassNotReadyError))
 			})
 		})
 		Context("when the error is unknown", func() {

--- a/pkg/cloudprovider/types.go
+++ b/pkg/cloudprovider/types.go
@@ -51,6 +51,10 @@ type CloudProvider interface {
 	// IsDrifted returns whether a NodeClaim has drifted from the provisioning requirements
 	// it is tied to.
 	IsDrifted(context.Context, *v1beta1.NodeClaim) (DriftReason, error)
+	// IsReady returns whether a NodePool is ready defined by the CloudProvider
+	// This function should eventually be modeled as NodePool and NodeClass status conditions; however,
+	// this is modeled as a CloudProvider interface method until we model this as status conditions
+	IsReady(context.Context, *v1beta1.NodePool) error
 	// Name returns the CloudProvider implementation name.
 	Name() string
 }
@@ -218,36 +222,6 @@ func IsInsufficientCapacityError(err error) bool {
 
 func IgnoreInsufficientCapacityError(err error) error {
 	if IsInsufficientCapacityError(err) {
-		return nil
-	}
-	return err
-}
-
-// NodeClassNotReadyError is an error type returned by CloudProviders when a NodeClass that is used by the launch process doesn't have all its resolved fields
-type NodeClassNotReadyError struct {
-	error
-}
-
-func NewNodeClassNotReadyError(err error) *NodeClassNotReadyError {
-	return &NodeClassNotReadyError{
-		error: err,
-	}
-}
-
-func (e *NodeClassNotReadyError) Error() string {
-	return fmt.Sprintf("NodeClassRef not ready, %s", e.error)
-}
-
-func IsNodeClassNotReadyError(err error) bool {
-	if err == nil {
-		return false
-	}
-	var nrError *NodeClassNotReadyError
-	return errors.As(err, &nrError)
-}
-
-func IgnoreNodeClassNotReadyError(err error) error {
-	if IsNodeClassNotReadyError(err) {
 		return nil
 	}
 	return err

--- a/pkg/controllers/nodeclaim/lifecycle/events.go
+++ b/pkg/controllers/nodeclaim/lifecycle/events.go
@@ -32,13 +32,3 @@ func InsufficientCapacityErrorEvent(nodeClaim *v1beta1.NodeClaim, err error) eve
 		DedupeValues:   []string{string(nodeClaim.UID)},
 	}
 }
-
-func NodeClassNotReadyEvent(nodeClaim *v1beta1.NodeClaim, err error) events.Event {
-	return events.Event{
-		InvolvedObject: nodeClaim,
-		Type:           v1.EventTypeWarning,
-		Reason:         "NodeClassNotReady",
-		Message:        fmt.Sprintf("NodeClaim %s event: %s", nodeClaim.Name, truncateMessage(err.Error())),
-		DedupeValues:   []string{string(nodeClaim.UID)},
-	}
-}


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR adds the `IsReady()` interface function to the CloudProvider. The plan is to eventually move this interface function into the status conditions with #493; however, we can keep this concept internal for now by calling out to the CloudProvider as a first iteration.

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
