### PR TITLE
chore: Drop `nodeclaim.Key` from provisioner, disruption, and state

### DIFF
--- a/pkg/controllers/disruption/controller.go
+++ b/pkg/controllers/disruption/controller.go
@@ -35,7 +35,6 @@ import (
 	"github.com/aws/karpenter-core/pkg/events"
 	"github.com/aws/karpenter-core/pkg/metrics"
 	"github.com/aws/karpenter-core/pkg/operator/controller"
-	"github.com/aws/karpenter-core/pkg/utils/nodeclaim"
 )
 
 type Controller struct {
@@ -183,10 +182,10 @@ func (c *Controller) executeCommand(ctx context.Context, m Method, cmd Command) 
 		return multierr.Append(fmt.Errorf("tainting nodes, %w", err), state.RequireNoScheduleTaint(ctx, c.kubeClient, false, stateNodes...))
 	}
 
-	var nodeClaimKeys []nodeclaim.Key
+	var nodeClaimNames []string
 	var err error
 	if len(cmd.replacements) > 0 {
-		if nodeClaimKeys, err = c.createReplacementNodeClaims(ctx, m, cmd); err != nil {
+		if nodeClaimNames, err = c.createReplacementNodeClaims(ctx, m, cmd); err != nil {
 			// If we failed to launch the replacement, don't disrupt.  If this is some permanent failure,
 			// we don't want to disrupt workloads with no way to provision new nodes for them.
 			return multierr.Append(fmt.Errorf("launching replacement nodeclaim, %w", err), state.RequireNoScheduleTaint(ctx, c.kubeClient, false, stateNodes...))
@@ -197,7 +196,7 @@ func (c *Controller) executeCommand(ctx context.Context, m Method, cmd Command) 
 	// We have the new NodeClaims created at the API server so mark the old NodeClaims for deletion
 	c.cluster.MarkForDeletion(providerIDs...)
 
-	if err := c.queue.Add(orchestration.NewCommand(nodeClaimKeys,
+	if err := c.queue.Add(orchestration.NewCommand(nodeClaimNames,
 		lo.Map(cmd.candidates, func(c *Candidate, _ int) *state.StateNode { return c.StateNode }), m.Type(), m.ConsolidationType())); err != nil {
 		c.cluster.UnmarkForDeletion(providerIDs...)
 		return fmt.Errorf("adding command to queue, %w", multierr.Append(err, state.RequireNoScheduleTaint(ctx, c.kubeClient, false, stateNodes...)))
@@ -206,17 +205,17 @@ func (c *Controller) executeCommand(ctx context.Context, m Method, cmd Command) 
 }
 
 // createReplacementNodeClaims creates replacement NodeClaims
-func (c *Controller) createReplacementNodeClaims(ctx context.Context, m Method, cmd Command) ([]nodeclaim.Key, error) {
+func (c *Controller) createReplacementNodeClaims(ctx context.Context, m Method, cmd Command) ([]string, error) {
 	reason := fmt.Sprintf("%s/%s", m.Type(), cmd.Action())
-	nodeClaimKeys, err := c.provisioner.CreateNodeClaims(ctx, cmd.replacements, provisioning.WithReason(reason))
+	nodeClaimNames, err := c.provisioner.CreateNodeClaims(ctx, cmd.replacements, provisioning.WithReason(reason))
 	if err != nil {
 		return nil, err
 	}
-	if len(nodeClaimKeys) != len(cmd.replacements) {
+	if len(nodeClaimNames) != len(cmd.replacements) {
 		// shouldn't ever occur since a partially failed CreateNodeClaims should return an error
-		return nil, fmt.Errorf("expected %d replacements, got %d", len(cmd.replacements), len(nodeClaimKeys))
+		return nil, fmt.Errorf("expected %d replacements, got %d", len(cmd.replacements), len(nodeClaimNames))
 	}
-	return nodeClaimKeys, nil
+	return nodeClaimNames, nil
 }
 
 func (c *Controller) recordRun(s string) {

--- a/pkg/controllers/state/informer/nodeclaim.go
+++ b/pkg/controllers/state/informer/nodeclaim.go
@@ -28,7 +28,6 @@ import (
 	"github.com/aws/karpenter-core/pkg/apis/v1beta1"
 	"github.com/aws/karpenter-core/pkg/controllers/state"
 	corecontroller "github.com/aws/karpenter-core/pkg/operator/controller"
-	nodeclaimutil "github.com/aws/karpenter-core/pkg/utils/nodeclaim"
 )
 
 // NodeClaimController reconciles machine for the purpose of maintaining state.
@@ -55,7 +54,7 @@ func (c *NodeClaimController) Reconcile(ctx context.Context, req reconcile.Reque
 	if err := c.kubeClient.Get(ctx, req.NamespacedName, nodeClaim); err != nil {
 		if errors.IsNotFound(err) {
 			// notify cluster state of the node deletion
-			c.cluster.DeleteNodeClaim(nodeclaimutil.Key{Name: req.Name})
+			c.cluster.DeleteNodeClaim(req.Name)
 		}
 		return reconcile.Result{}, client.IgnoreNotFound(err)
 	}

--- a/pkg/test/expectations/expectations.go
+++ b/pkg/test/expectations/expectations.go
@@ -271,12 +271,12 @@ func ExpectProvisionedNoBinding(ctx context.Context, c client.Client, cluster *s
 	}
 	for _, m := range results.NewNodeClaims {
 		// TODO: Check the error on the provisioner launch
-		key, err := provisioner.Launch(ctx, m, provisioning.WithReason(metrics.ProvisioningReason))
+		nodeClaimName, err := provisioner.Create(ctx, m, provisioning.WithReason(metrics.ProvisioningReason))
 		if err != nil {
 			return bindings
 		}
 		nodeClaim := &v1beta1.NodeClaim{}
-		Expect(c.Get(ctx, types.NamespacedName{Name: key.Name}, nodeClaim)).To(Succeed())
+		Expect(c.Get(ctx, types.NamespacedName{Name: nodeClaimName}, nodeClaim)).To(Succeed())
 		nodeClaim, node := ExpectNodeClaimDeployed(ctx, c, cluster, cloudProvider, nodeClaim)
 		if nodeClaim != nil && node != nil {
 			for _, pod := range m.Pods {

--- a/pkg/utils/nodeclaim/nodeclaim.go
+++ b/pkg/utils/nodeclaim/nodeclaim.go
@@ -38,11 +38,6 @@ import (
 	nodepoolutil "github.com/aws/karpenter-core/pkg/utils/nodepool"
 )
 
-type Key struct {
-	Name      string
-	IsMachine bool
-}
-
 // PodEventHandler is a watcher on v1.Pods that maps Pods to NodeClaim based on the node names
 // and enqueues reconcile.Requests for the NodeClaims
 func PodEventHandler(c client.Client) handler.EventHandler {
@@ -232,9 +227,9 @@ func NewFromNode(node *v1.Node) *v1beta1.NodeClaim {
 	return nc
 }
 
-func Get(ctx context.Context, c client.Client, key Key) (*v1beta1.NodeClaim, error) {
+func Get(ctx context.Context, c client.Client, name string) (*v1beta1.NodeClaim, error) {
 	nodeClaim := &v1beta1.NodeClaim{}
-	if err := c.Get(ctx, types.NamespacedName{Name: key.Name}, nodeClaim); err != nil {
+	if err := c.Get(ctx, types.NamespacedName{Name: name}, nodeClaim); err != nil {
 		return nil, err
 	}
 	return nodeClaim, nil

--- a/pkg/utils/nodeclaim/suite_test.go
+++ b/pkg/utils/nodeclaim/suite_test.go
@@ -142,7 +142,7 @@ var _ = Describe("NodeClaimUtils", func() {
 		})
 		ExpectApplied(ctx, env.Client, nodeClaim)
 
-		retrieved, err := nodeclaimutil.Get(ctx, env.Client, nodeclaimutil.Key{Name: nodeClaim.Name, IsMachine: false})
+		retrieved, err := nodeclaimutil.Get(ctx, env.Client, nodeClaim.Name)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(retrieved.Name).To(Equal(nodeClaim.Name))
 	})


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR drops the `nodeclaim.Key` concept from provisioner, disruption, and state in favor of the NodeClaim name

**How was this change tested?**

`make presubmit`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
