### PR TITLE
chore: update kubebuilder toolchain and test k8sversion

### DIFF
--- a/hack/toolchain.sh
+++ b/hack/toolchain.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-K8S_VERSION="${K8S_VERSION:="1.27.x"}"
+K8S_VERSION="${K8S_VERSION:="1.28.x"}"
 KUBEBUILDER_ASSETS="/usr/local/kubebuilder/bin"
 
 main() {
@@ -33,10 +33,6 @@ kubebuilder() {
     sudo mkdir -p /usr/local/kubebuilder/bin
     sudo chown "${USER}" /usr/local/kubebuilder/bin
     arch=$(go env GOARCH)
-    ## Kubebuilder does not support darwin/arm64, so use amd64 through Rosetta instead
-    if [[ $(go env GOOS) == "darwin" ]] && [[ $(go env GOARCH) == "arm64" ]]; then
-        arch="amd64"
-    fi
     ln -sf $(setup-envtest use -p path "${K8S_VERSION}" --arch="${arch}" --bin-dir="${KUBEBUILDER_ASSETS}")/* ${KUBEBUILDER_ASSETS}
     find $KUBEBUILDER_ASSETS
 }

--- a/pkg/test/environment.go
+++ b/pkg/test/environment.go
@@ -89,7 +89,7 @@ func NewEnvironment(scheme *runtime.Scheme, options ...functional.Option[Environ
 	ctx, cancel := context.WithCancel(context.Background())
 
 	os.Setenv(system.NamespaceEnvKey, "default")
-	version := version.MustParseSemantic(strings.Replace(env.WithDefaultString("K8S_VERSION", "1.24.x"), ".x", ".0", -1))
+	version := version.MustParseSemantic(strings.Replace(env.WithDefaultString("K8S_VERSION", "1.28.x"), ".x", ".0", -1))
 	environment := envtest.Environment{Scheme: scheme, CRDs: opts.crds}
 	if version.Minor() >= 21 {
 		// PodAffinityNamespaceSelector is used for label selectors in pod affinities.  If the feature-gate is turned off,


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**
This updates testing versions to K8s v1.28, and removes a stale check for kubebuilder installs when arm64 wasn't supported.

**How was this change tested?**
make toolchain && make presubmit

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
