### PR TITLE
fix: Fix `RuntimeValidate` check to only check NodePools

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -40,6 +40,14 @@ linters-settings:
     min-complexity: 11
   govet:
     check-shadowing: true
+  revive:
+    rules:
+      - name: dot-imports
+        disabled: true
+  stylecheck:
+    dot-import-whitelist:
+      - "github.com/onsi/ginkgo/v2"
+      - "github.com/onsi/gomega"
   misspell:
     locale: US
     ignore-words: []

--- a/pkg/controllers/provisioning/provisioner.go
+++ b/pkg/controllers/provisioning/provisioner.go
@@ -212,9 +212,12 @@ func (p *Provisioner) NewScheduler(ctx context.Context, pods []*v1.Pod, stateNod
 		return nil, err
 	}
 	nodePoolList.Items = lo.Filter(nodePoolList.Items, func(n v1beta1.NodePool, _ int) bool {
-		if err := n.RuntimeValidate(); err != nil {
-			logging.FromContext(ctx).With("nodepool", n.Name).Errorf("nodepool failed validation, %s", err)
-			return false
+		// We only runtime validate NodePools due to limitations around Common Expression Language (CEL)
+		if !n.IsProvisioner {
+			if err := n.RuntimeValidate(); err != nil {
+				logging.FromContext(ctx).With("nodepool", n.Name).Errorf("nodepool failed validation, %s", err)
+				return false
+			}
 		}
 		return n.DeletionTimestamp.IsZero()
 	})


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Releated to https://github.com/aws/karpenter/issues/5055

**Description**

This PR ensures that `RuntimeValidate()` calls only run against NodePools since Provisioners should be validated using the webhooks and we shouldn't have the same validation logic that we use against NodePools happening against Provisioners

**How was this change tested?**

`make presubmit`
`make apply`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
