### PR TITLE
ci: Constrain action permissions

### DIFF
--- a/.github/workflows/presubmit.yaml
+++ b/.github/workflows/presubmit.yaml
@@ -6,6 +6,8 @@ on:
   workflow_dispatch:
 jobs:
   presubmit:
+    permissions:
+      issues: write
     runs-on: ubuntu-latest
     strategy:
         matrix:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,8 @@ on:
     tags: ['v*.*.*']
 jobs:
   release:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
<!-- Please follow the guidelines at https://www.conventionalcommits.org/en/v1.0.0/ and use one of the following in your title:
feat:            <-- New features that require a MINOR version update
fix:             <-- Bug fixes that require at PATCH version update
chore:           <-- Smaller changes that impact behavior but aren't large enough to be features
perf:            <-- Code changes that improve performance but do not impact behavior
docs:            <-- Documentation changes that do not impact code
test:            <-- Test changes that do not impact behavior
ci:              <-- Changes that affect test or rollout automation
!${type}:        <-- Include ! if your change includes a backwards incompatible change.
-->

Fixes #N/A <!-- issue number -->

**Description**

This PR assumes that the default permissions for the `GITHUB_TOKEN` is read-only for all permission in the account. Outside of that, we specify the constrained set of permissions that are required for each job to execute against the repo. This includes `issues: write` permissions for the Presubmit task for writing the coveralls output to the PR and `contents: write` permission for the Release task for creating the release.

**How was this change tested?**

- Opening a PR against the `karpenter-core` repo

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
